### PR TITLE
feat: Implement support for `@_optional` and `@_required` on fields

### DIFF
--- a/.changeset/fair-pillows-repair.md
+++ b/.changeset/fair-pillows-repair.md
@@ -1,0 +1,7 @@
+---
+'gql.tada': minor
+---
+
+Support `@_optional` and `@_required` directives on fields overriding the field types.
+When used, `@_required` can turn a nullable type into a non-nullable, and `@_optional`
+can turn non-nullable fields into nullable ones. (See [“Client-Controlled Nullability” in Graphcache for an example of a client implementing this.](https://formidable.com/open-source/urql/docs/graphcache/local-directives/#client-controlled-nullability))

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -113,6 +113,29 @@ test('infers optional properties for @skip/@include', () => {
   expectTypeOf<expected>().toEqualTypeOf<actual>();
 });
 
+test('infers nullable field types for @required/@optional', () => {
+  type query = parseDocument</* GraphQL */ `
+    query {
+      todos {
+        id @optional
+        complete @required
+      }
+    }
+  `>;
+
+  type actual = getDocumentType<query, schema>;
+  type expected = {
+    todos:
+      | ({
+          id: string | number | null;
+          complete: boolean;
+        } | null)[]
+      | null;
+  };
+
+  expectTypeOf<expected>().toEqualTypeOf<actual>();
+});
+
 test('infers optional fragment for @defer', () => {
   type query = parseDocument</* GraphQL */ `
     query {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -56,9 +56,25 @@ type unwrapType<
   SelectionSet extends { kind: Kind.SELECTION_SET } | undefined,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
+  TypeDirective = void,
 > = Type extends IntrospectionNonNullTypeRef
-  ? _unwrapTypeRec<Type['ofType'], SelectionSet, Introspection, Fragments>
-  : null | _unwrapTypeRec<Type, SelectionSet, Introspection, Fragments>;
+  ? TypeDirective extends 'optional'
+    ? null | _unwrapTypeRec<Type['ofType'], SelectionSet, Introspection, Fragments>
+    : _unwrapTypeRec<Type['ofType'], SelectionSet, Introspection, Fragments>
+  : TypeDirective extends 'required'
+    ? _unwrapTypeRec<Type, SelectionSet, Introspection, Fragments>
+    : null | _unwrapTypeRec<Type, SelectionSet, Introspection, Fragments>;
+
+type getTypeDirective<Directives extends readonly unknown[] | undefined> =
+  Directives extends readonly [infer Directive, ...infer Rest]
+    ? Directive extends { kind: Kind.DIRECTIVE; name: any }
+      ? Directive['name']['value'] extends 'required' | '_required'
+        ? 'required'
+        : Directive['name']['value'] extends 'optional' | '_optional'
+          ? 'optional'
+          : getTypeDirective<Rest>
+      : getTypeDirective<Rest>
+    : void;
 
 type isOptionalRec<Directives extends readonly unknown[] | undefined> =
   Directives extends readonly [infer Directive, ...infer Rest]
@@ -150,7 +166,8 @@ type _getPossibleTypeSelectionRec<
                     Type['fields'][Node['name']['value']]['type'],
                     Node['selectionSet'],
                     Introspection,
-                    Fragments
+                    Fragments,
+                    getTypeDirective<Node['directives']>
                   >;
             }
           : {
@@ -160,7 +177,8 @@ type _getPossibleTypeSelectionRec<
                     Type['fields'][Node['name']['value']]['type'],
                     Node['selectionSet'],
                     Introspection,
-                    Fragments
+                    Fragments,
+                    getTypeDirective<Node['directives']>
                   >;
             }
         : {}) &


### PR DESCRIPTION
Resolves #30

## Summary

This supports client-controlled nullability directives, as implemented for instance in [in Graphcache for an example.](https://formidable.com/open-source/urql/docs/graphcache/local-directives/#client-controlled-nullability)

When applied,
- `@_optional` / `@optional` turns a non-nullable field into a nullable one.
- `@_required` / `@required` turns a nullable field into a non-nullable one.

## Set of changes

- Add `getTypeDirective` as `unwrapType` input and override type as required
