### PR TITLE
fix: Prevent introspection mapping on schemas with huge root types from failing

### DIFF
--- a/.changeset/dry-actors-exercise.md
+++ b/.changeset/dry-actors-exercise.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Prevent type inference for schemas with “huge” root types (i.e. types with an excessive amount of fields) from failing introspection mapping.

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -168,7 +168,13 @@ type mapInterface<T extends IntrospectionInterfaceType> = {
   name: T['name'];
   interfaces: T['interfaces'] extends readonly any[] ? T['interfaces'][number]['name'] : never;
   possibleTypes: T['possibleTypes'][number]['name'];
-  fields: obj<mapNames<T['fields']>>;
+  fields: obj<{
+    [P in T['fields'][number]['name']]: T['fields'][number] extends infer Field
+      ? Field extends { readonly name: P }
+        ? mapField<Field>
+        : never
+      : never;
+  }>;
 };
 
 type mapUnion<T extends IntrospectionUnionType> = {

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -110,14 +110,6 @@ interface DefaultScalars {
   Int: number;
 }
 
-type mapNames<T extends readonly any[]> = obj<{
-  [P in T[number]['name']]: T[number] extends infer Value
-    ? Value extends { readonly name: P }
-      ? obj<Value>
-      : never
-    : never;
-}>;
-
 type mapScalar<
   Type extends IntrospectionScalarType,
   Scalars extends ScalarsLike = DefaultScalars,

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -136,11 +136,25 @@ type mapEnum<T extends IntrospectionEnumType> = {
   type: T['enumValues'][number]['name'];
 };
 
+type mapField<T> = T extends IntrospectionField
+  ? {
+      name: T['name'];
+      type: T['type'];
+      args: any;
+    }
+  : never;
+
 export type mapObject<T extends IntrospectionObjectType> = {
   kind: 'OBJECT';
   name: T['name'];
   interfaces: T['interfaces'][number]['name'];
-  fields: obj<mapNames<T['fields']>>;
+  fields: obj<{
+    [P in T['fields'][number]['name']]: T['fields'][number] extends infer Field
+      ? Field extends { readonly name: P }
+        ? mapField<Field>
+        : never
+      : never;
+  }>;
 };
 
 export type mapInputObject<T extends IntrospectionInputObjectType> = {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -16,7 +16,6 @@ import type {
 } from './namespace';
 
 import type {
-  IntrospectionField,
   IntrospectionListTypeRef,
   IntrospectionNamedTypeRef,
   IntrospectionNonNullTypeRef,
@@ -27,7 +26,7 @@ import type {
 type ObjectLikeType = {
   kind: 'OBJECT' | 'INTERFACE' | 'UNION';
   name: string;
-  fields: { [key: string]: IntrospectionField };
+  fields: { [key: string]: any };
 };
 
 type _unwrapTypeRec<


### PR DESCRIPTION
Resolves #22

## Summary

Prevent type inference for schemas with “huge” root types (i.e. types with an excessive amount of fields) from failing introspection mapping.

This is done by omitting `args` from the introspection mapping to slim down the type, and by preventing a match against every field from accidentally happening by removing `IntrospectionField` matching from `ObjectLikeType`.

## Set of changes

- Fix `ObjectLikeType` to not include `IntrospectionField` matching
- Remove `args` from fields in `mapObject` and `mapInterface`
