### PR TITLE
fix: Fix readFragment() not deriving complex return types

### DIFF
--- a/.changeset/neat-numbers-shake.md
+++ b/.changeset/neat-numbers-shake.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Fix `readFragment()` not inferring the types of complex fragments, i.e. fragments that derive with a union type.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -93,6 +93,6 @@ describe('readFragment', () => {
 
     type document = getDocumentNode<fragment, schema>;
     const result = readFragment({} as document, {} as FragmentOf<document>);
-    expectTypeOf<ResultOf<document>>().toEqualTypeOf<typeof result>();
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 });

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -29,6 +29,12 @@ describe('mirrorFragmentTypeRec', () => {
     >();
     expectTypeOf<mirrorFragmentTypeRec<readonly value[], data>>().toEqualTypeOf<readonly data[]>();
   });
+
+  it('mirrors complex types', () => {
+    type complex = { a: true } | { b: true };
+    type actual = mirrorFragmentTypeRec<value, complex>;
+    expectTypeOf<actual>().toEqualTypeOf<complex>();
+  });
 });
 
 describe('readFragment', () => {
@@ -40,12 +46,7 @@ describe('readFragment', () => {
     `>;
 
     type document = getDocumentNode<fragment, schema>;
-
-    const document: document = {} as any;
-    const data: FragmentOf<document> = {} as any;
-
-    const result = readFragment(document, data);
-
+    const result = readFragment({} as document, {} as FragmentOf<document>);
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 
@@ -59,12 +60,39 @@ describe('readFragment', () => {
     `>;
 
     type document = getDocumentNode<fragment, schema>;
-
-    const document: document = {} as any;
-    const data: FragmentOf<document> = {} as any;
-
-    const result = readFragment(document, data);
-
+    const result = readFragment({} as document, {} as FragmentOf<document>);
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
+  });
+
+  it('unmasks fragments of interfaces', () => {
+    type fragment = parseDocument<`
+      fragment Fields on ITodo {
+        id
+        ... on BigTodo {
+          wallOfText
+        }
+        ... on SmallTodo {
+          maxLength
+        }
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = readFragment({} as document, {} as FragmentOf<document>);
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
+  });
+
+  it('unmasks fragments of interfaces with optional spreads', () => {
+    type fragment = parseDocument<`
+      fragment Fields on ITodo {
+        ... on ITodo @defer {
+          id
+        }
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = readFragment({} as document, {} as FragmentOf<document>);
+    expectTypeOf<ResultOf<document>>().toEqualTypeOf<typeof result>();
   });
 });

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -1,6 +1,11 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type { mirrorFragmentTypeRec } from '../api';
 
+import type { simpleSchema } from './fixtures/simpleSchema';
+import type { parseDocument } from '../parser';
+import type { ResultOf, FragmentOf, mirrorFragmentTypeRec, getDocumentNode } from '../api';
+import { readFragment } from '../api';
+
+type schema = simpleSchema;
 type value = { __value: true };
 type data = { __data: true };
 
@@ -23,5 +28,43 @@ describe('mirrorFragmentTypeRec', () => {
       (data | null)[] | null
     >();
     expectTypeOf<mirrorFragmentTypeRec<readonly value[], data>>().toEqualTypeOf<readonly data[]>();
+  });
+});
+
+describe('readFragment', () => {
+  it('unmasks regular fragments', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+
+    const document: document = {} as any;
+    const data: FragmentOf<document> = {} as any;
+
+    const result = readFragment(document, data);
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
+  });
+
+  it('unmasks fragments with optional spreads', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        ... @defer {
+          id
+        }
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+
+    const document: document = {} as any;
+    const data: FragmentOf<document> = {} as any;
+
+    const result = readFragment(document, data);
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -188,7 +188,7 @@ function parse<const In extends stringLiteral<In>>(input: In): parseDocument<In>
   return _parse(input) as any;
 }
 
-type getDocumentNode<
+export type getDocumentNode<
   Document extends DocumentNodeLike,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any } = {},

--- a/src/api.ts
+++ b/src/api.ts
@@ -347,13 +347,9 @@ type fragmentOfTypeRec<Document extends DocumentDefDecorationLike> =
  * @see {@link readFragment} for how to read from fragment masks.
  */
 function readFragment<
-  const Document extends DocumentDefDecorationLike,
+  const Document extends DocumentDefDecorationLike & DocumentDecoration<any, any>,
   const Fragment extends fragmentOfTypeRec<Document>,
-  const Data,
->(
-  _document: DocumentDecoration<Data, any> & Document,
-  fragment: Fragment
-): fragmentOfTypeRec<Document> extends Fragment ? unknown : mirrorFragmentTypeRec<Fragment, Data> {
+>(_document: Document, fragment: Fragment): mirrorFragmentTypeRec<Fragment, ResultOf<Document>> {
   return fragment as any;
 }
 


### PR DESCRIPTION
## Summary

When a complex fragment type (e.g. any fragment that derives to a union type of multiple object shapes) is passed to `readFragment()` then the return type would only infer as the first type of the union.

```ts
// derives to `{ wallOfText: string } | { maxLength: number }`
const fragment = graphql(`
  fragment Fields on ITodo {
    ... on BigTodo {
      wallOfText
    }
    ... on SmallTodo {
      maxLength
    }
  }
`);

// previously derived to: `{ wallOfText: string }`
// rather than: `{ wallOfText: string } | { maxLength: number }`
const fields = readFragment(fragment, data);
```

## Set of changes

- Add tests for `readFragment` inputs
- Remove `Data` generic on `readFragment` and instead infer `Data` from `Document` directly
