### PR TITLE
feat: allow for unmasking a fragment by means of a directive

### DIFF
--- a/.changeset/late-rabbits-burn.md
+++ b/.changeset/late-rabbits-burn.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Add the possibility to unmask a fragment with a directive `@disable_mask`

--- a/.changeset/late-rabbits-burn.md
+++ b/.changeset/late-rabbits-burn.md
@@ -2,4 +2,5 @@
 'gql.tada': minor
 ---
 
-Add the possibility to unmask a fragment with a directive `@disable_mask`
+Add the possibility to unmask a fragment with a directive `@disable_mask` which can be
+added to a `FragmentDefinition`

--- a/examples/example-pokemon-api/src/components/PokemonItem.tsx
+++ b/examples/example-pokemon-api/src/components/PokemonItem.tsx
@@ -7,6 +7,13 @@ export const PokemonItemFragment = graphql(`
   }
 `);
 
+export const PokemonItemFragmentUnmasked = graphql(`
+  fragment PokemonItemNoMask on Pokemon @mask_disable {
+    id
+    name
+  }
+`);
+
 interface Props {
   data: FragmentOf<typeof PokemonItemFragment> | null;
 }

--- a/examples/example-pokemon-api/src/components/PokemonList.tsx
+++ b/examples/example-pokemon-api/src/components/PokemonList.tsx
@@ -7,6 +7,7 @@ const PokemonsQuery = graphql(`
   query Pokemons ($limit: Int = 10) {
     pokemons(limit: $limit) {
       id
+      ...PokemonItem @mask_disable
       ...PokemonItem
     }
   }

--- a/examples/example-pokemon-api/src/components/PokemonList.tsx
+++ b/examples/example-pokemon-api/src/components/PokemonList.tsx
@@ -1,17 +1,17 @@
 import { useQuery } from 'urql';
 import { graphql } from '../graphql';
 
-import { PokemonItem, PokemonItemFragment } from './PokemonItem';
+import { PokemonItem, PokemonItemFragment, PokemonItemFragmentUnmasked } from './PokemonItem';
 
 const PokemonsQuery = graphql(`
   query Pokemons ($limit: Int = 10) {
     pokemons(limit: $limit) {
       id
-      ...PokemonItem @mask_disable
+      ...PokemonItemNoMask
       ...PokemonItem
     }
   }
-`, [PokemonItemFragment]);
+`, [PokemonItemFragment, PokemonItemFragmentUnmasked]);
 
 const PokemonList = () => {
   const [result] = useQuery({ query: PokemonsQuery });

--- a/src/__tests__/namespace.test-d.ts
+++ b/src/__tests__/namespace.test-d.ts
@@ -21,7 +21,7 @@ describe('decorateFragmentDef', () => {
               value: 'Todo';
             };
           };
-          directives: unknown;
+          directives: [];
           selectionSet: unknown;
         },
       ];
@@ -62,7 +62,7 @@ describe('getFragmentsOfDocumentsRec', () => {
         value: 'Todo';
       };
     };
-    selectionSet: {};
+    masked: true;
     readonly [$tada.fragmentId]: unique symbol;
   };
 

--- a/src/__tests__/namespace.test-d.ts
+++ b/src/__tests__/namespace.test-d.ts
@@ -62,6 +62,7 @@ describe('getFragmentsOfDocumentsRec', () => {
         value: 'Todo';
       };
     };
+    selectionSet: {};
     readonly [$tada.fragmentId]: unique symbol;
   };
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -165,6 +165,11 @@ function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
     for (const document of fragments || []) {
       for (const definition of document.definitions) {
         if (definition.kind === Kind.FRAGMENT_DEFINITION && !seen.has(definition)) {
+          if (definition.directives && definition.directives.length) {
+            (definition as any).directives = definition.directives.filter(
+              (directive) => directive.name.value !== 'mask_disable'
+            );
+          }
           definitions.push(definition);
           seen.add(definition);
         }

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -26,6 +26,7 @@ interface FragmentDefDecorationLike {
   kind: Kind.FRAGMENT_DEFINITION;
   name: any;
   typeCondition: any;
+  selectionSet: any;
 }
 
 interface DocumentDefDecorationLike extends DocumentNode {
@@ -36,12 +37,14 @@ type decorateFragmentDef<Document extends DocumentNodeLike> = Document['definiti
   kind: Kind.FRAGMENT_DEFINITION;
   name: any;
   typeCondition: any;
+  selectionSet: any;
 }
   ? {
       // NOTE: This is a shortened definition for readability in LSP hovers
       kind: Kind.FRAGMENT_DEFINITION;
       name: Document['definitions'][0]['name'];
       typeCondition: Document['definitions'][0]['typeCondition'];
+      selectionSet: Document['definitions'][0]['selectionSet'];
       readonly [$tada.fragmentId]: unique symbol;
     }
   : never;
@@ -55,6 +58,7 @@ type getFragmentsOfDocumentsRec<Documents> = Documents extends readonly [
           kind: Kind.FRAGMENT_DEFINITION;
           name: any;
           typeCondition: any;
+          selectionSet: any;
         }
         ? { [Name in FragmentDef['name']['value']]: FragmentDef }
         : {}

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -69,15 +69,6 @@ type isOptionalRec<Directives extends readonly unknown[] | undefined> =
       : isOptionalRec<Rest>
     : false;
 
-type isUnmaskedFragmentRec<Directives extends readonly unknown[] | undefined> =
-  Directives extends readonly [infer Directive, ...infer Rest]
-    ? Directive extends { kind: Kind.DIRECTIVE; name: any }
-      ? Directive['name']['value'] extends 'mask_disable'
-        ? true
-        : isUnmaskedFragmentRec<Rest>
-      : isUnmaskedFragmentRec<Rest>
-    : false;
-
 type getFieldAlias<Node extends FieldNode> = Node['alias'] extends undefined
   ? Node['name']['value']
   : Node['alias'] extends NameNode
@@ -94,14 +85,14 @@ type getFragmentSelection<
   : Node extends { kind: Kind.FRAGMENT_SPREAD; name: any; directives: any[] }
     ? Node['name']['value'] extends keyof Fragments
       ? Fragments[Node['name']['value']] extends FragmentDefDecorationLike
-        ? isUnmaskedFragmentRec<Node['directives']> extends true
-          ? getSelection<
+        ? Fragments[Node['name']['value']]['masked'] extends true
+          ? makeFragmentRef<Fragments[Node['name']['value']]>
+          : getSelection<
               Fragments[Node['name']['value']]['selectionSet']['selections'],
               Type,
               Introspection,
               Fragments
             >
-          : makeFragmentRef<Fragments[Node['name']['value']]>
         : getSelection<
             Fragments[Node['name']['value']]['selectionSet']['selections'],
             Type,


### PR DESCRIPTION
Resolves https://github.com/0no-co/gql.tada/issues/23

## Summary

This adds the possibility of annotating a fragment-spread with `@mask_disable` I went for the same name as houdini for familiarity. This still needs some code to remove these directives during `parse` but wanted to already surface this PR, would we be opposed to using `visit` from `@graphql.web` for this?
