### PR TITLE
fix: Make fragmentRefs in selection types a required property

### DIFF
--- a/.changeset/rude-bulldogs-kneel.md
+++ b/.changeset/rude-bulldogs-kneel.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Make `$tada.fragmentRefs` property required. Previously, this was optional (to mirror what GCG’s client-preset does). However, this can lead to invalid checks in `readFragment`, as it would be able to match types that don’t actually match the fragment refs.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -38,6 +38,19 @@ describe('mirrorFragmentTypeRec', () => {
 });
 
 describe('readFragment', () => {
+  it('should not unmask empty objects', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    // @ts-expect-error
+    const result = readFragment({} as document, {});
+    expectTypeOf<typeof result>().toBeNever();
+  });
+
   it('unmasks regular fragments', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -219,7 +219,7 @@ test('infers fragment spreads for fragment refs', () => {
   type actual = getDocumentType<query, schema, extraFragments>;
 
   type expected = {
-    [$tada.fragmentRefs]?: {
+    [$tada.fragmentRefs]: {
       Fields: extraFragments['Fields'][$tada.fragmentId];
     };
   };
@@ -235,7 +235,7 @@ test('marks undefined fragments with special fragment ref error', () => {
   type actual = getDocumentType<query, schema>;
 
   type expected = {
-    [$tada.fragmentRefs]?: {
+    [$tada.fragmentRefs]: {
       Fields: 'Undefined Fragment';
     };
   };

--- a/src/api.ts
+++ b/src/api.ts
@@ -349,7 +349,12 @@ type fragmentOfTypeRec<Document extends DocumentDefDecorationLike> =
 function readFragment<
   const Document extends DocumentDefDecorationLike & DocumentDecoration<any, any>,
   const Fragment extends fragmentOfTypeRec<Document>,
->(_document: Document, fragment: Fragment): mirrorFragmentTypeRec<Fragment, ResultOf<Document>> {
+>(
+  _document: Document,
+  fragment: Fragment
+): fragmentOfTypeRec<Document> extends Fragment
+  ? never
+  : mirrorFragmentTypeRec<Fragment, ResultOf<Document>> {
   return fragment as any;
 }
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -63,13 +63,13 @@ type getFragmentsOfDocumentsRec<Documents> = Documents extends readonly [
   : {};
 
 type makeFragmentRef<Definition extends FragmentDefDecorationLike> = obj<{
-  [$tada.fragmentRefs]?: {
+  [$tada.fragmentRefs]: {
     [Name in Definition['name']['value']]: Definition[$tada.fragmentId];
   };
 }>;
 
 type makeUndefinedFragmentRef<FragmentName extends string> = {
-  [$tada.fragmentRefs]?: {
+  [$tada.fragmentRefs]: {
     [Name in FragmentName]: 'Undefined Fragment';
   };
 };

--- a/website/src/content/docs/get-started/writing-graphql.mdx
+++ b/website/src/content/docs/get-started/writing-graphql.mdx
@@ -197,7 +197,7 @@ const result: ResultOf<typeof TodosQuery> = {
   todos: [
     {
       id: 'ExampleID',
-      [$tada.fragmentRefs]?: {
+      [$tada.fragmentRefs]: {
         TodoItem: unique symbol;
       };
     },


### PR DESCRIPTION
## Summary

Previously, `$tada.fragmentRefs` was an optional property.
This is because it’s “virtual” i.e. it doesn't actually exist on result types.

However, this also meant that when matching against empty objects with `readFragment` an unsound match would occur.

In other words, `readFragment(fragment, {})` should not return an unwrapped fragment type.

## Set of changes

- Make `[$tada.fragmentRefs]` a required field
