### PR TITLE
fix: Fix __typename fields on abstract selections not being exact

### DIFF
--- a/.changeset/mean-geckos-dream.md
+++ b/.changeset/mean-geckos-dream.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Fix `__typename` literal string not being exact and instead a union of possible types, when the `__typename` field is put onto an abstract type’s selection set.

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -301,6 +301,32 @@ test('infers unions and interfaces correctly', () => {
   expectTypeOf<expected>().toEqualTypeOf<actual>();
 });
 
+test('infers __typename on union unambiguously', () => {
+  type query = parseDocument</* GraphQL */ `
+    query {
+      test {
+        __typename
+        ... on BigTodo { wallOfText }
+      }
+    }
+  `>;
+
+  type actual = getDocumentType<query, schema>;
+  type expected = {
+    test:
+      | {
+          __typename: 'SmallTodo';
+        }
+      | {
+          __typename: 'BigTodo';
+          wallOfText: string | null;
+        }
+      | null;
+  };
+
+  expectTypeOf<expected>().toEqualTypeOf<actual>();
+});
+
 test('infers queries from GitHub introspection schema', () => {
   type schema = mapIntrospection<
     typeof import('./fixtures/githubIntrospection').githubIntrospection

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -122,9 +122,9 @@ type getSelection<
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
-> = obj<getFragmentsSelection<Selections, Type, Introspection, Fragments>>;
+> = obj<getPossibleTypesSelection<Selections, Type, Introspection, Fragments>>;
 
-type _getFragmentsSelectionRec<
+type _getPossibleTypeSelectionRec<
   Selections extends readonly unknown[],
   PossibleType extends string,
   Type extends ObjectLikeType,
@@ -165,17 +165,17 @@ type _getFragmentsSelectionRec<
                   >;
             }
         : {}) &
-      _getFragmentsSelectionRec<Rest, PossibleType, Type, Introspection, Fragments>
+      _getPossibleTypeSelectionRec<Rest, PossibleType, Type, Introspection, Fragments>
   : {};
 
-type getFragmentsSelection<
+type getPossibleTypesSelection<
   Selections extends readonly unknown[],
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
 > = Type extends { kind: 'UNION' | 'INTERFACE'; possibleTypes: any }
   ? objValues<{
-      [PossibleType in Type['possibleTypes']]: _getFragmentsSelectionRec<
+      [PossibleType in Type['possibleTypes']]: _getPossibleTypeSelectionRec<
         Selections,
         PossibleType,
         Type,
@@ -184,7 +184,7 @@ type getFragmentsSelection<
       >;
     }>
   : Type extends { kind: 'OBJECT'; name: any }
-    ? _getFragmentsSelectionRec<Selections, Type['name'], Type, Introspection, Fragments>
+    ? _getPossibleTypeSelectionRec<Selections, Type['name'], Type, Introspection, Fragments>
     : {};
 
 type getOperationSelectionType<

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -122,42 +122,7 @@ type getSelection<
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
-> = obj<
-  getFieldsSelectionRec<Selections, Type, Introspection, Fragments> &
-    getFragmentsSelection<Selections, Type, Introspection, Fragments>
->;
-
-type getFieldsSelectionRec<
-  Selections extends readonly unknown[],
-  Type extends ObjectLikeType,
-  Introspection extends IntrospectionLikeType,
-  Fragments extends { [name: string]: any },
-> = Selections extends readonly [infer Selection, ...infer Rest]
-  ? (Selection extends FieldNode
-      ? isOptionalRec<Selection['directives']> extends true
-        ? {
-            [Prop in getFieldAlias<Selection>]: Selection['name']['value'] extends '__typename'
-              ? getTypenameOfType<Type>
-              : unwrapType<
-                  Type['fields'][Selection['name']['value']]['type'],
-                  Selection['selectionSet'],
-                  Introspection,
-                  Fragments
-                >;
-          }
-        : {
-            [Prop in getFieldAlias<Selection>]?: Selection['name']['value'] extends '__typename'
-              ? getTypenameOfType<Type>
-              : unwrapType<
-                  Type['fields'][Selection['name']['value']]['type'],
-                  Selection['selectionSet'],
-                  Introspection,
-                  Fragments
-                >;
-          }
-      : {}) &
-      getFieldsSelectionRec<Rest, Type, Introspection, Fragments>
-  : {};
+> = obj<getFragmentsSelection<Selections, Type, Introspection, Fragments>>;
 
 type _getFragmentsSelectionRec<
   Selections extends readonly unknown[],
@@ -178,11 +143,27 @@ type _getFragmentsSelectionRec<
           ? makeUndefinedFragmentRef<Node['name']['value']>
           : {}
       : Node extends FieldNode
-        ? Node['name']['value'] extends '__typename'
-          ? isOptionalRec<Node['directives']> extends true
-            ? { [Prop in getFieldAlias<Node>]: PossibleType }
-            : { [Prop in getFieldAlias<Node>]?: PossibleType }
-          : {}
+        ? isOptionalRec<Node['directives']> extends true
+          ? {
+              [Prop in getFieldAlias<Node>]: Node['name']['value'] extends '__typename'
+                ? PossibleType
+                : unwrapType<
+                    Type['fields'][Node['name']['value']]['type'],
+                    Node['selectionSet'],
+                    Introspection,
+                    Fragments
+                  >;
+            }
+          : {
+              [Prop in getFieldAlias<Node>]?: Node['name']['value'] extends '__typename'
+                ? PossibleType
+                : unwrapType<
+                    Type['fields'][Node['name']['value']]['type'],
+                    Node['selectionSet'],
+                    Introspection,
+                    Fragments
+                  >;
+            }
         : {}) &
       _getFragmentsSelectionRec<Rest, PossibleType, Type, Introspection, Fragments>
   : {};

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -114,7 +114,7 @@ type getSpreadSubtype<
 type getTypenameOfType<Type extends ObjectLikeType> = Type extends {
   possibleTypes: any;
 }
-  ? Type['possibleTypes']
+  ? Type['name'] | Type['possibleTypes']
   : Type['name'];
 
 type getSelection<
@@ -134,7 +134,7 @@ type _getFragmentsSelectionRec<
   ? (Node extends FragmentSpreadNode | InlineFragmentNode
       ? getSpreadSubtype<Node, Type, Introspection, Fragments> extends infer Subtype extends
           ObjectLikeType
-        ? PossibleType extends Subtype['name'] | getTypenameOfType<Subtype>
+        ? PossibleType extends getTypenameOfType<Subtype>
           ?
               | (isOptionalRec<Node['directives']> extends true ? never : {})
               | getFragmentSelection<Node, Subtype, Introspection, Fragments>

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -177,7 +177,11 @@ type _getFragmentsSelectionRec<
         : Node extends FragmentSpreadNode
           ? makeUndefinedFragmentRef<Node['name']['value']>
           : {}
-      : {}) &
+      : Node extends FieldNode
+        ? Node['name']['value'] extends '__typename'
+          ? { [Prop in getFieldAlias<Node>]: PossibleType }
+          : {}
+        : {}) &
       _getFragmentsSelectionRec<Rest, PossibleType, Type, Introspection, Fragments>
   : {};
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -65,10 +65,10 @@ type isOptionalRec<Directives extends readonly unknown[] | undefined> =
   Directives extends readonly [infer Directive, ...infer Rest]
     ? Directive extends { kind: Kind.DIRECTIVE; name: any }
       ? Directive['name']['value'] extends 'include' | 'skip' | 'defer'
-        ? false
+        ? true
         : isOptionalRec<Rest>
       : isOptionalRec<Rest>
-    : true;
+    : false;
 
 type getFieldAlias<Node extends FieldNode> = Node['alias'] extends undefined
   ? Node['name']['value']
@@ -136,7 +136,7 @@ type _getPossibleTypeSelectionRec<
           ObjectLikeType
         ? PossibleType extends getTypenameOfType<Subtype>
           ?
-              | (isOptionalRec<Node['directives']> extends true ? never : {})
+              | (isOptionalRec<Node['directives']> extends true ? {} : never)
               | getFragmentSelection<Node, Subtype, Introspection, Fragments>
           : {}
         : Node extends FragmentSpreadNode
@@ -145,7 +145,7 @@ type _getPossibleTypeSelectionRec<
       : Node extends FieldNode
         ? isOptionalRec<Node['directives']> extends true
           ? {
-              [Prop in getFieldAlias<Node>]: Node['name']['value'] extends '__typename'
+              [Prop in getFieldAlias<Node>]?: Node['name']['value'] extends '__typename'
                 ? PossibleType
                 : unwrapType<
                     Type['fields'][Node['name']['value']]['type'],
@@ -155,7 +155,7 @@ type _getPossibleTypeSelectionRec<
                   >;
             }
           : {
-              [Prop in getFieldAlias<Node>]?: Node['name']['value'] extends '__typename'
+              [Prop in getFieldAlias<Node>]: Node['name']['value'] extends '__typename'
                 ? PossibleType
                 : unwrapType<
                     Type['fields'][Node['name']['value']]['type'],

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -179,7 +179,9 @@ type _getFragmentsSelectionRec<
           : {}
       : Node extends FieldNode
         ? Node['name']['value'] extends '__typename'
-          ? { [Prop in getFieldAlias<Node>]: PossibleType }
+          ? isOptionalRec<Node['directives']> extends true
+            ? { [Prop in getFieldAlias<Node>]: PossibleType }
+            : { [Prop in getFieldAlias<Node>]?: PossibleType }
           : {}
         : {}) &
       _getFragmentsSelectionRec<Rest, PossibleType, Type, Introspection, Fragments>


### PR DESCRIPTION
## Summary

When a `__typename` field is used on an abstract type’s selection set its value type wouldn’t be exact and instead a union of all possible types unless all possible types have selections containing a `__typename` field themselves.

```graphql
{
  test { # possible types: A / B
    __typename
    ... on B {
      field
    }
  }
}
```

The above would result in an incorrect inference since `B`’s selection set doesn't contain `__typename` itself:

```ts
const before: {
  test: {
    __typename: 'A' | 'B';
  } | {
    __typename: 'A' | 'B';
    field: unknown;
  };
};

const after: {
  test: {
    __typename: 'A';
  } | {
    __typename: 'B';
    field: unknown;
  };
};
```

## Set of changes

- Move `__typename` field handling to the selection handler that handles all possible types separately
- Remove field handling entirely in favour of always handling fields per possible type
- Refactor and rename utilities as appropriate
