### PR TITLE
fix: Improve parser performance

### DIFF
--- a/.changeset/sweet-birds-grab.md
+++ b/.changeset/sweet-birds-grab.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Improve performance of GraphQL document parser.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -17,19 +17,19 @@ type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
       ? In
       : never;
 
-type skipDigits<In extends string> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
-type skipInt<In extends string> = In extends `${'-'}${digit}${infer In}`
+type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
+type skipInt<In> = In extends `${'-'}${digit}${infer In}`
   ? skipDigits<In>
   : In extends `${digit}${infer In}`
     ? skipDigits<In>
     : void;
 
-type skipExponent<In extends string> = In extends `${'e' | 'E'}${'+' | '-'}${infer In}`
+type skipExponent<In> = In extends `${'e' | 'E'}${'+' | '-'}${infer In}`
   ? skipDigits<In>
   : In extends `${'e' | 'E'}${infer In}`
     ? skipDigits<In>
     : In;
-type skipFloat<In extends string> = In extends `${'.'}${infer In}`
+type skipFloat<In> = In extends `${'.'}${infer In}`
   ? In extends `${digit}${infer In}`
     ? skipExponent<skipDigits<In>>
     : void
@@ -37,44 +37,41 @@ type skipFloat<In extends string> = In extends `${'.'}${infer In}`
     ? skipExponent<In>
     : void;
 
-type skipBlockString<In extends string> = In extends `${infer Hd}${'"""'}${infer In}`
+type skipBlockString<In> = In extends `${infer Hd}${'"""'}${infer In}`
   ? Hd extends `${infer _}${'\\'}`
     ? skipBlockString<skipIgnored<In>>
     : In
   : void;
-type skipString<In extends string> = In extends `${infer Hd}${'"'}${infer In}`
+type skipString<In> = In extends `${infer Hd}${'"'}${infer In}`
   ? Hd extends `${infer _}${'\\'}`
     ? skipString<In>
     : In
   : void;
 
-type _takeNameLiteralRec<
-  PrevMatch extends string,
-  In extends string,
-> = In extends `${infer Match}${infer Out}`
+type _takeNameLiteralRec<PrevMatch extends string, In> = In extends `${infer Match}${infer Out}`
   ? Match extends letter | digit | '_'
     ? _takeNameLiteralRec<`${PrevMatch}${Match}`, Out>
     : [PrevMatch, In]
   : [PrevMatch, In];
-type takeNameLiteral<In extends string> = In extends `${infer Match}${infer In}`
+type takeNameLiteral<In> = In extends `${infer Match}${infer In}`
   ? Match extends letter | '_'
     ? _takeNameLiteralRec<Match, In>
     : void
   : void;
 
-type takeName<In extends string> = takeNameLiteral<In> extends [infer Out, infer In]
+type takeName<In> = takeNameLiteral<In> extends [infer Out, infer In]
   ? [{ kind: Kind.NAME; value: Out }, In]
   : void;
 
-type takeOptionalName<In extends string> = takeNameLiteral<In> extends [infer Out, infer In]
+type takeOptionalName<In> = takeNameLiteral<In> extends [infer Out, infer In]
   ? [{ kind: Kind.NAME; value: Out }, In]
   : [undefined, In];
 
-type takeEnum<In extends string> = takeNameLiteral<In> extends [infer Out, infer In]
+type takeEnum<In> = takeNameLiteral<In> extends [infer Out, infer In]
   ? [{ kind: Kind.ENUM; value: Out }, In]
   : void;
 
-type TakeVariable<In extends string, Const extends boolean> = Const extends false
+type TakeVariable<In, Const> = Const extends false
   ? In extends `${'$'}${infer In}`
     ? takeNameLiteral<In> extends [infer Out, infer In]
       ? [{ kind: Kind.VARIABLE; name: { kind: Kind.NAME; value: Out } }, In]
@@ -82,13 +79,13 @@ type TakeVariable<In extends string, Const extends boolean> = Const extends fals
     : void
   : void;
 
-type takeNumber<In extends string> = skipInt<In> extends `${infer In}`
+type takeNumber<In> = skipInt<In> extends `${infer In}`
   ? skipFloat<In> extends `${infer In}`
     ? [{ kind: Kind.FLOAT; value: string }, In]
     : [{ kind: Kind.INT; value: string }, In]
   : void;
 
-type takeString<In extends string> = In extends `${'"""'}${infer In}`
+type takeString<In> = In extends `${'"""'}${infer In}`
   ? skipBlockString<In> extends `${infer In}`
     ? [{ kind: Kind.STRING; value: string; block: true }, In]
     : void
@@ -98,16 +95,13 @@ type takeString<In extends string> = In extends `${'"""'}${infer In}`
       : void
     : void;
 
-type takeLiteral<In extends string> = In extends `${'null'}${infer In}`
+type takeLiteral<In> = In extends `${'null'}${infer In}`
   ? [{ kind: Kind.NULL }, In]
   : In extends `${'true' | 'false'}${infer In}`
     ? [{ kind: Kind.BOOLEAN; value: boolean }, In]
     : void;
 
-export type takeValue<In extends string, Const extends boolean> = takeLiteral<In> extends [
-  infer Node,
-  infer Rest,
-]
+export type takeValue<In, Const> = takeLiteral<In> extends [infer Node, infer Rest]
   ? [Node, Rest]
   : TakeVariable<In, Const> extends [infer Node, infer Rest]
     ? [Node, Rest]
@@ -123,23 +117,16 @@ export type takeValue<In extends string, Const extends boolean> = takeLiteral<In
               ? [Node, Rest]
               : void;
 
-type _takeListRec<
-  Nodes extends unknown[],
-  In extends string,
-  Const extends boolean,
-> = In extends `${']'}${infer In}`
+type _takeListRec<Nodes extends any[], In, Const> = In extends `${']'}${infer In}`
   ? [{ kind: Kind.LIST; values: Nodes }, In]
   : takeValue<skipIgnored<In>, Const> extends [infer Node, infer In]
     ? _takeListRec<[...Nodes, Node], skipIgnored<In>, Const>
     : void;
-export type takeList<In extends string, Const extends boolean> = In extends `${'['}${infer In}`
+export type takeList<In, Const> = In extends `${'['}${infer In}`
   ? _takeListRec<[], skipIgnored<In>, Const>
   : void;
 
-type takeObjectField<In extends string, Const extends boolean> = takeName<In> extends [
-  infer Name,
-  infer In,
-]
+type takeObjectField<In, Const> = takeName<In> extends [infer Name, infer In]
   ? skipIgnored<In> extends `${':'}${infer In}`
     ? takeValue<skipIgnored<In>, Const> extends [infer Value, infer In]
       ? [{ kind: Kind.OBJECT_FIELD; name: Name; value: Value }, In]
@@ -147,23 +134,16 @@ type takeObjectField<In extends string, Const extends boolean> = takeName<In> ex
     : void
   : void;
 
-export type _takeObjectRec<
-  Fields extends unknown[],
-  In extends string,
-  Const extends boolean,
-> = In extends `${'}'}${infer In}`
+export type _takeObjectRec<Fields extends any[], In, Const> = In extends `${'}'}${infer In}`
   ? [{ kind: Kind.OBJECT; fields: Fields }, In]
   : takeObjectField<skipIgnored<In>, Const> extends [infer Field, infer In]
     ? _takeObjectRec<[...Fields, Field], skipIgnored<In>, Const>
     : void;
-type takeObject<In extends string, Const extends boolean> = In extends `${'{'}${infer In}`
+type takeObject<In, Const> = In extends `${'{'}${infer In}`
   ? _takeObjectRec<[], skipIgnored<In>, Const>
   : void;
 
-type takeArgument<In extends string, Const extends boolean> = takeName<In> extends [
-  infer Name,
-  infer In,
-]
+type takeArgument<In, Const> = takeName<In> extends [infer Name, infer In]
   ? skipIgnored<In> extends `${':'}${infer In}`
     ? takeValue<skipIgnored<In>, Const> extends [infer Value, infer In]
       ? [{ kind: Kind.ARGUMENT; name: Name; value: Value }, In]
@@ -171,22 +151,18 @@ type takeArgument<In extends string, Const extends boolean> = takeName<In> exten
     : void
   : void;
 
-type _takeArgumentsRec<
-  Arguments extends unknown[],
-  In extends string,
-  Const extends boolean,
-> = In extends `${')'}${infer In}`
+type _takeArgumentsRec<Arguments extends any[], In, Const> = In extends `${')'}${infer In}`
   ? Arguments extends []
     ? void
     : [Arguments, In]
   : takeArgument<In, Const> extends [infer Argument, infer In]
     ? _takeArgumentsRec<[...Arguments, Argument], skipIgnored<In>, Const>
     : void;
-export type takeArguments<In extends string, Const extends boolean> = In extends `${'('}${infer In}`
+export type takeArguments<In, Const> = In extends `${'('}${infer In}`
   ? _takeArgumentsRec<[], skipIgnored<In>, Const>
   : [[], In];
 
-export type takeDirective<In extends string, Const extends boolean> = In extends `${'@'}${infer In}`
+export type takeDirective<In, Const> = In extends `${'@'}${infer In}`
   ? takeName<In> extends [infer Name, infer In]
     ? takeArguments<skipIgnored<In>, Const> extends [infer Arguments, infer In]
       ? [{ kind: Kind.DIRECTIVE; name: Name; arguments: Arguments }, In]
@@ -194,16 +170,13 @@ export type takeDirective<In extends string, Const extends boolean> = In extends
     : void
   : void;
 
-export type takeDirectives<In extends string, Const extends boolean> = takeDirective<
-  In,
-  Const
-> extends [infer Directive, infer In]
+export type takeDirectives<In, Const> = takeDirective<In, Const> extends [infer Directive, infer In]
   ? takeDirectives<skipIgnored<In>, Const> extends [[...infer Directives], infer In]
     ? [[Directive, ...Directives], In]
     : [[], In]
   : [[], In];
 
-type takeFieldName<In extends string> = takeName<In> extends [infer MaybeAlias, infer In]
+type takeFieldName<In> = takeName<In> extends [infer MaybeAlias, infer In]
   ? skipIgnored<In> extends `${':'}${infer In}`
     ? takeName<skipIgnored<In>> extends [infer Name, infer In]
       ? [MaybeAlias, Name, In]
@@ -211,11 +184,7 @@ type takeFieldName<In extends string> = takeName<In> extends [infer MaybeAlias, 
     : [undefined, MaybeAlias, In]
   : void;
 
-export type takeField<In extends string> = takeFieldName<In> extends [
-  infer Alias,
-  infer Name,
-  infer In,
-]
+export type takeField<In> = takeFieldName<In> extends [infer Alias, infer Name, infer In]
   ? takeArguments<skipIgnored<In>, false> extends [infer Arguments, infer In]
     ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
       ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
@@ -245,7 +214,7 @@ export type takeField<In extends string> = takeFieldName<In> extends [
     : void
   : void;
 
-export type takeType<In extends string> = In extends `${'['}${infer In}`
+export type takeType<In> = In extends `${'['}${infer In}`
   ? takeType<skipIgnored<In>> extends [infer Subtype, infer In]
     ? In extends `${']'}${infer In}`
       ? skipIgnored<In> extends `${'!'}${infer In}`
@@ -259,13 +228,13 @@ export type takeType<In extends string> = In extends `${'['}${infer In}`
       : [{ kind: Kind.NAMED_TYPE; name: Name }, In]
     : void;
 
-type takeTypeCondition<In extends string> = In extends `${'on'}${infer In}`
+type takeTypeCondition<In> = In extends `${'on'}${infer In}`
   ? takeName<skipIgnored<In>> extends [infer Name, infer In]
     ? [{ kind: Kind.NAMED_TYPE; name: Name }, In]
     : void
   : void;
 
-export type takeFragmentSpread<In extends string> = In extends `${'...'}${infer In}`
+export type takeFragmentSpread<In> = In extends `${'...'}${infer In}`
   ? skipIgnored<In> extends `${'on'}${infer In}`
     ? takeName<skipIgnored<In>> extends [infer Name, infer In]
       ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
@@ -301,10 +270,7 @@ export type takeFragmentSpread<In extends string> = In extends `${'...'}${infer 
         : void
   : void;
 
-type _takeSelectionRec<
-  Selections extends unknown[],
-  In extends string,
-> = In extends `${'}'}${infer In}`
+type _takeSelectionRec<Selections extends any[], In> = In extends `${'}'}${infer In}`
   ? [{ kind: Kind.SELECTION_SET; selections: Selections }, In]
   : takeFragmentSpread<skipIgnored<In>> extends [infer Selection, infer In]
     ? _takeSelectionRec<[...Selections, Selection], skipIgnored<In>>
@@ -312,14 +278,11 @@ type _takeSelectionRec<
       ? _takeSelectionRec<[...Selections, Selection], skipIgnored<In>>
       : void;
 
-export type takeSelectionSet<In extends string> = In extends `${'{'}${infer In}`
+export type takeSelectionSet<In> = In extends `${'{'}${infer In}`
   ? _takeSelectionRec<[], skipIgnored<In>>
   : void;
 
-export type takeVarDefinition<In extends string> = TakeVariable<In, false> extends [
-  infer Variable,
-  infer In,
-]
+export type takeVarDefinition<In> = TakeVariable<In, false> extends [infer Variable, infer In]
   ? skipIgnored<In> extends `${':'}${infer In}`
     ? takeType<skipIgnored<In>> extends [infer Type, infer In]
       ? skipIgnored<In> extends `${'='}${infer In}`
@@ -353,19 +316,16 @@ export type takeVarDefinition<In extends string> = TakeVariable<In, false> exten
     : void
   : void;
 
-type _takeVarDefinitionRec<
-  Definitions extends unknown[],
-  In extends string,
-> = In extends `${')'}${infer In}`
+type _takeVarDefinitionRec<Definitions extends any[], In> = In extends `${')'}${infer In}`
   ? [Definitions, In]
   : takeVarDefinition<In> extends [infer Definition, infer In]
     ? _takeVarDefinitionRec<[...Definitions, Definition], skipIgnored<In>>
     : void;
-export type takeVarDefinitions<In extends string> = skipIgnored<In> extends `${'('}${infer In}`
+export type takeVarDefinitions<In> = skipIgnored<In> extends `${'('}${infer In}`
   ? _takeVarDefinitionRec<[], skipIgnored<In>>
   : [[], In];
 
-export type takeFragmentDefinition<In extends string> = In extends `${'fragment'}${infer In}`
+export type takeFragmentDefinition<In> = In extends `${'fragment'}${infer In}`
   ? takeName<skipIgnored<In>> extends [infer Name, infer In]
     ? takeTypeCondition<skipIgnored<In>> extends [infer TypeCondition, infer In]
       ? takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
@@ -386,7 +346,7 @@ export type takeFragmentDefinition<In extends string> = In extends `${'fragment'
     : void
   : void;
 
-type TakeOperation<In extends string> = In extends `${'query'}${infer In}`
+type TakeOperation<In> = In extends `${'query'}${infer In}`
   ? [OperationTypeNode.QUERY, In]
   : In extends `${'mutation'}${infer In}`
     ? [OperationTypeNode.MUTATION, In]
@@ -394,10 +354,7 @@ type TakeOperation<In extends string> = In extends `${'query'}${infer In}`
       ? [OperationTypeNode.SUBSCRIPTION, In]
       : void;
 
-export type takeOperationDefinition<In extends string> = TakeOperation<In> extends [
-  infer Operation,
-  infer In,
-]
+export type takeOperationDefinition<In> = TakeOperation<In> extends [infer Operation, infer In]
   ? takeOptionalName<skipIgnored<In>> extends [infer Name, infer In]
     ? takeVarDefinitions<skipIgnored<In>> extends [infer VarDefinitions, infer In]
       ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
@@ -431,16 +388,16 @@ export type takeOperationDefinition<In extends string> = TakeOperation<In> exten
       ]
     : void;
 
-type _takeDocumentRec<
-  Definitions extends unknown[],
-  In extends string,
-> = takeFragmentDefinition<In> extends [infer Definition, infer In]
+type _takeDocumentRec<Definitions extends any[], In> = takeFragmentDefinition<In> extends [
+  infer Definition,
+  infer In,
+]
   ? _takeDocumentRec<[...Definitions, Definition], skipIgnored<In>>
   : takeOperationDefinition<In> extends [infer Definition, infer In]
     ? _takeDocumentRec<[...Definitions, Definition], skipIgnored<In>>
     : [Definitions, In];
 
-type parseDocument<In extends string> = _takeDocumentRec<[], skipIgnored<In>> extends [
+type parseDocument<In> = _takeDocumentRec<[], skipIgnored<In>> extends [
   [...infer Definitions],
   infer _Rest,
 ]


### PR DESCRIPTION
## Summary

This improves the parser’s performance by eliminating unused generic constraints.

## Set of changes

- Remove unused `In extends string` constraints
- Remove unused `Const extends boolean` constraints
- Turn `unknown[]` constraints to `any[]`