### PR TITLE
fix: Improve selection and variables performance

### DIFF
--- a/.changeset/four-bats-impress.md
+++ b/.changeset/four-bats-impress.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Improve performance of selection and variables inference.

--- a/src/__tests__/selection.bench.ts
+++ b/src/__tests__/selection.bench.ts
@@ -7,18 +7,70 @@ describe('TypedDocument', () => {
     ...ts.readSourceFolders(['.']),
     'simpleSchema.ts': ts.readFileFromRoot('src/__tests__/fixtures/simpleSchema.ts'),
     'index.ts': `
+      import { Kind, OperationTypeNode } from '@0no-co/graphql.web';
       import { simpleSchema as schema } from './simpleSchema';
       import { parseDocument } from './parser';
       import { getDocumentType } from './selection';
       import { getVariablesType } from './variables';
 
-      type document = parseDocument<\`
-        query ($org: String!, $repo: String!) {
-          todos {
-            id
-          }
-        }
-      \`>;
+      type document = {
+        kind: Kind.DOCUMENT;
+        definitions: [{
+          kind: Kind.OPERATION_DEFINITION;
+          operation: OperationTypeNode.QUERY;
+          name: undefined;
+          variableDefinitions: [{
+            kind: Kind.VARIABLE_DEFINITION;
+            variable: {
+              kind: Kind.VARIABLE;
+              name: {
+                kind: Kind.NAME;
+                value: 'test';
+              };
+            };
+            type: {
+              kind: Kind.NON_NULL_TYPE;
+              type: {
+                kind: Kind.NAMED_TYPE;
+                name: {
+                  kind: Kind.NAME;
+                  value: 'String';
+                };
+              };
+            };
+            defaultValue: undefined;
+            directives: [];
+          }];
+          selectionSet: {
+            kind: Kind.SELECTION_SET;
+            selections: [{
+              kind: Kind.FIELD;
+              alias: undefined;
+              name: {
+                kind: Kind.NAME;
+                value: 'todos';
+              };
+              directives: [];
+              arguments: [];
+              selectionSet: {
+                kind: Kind.SELECTION_SET;
+                selections: [{
+                  kind: Kind.FIELD;
+                  alias: undefined;
+                  name: {
+                    kind: Kind.NAME;
+                    value: 'id';
+                  };
+                  selectionSet: undefined;
+                  directives: [];
+                  arguments: [];
+                }];
+              };
+            }]
+          };
+          directives: [];
+        }];
+      };
 
       type Result = getDocumentType<document, schema>;
       type Input = getVariablesType<document, schema>;

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,10 +1,4 @@
-import type {
-  Kind,
-  FieldNode,
-  FragmentSpreadNode,
-  InlineFragmentNode,
-  NameNode,
-} from '@0no-co/graphql.web';
+import type { Kind, FieldNode, FragmentSpreadNode, InlineFragmentNode } from '@0no-co/graphql.web';
 
 import type { obj, objValues } from './utils';
 import type { DocumentNodeLike } from './parser';
@@ -72,9 +66,9 @@ type isOptionalRec<Directives> = Directives extends readonly [infer Directive, .
     : isOptionalRec<Rest>
   : false;
 
-type getFieldAlias<Node extends FieldNode> = Node['alias'] extends undefined
+type getFieldAlias<Node> = Node extends { alias: undefined; name: any }
   ? Node['name']['value']
-  : Node['alias'] extends NameNode
+  : Node extends { alias: any }
     ? Node['alias']['value']
     : never;
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,4 +1,4 @@
-import type { Kind, FieldNode, FragmentSpreadNode, InlineFragmentNode } from '@0no-co/graphql.web';
+import type { Kind } from '@0no-co/graphql.web';
 
 import type { obj, objValues } from './utils';
 import type { DocumentNodeLike } from './parser';
@@ -135,7 +135,7 @@ type _getPossibleTypeSelectionRec<
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
 > = Selections extends [infer Node, ...infer Rest]
-  ? (Node extends FragmentSpreadNode | InlineFragmentNode
+  ? (Node extends { kind: Kind.FRAGMENT_SPREAD | Kind.INLINE_FRAGMENT }
       ? getSpreadSubtype<Node, Type, Introspection, Fragments> extends infer Subtype extends
           ObjectLikeType
         ? PossibleType extends getTypenameOfType<Subtype>
@@ -143,10 +143,10 @@ type _getPossibleTypeSelectionRec<
               | (isOptional<Node> extends true ? {} : never)
               | getFragmentSelection<Node, Subtype, Introspection, Fragments>
           : {}
-        : Node extends FragmentSpreadNode
+        : Node extends { kind: Kind.FRAGMENT_SPREAD; name: any }
           ? makeUndefinedFragmentRef<Node['name']['value']>
           : {}
-      : Node extends FieldNode
+      : Node extends { kind: Kind.FIELD; name: any; selectionSet: any }
         ? isOptional<Node> extends true
           ? {
               [Prop in getFieldAlias<Node>]?: Node['name']['value'] extends '__typename'

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -112,7 +112,7 @@ type getTypenameOfType<Type> =
   | (Type extends { possibleTypes: any } ? Type['possibleTypes'] : never);
 
 type getSelection<
-  Selections extends readonly any[],
+  Selections,
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
@@ -133,7 +133,7 @@ type getSelection<
 >;
 
 type _getPossibleTypeSelectionRec<
-  Selections extends readonly any[],
+  Selections,
   PossibleType extends string,
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -107,11 +107,9 @@ type getSpreadSubtype<
       : void
     : void;
 
-type getTypenameOfType<Type extends ObjectLikeType> = Type extends {
-  possibleTypes: any;
-}
-  ? Type['name'] | Type['possibleTypes']
-  : Type['name'];
+type getTypenameOfType<Type> =
+  | (Type extends { name: any } ? Type['name'] : never)
+  | (Type extends { possibleTypes: any } ? Type['possibleTypes'] : never);
 
 type getSelection<
   Selections extends readonly any[],

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -10,14 +10,7 @@ import type { obj, objValues } from './utils';
 import type { DocumentNodeLike } from './parser';
 
 import type { $tada, makeUndefinedFragmentRef } from './namespace';
-
-import type {
-  IntrospectionListTypeRef,
-  IntrospectionNamedTypeRef,
-  IntrospectionNonNullTypeRef,
-  IntrospectionTypeRef,
-  IntrospectionLikeType,
-} from './introspection';
+import type { IntrospectionLikeType } from './introspection';
 
 type ObjectLikeType = {
   kind: 'OBJECT' | 'INTERFACE' | 'UNION';
@@ -26,15 +19,15 @@ type ObjectLikeType = {
 };
 
 type _unwrapTypeRec<
-  Type extends IntrospectionTypeRef,
+  Type,
   SelectionSet,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
-> = Type extends IntrospectionNonNullTypeRef
+> = Type extends { readonly kind: 'NON_NULL'; readonly ofType: any }
   ? _unwrapTypeRec<Type['ofType'], SelectionSet, Introspection, Fragments>
-  : Type extends IntrospectionListTypeRef
+  : Type extends { readonly kind: 'LIST'; readonly ofType: any }
     ? Array<unwrapType<Type['ofType'], SelectionSet, Introspection, Fragments>>
-    : Type extends IntrospectionNamedTypeRef
+    : Type extends { readonly name: string }
       ? Introspection['types'][Type['name']] extends ObjectLikeType
         ? SelectionSet extends { kind: Kind.SELECTION_SET; selections: any }
           ? getSelection<
@@ -48,12 +41,12 @@ type _unwrapTypeRec<
       : unknown;
 
 type unwrapType<
-  Type extends IntrospectionTypeRef,
+  Type,
   SelectionSet,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
   TypeDirective = void,
-> = Type extends IntrospectionNonNullTypeRef
+> = Type extends { readonly kind: 'NON_NULL'; readonly ofType: any }
   ? TypeDirective extends 'optional'
     ? null | _unwrapTypeRec<Type['ofType'], SelectionSet, Introspection, Fragments>
     : _unwrapTypeRec<Type['ofType'], SelectionSet, Introspection, Fragments>

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -73,7 +73,7 @@ type getFieldAlias<Node> = Node extends { alias: undefined; name: any }
     : never;
 
 type getFragmentSelection<
-  Node extends { kind: Kind.FRAGMENT_SPREAD | Kind.INLINE_FRAGMENT },
+  Node,
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
@@ -93,7 +93,7 @@ type getFragmentSelection<
     : {};
 
 type getSpreadSubtype<
-  Node extends { kind: Kind.FRAGMENT_SPREAD | Kind.INLINE_FRAGMENT },
+  Node,
   BaseType extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -54,10 +54,7 @@ type unwrapType<
     ? _unwrapTypeRec<Type, SelectionSet, Introspection, Fragments>
     : null | _unwrapTypeRec<Type, SelectionSet, Introspection, Fragments>;
 
-type getTypeDirective<Directives extends readonly any[] | undefined> = Directives extends readonly [
-  infer Directive,
-  ...infer Rest,
-]
+type getTypeDirective<Directives> = Directives extends readonly [infer Directive, ...infer Rest]
   ? Directive extends { kind: Kind.DIRECTIVE; name: any }
     ? Directive['name']['value'] extends 'required' | '_required'
       ? 'required'
@@ -67,10 +64,7 @@ type getTypeDirective<Directives extends readonly any[] | undefined> = Directive
     : getTypeDirective<Rest>
   : void;
 
-type isOptionalRec<Directives extends readonly any[] | undefined> = Directives extends readonly [
-  infer Directive,
-  ...infer Rest,
-]
+type isOptionalRec<Directives> = Directives extends readonly [infer Directive, ...infer Rest]
   ? Directive extends { kind: Kind.DIRECTIVE; name: any }
     ? Directive['name']['value'] extends 'include' | 'skip' | 'defer'
       ? true

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,14 +1,14 @@
-import type { Kind, TypeNode } from '@0no-co/graphql.web';
+import type { Kind } from '@0no-co/graphql.web';
 import type { IntrospectionLikeType } from './introspection';
 import type { DocumentNodeLike } from './parser';
 import type { obj } from './utils';
 
 type getInputObjectTypeRec<
-  InputFields extends readonly unknown[],
+  InputFields,
   Introspection extends IntrospectionLikeType,
 > = InputFields extends [infer InputField, ...infer Rest]
   ? (InputField extends { name: any; type: any }
-      ? InputField extends { type: { kind: 'NON_NULL' } }
+      ? InputField['type'] extends { kind: 'NON_NULL' }
         ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
         : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> }
       : {}) &
@@ -16,7 +16,7 @@ type getInputObjectTypeRec<
   : {};
 
 type getScalarType<
-  TypeName extends string,
+  TypeName,
   Introspection extends IntrospectionLikeType,
 > = TypeName extends keyof Introspection['types']
   ? Introspection['types'][TypeName] extends {
@@ -32,45 +32,46 @@ type getScalarType<
       : never
   : unknown;
 
-type _unwrapTypeRec<
-  TypeRef extends TypeNode,
-  Introspection extends IntrospectionLikeType,
-> = TypeRef extends { kind: 'NON_NULL' }
+type _unwrapTypeRec<TypeRef, Introspection extends IntrospectionLikeType> = TypeRef extends {
+  kind: 'NON_NULL';
+  ofType: any;
+}
   ? _unwrapTypeRec<TypeRef['ofType'], Introspection>
-  : TypeRef extends { kind: 'LIST' }
+  : TypeRef extends { kind: 'LIST'; ofType: any }
     ? Array<unwrapType<TypeRef['ofType'], Introspection>>
     : TypeRef extends { name: any }
       ? getScalarType<TypeRef['name'], Introspection>
       : unknown;
 
-type unwrapType<Type extends TypeNode, Introspection extends IntrospectionLikeType> = Type extends {
+type unwrapType<Type, Introspection extends IntrospectionLikeType> = Type extends {
   kind: 'NON_NULL';
+  ofType: any;
 }
   ? _unwrapTypeRec<Type['ofType'], Introspection>
   : null | _unwrapTypeRec<Type, Introspection>;
 
-type _nwrapTypeRefRec<
-  Type extends TypeNode,
-  Introspection extends IntrospectionLikeType,
-> = Type extends { kind: Kind.NON_NULL_TYPE }
-  ? _nwrapTypeRefRec<Type['type'], Introspection>
-  : Type extends { kind: Kind.LIST_TYPE }
+type _unwrapTypeRefRec<Type, Introspection extends IntrospectionLikeType> = Type extends {
+  kind: Kind.NON_NULL_TYPE;
+  type: any;
+}
+  ? _unwrapTypeRefRec<Type['type'], Introspection>
+  : Type extends { kind: Kind.LIST_TYPE; type: any }
     ? Array<unwrapTypeRef<Type['type'], Introspection>>
     : Type extends { kind: Kind.NAMED_TYPE; name: any }
       ? getScalarType<Type['name']['value'], Introspection>
       : unknown;
 
-type unwrapTypeRef<
-  Type extends TypeNode,
-  Introspection extends IntrospectionLikeType,
-> = Type extends { kind: Kind.NON_NULL_TYPE }
-  ? _nwrapTypeRefRec<Type['type'], Introspection>
-  : null | _nwrapTypeRefRec<Type, Introspection>;
+type unwrapTypeRef<Type, Introspection extends IntrospectionLikeType> = Type extends {
+  kind: Kind.NON_NULL_TYPE;
+  type: any;
+}
+  ? _unwrapTypeRefRec<Type['type'], Introspection>
+  : null | _unwrapTypeRefRec<Type, Introspection>;
 
-type getVariablesRec<
-  Variables extends readonly unknown[],
-  Introspection extends IntrospectionLikeType,
-> = Variables extends [infer Variable, ...infer Rest]
+type getVariablesRec<Variables, Introspection extends IntrospectionLikeType> = Variables extends [
+  infer Variable,
+  ...infer Rest,
+]
   ? (Variable extends { kind: Kind.VARIABLE_DEFINITION; variable: any; type: any }
       ? Variable extends { defaultValue: undefined; type: { kind: Kind.NON_NULL_TYPE } }
         ? {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -19,16 +19,10 @@ type getScalarType<
   TypeName,
   Introspection extends IntrospectionLikeType,
 > = TypeName extends keyof Introspection['types']
-  ? Introspection['types'][TypeName] extends {
-      kind: 'SCALAR' | 'ENUM';
-      type: infer IntrospectionValueType;
-    }
-    ? IntrospectionValueType
-    : Introspection['types'][TypeName] extends {
-          kind: 'INPUT_OBJECT';
-          inputFields: [...infer InputFields];
-        }
-      ? obj<getInputObjectTypeRec<InputFields, Introspection>>
+  ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+    ? Introspection['types'][TypeName]['type']
+    : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
+      ? obj<getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>>
       : never
   : unknown;
 


### PR DESCRIPTION
## Summary

This improves the selection and variables’s type inference/derivation performance by eliminating unused generic constraints, unused infers, and unnecessary nested type checks.

## Set of changes

- Remove unused generics
- Remove unused `infer`s from variables types
- Unwrap `isOptionalRec` (renamed to `isOptional`) and `getTypeDirective`
