### PR TITLE
fix: Skip parser outputting empty arrays for directives/arguments

### DIFF
--- a/.changeset/rude-dryers-cheat.md
+++ b/.changeset/rude-dryers-cheat.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Update parser to skip outputting empty arrays for directives and arguments.

--- a/src/__tests__/fixtures/kitchensinkQuery.ts
+++ b/src/__tests__/fixtures/kitchensinkQuery.ts
@@ -132,7 +132,7 @@ export type kitchensinkDocument = {
             kind: Kind.NAME;
             value: 'onQuery';
           };
-          arguments: [];
+          arguments: undefined;
         },
       ];
       selectionSet: {
@@ -180,7 +180,7 @@ export type kitchensinkDocument = {
                     kind: Kind.NAME;
                     value: 'id';
                   };
-                  arguments: [];
+                  arguments: undefined;
                   directives: undefined;
                   alias: undefined;
                   selectionSet: undefined;
@@ -201,7 +201,7 @@ export type kitchensinkDocument = {
                         kind: Kind.NAME;
                         value: 'onInlineFragment';
                       };
-                      arguments: [];
+                      arguments: undefined;
                     },
                   ];
                   selectionSet: {
@@ -214,7 +214,7 @@ export type kitchensinkDocument = {
                           value: 'field2';
                         };
                         alias: undefined;
-                        arguments: [];
+                        arguments: undefined;
                         directives: undefined;
                         selectionSet: {
                           kind: Kind.SELECTION_SET;
@@ -225,7 +225,7 @@ export type kitchensinkDocument = {
                                 kind: Kind.NAME;
                                 value: 'id';
                               };
-                              arguments: [];
+                              arguments: undefined;
                               directives: undefined;
                               alias: undefined;
                               selectionSet: undefined;
@@ -301,7 +301,7 @@ export type kitchensinkDocument = {
                                       kind: Kind.NAME;
                                       value: 'id';
                                     };
-                                    arguments: [];
+                                    arguments: undefined;
                                     directives: undefined;
                                     alias: undefined;
                                     selectionSet: undefined;
@@ -319,7 +319,7 @@ export type kitchensinkDocument = {
                                           kind: Kind.NAME;
                                           value: 'onFragmentSpread';
                                         };
-                                        arguments: [];
+                                        arguments: undefined;
                                       },
                                     ];
                                   },
@@ -369,7 +369,7 @@ export type kitchensinkDocument = {
                           kind: Kind.NAME;
                           value: 'id';
                         };
-                        arguments: [];
+                        arguments: undefined;
                         directives: undefined;
                         alias: undefined;
                         selectionSet: undefined;
@@ -390,7 +390,7 @@ export type kitchensinkDocument = {
                           kind: Kind.NAME;
                           value: 'id';
                         };
-                        arguments: [];
+                        arguments: undefined;
                         directives: undefined;
                         alias: undefined;
                         selectionSet: undefined;
@@ -419,7 +419,7 @@ export type kitchensinkDocument = {
             kind: Kind.NAME;
             value: 'onMutation';
           };
-          arguments: [];
+          arguments: undefined;
         },
       ];
       selectionSet: {
@@ -452,7 +452,7 @@ export type kitchensinkDocument = {
                   kind: Kind.NAME;
                   value: 'onField';
                 };
-                arguments: [];
+                arguments: undefined;
               },
             ];
             selectionSet: {
@@ -465,7 +465,7 @@ export type kitchensinkDocument = {
                     value: 'story';
                   };
                   alias: undefined;
-                  arguments: [];
+                  arguments: undefined;
                   directives: undefined;
                   selectionSet: {
                     kind: Kind.SELECTION_SET;
@@ -476,7 +476,7 @@ export type kitchensinkDocument = {
                           kind: Kind.NAME;
                           value: 'id';
                         };
-                        arguments: [];
+                        arguments: undefined;
                         directives: [
                           {
                             kind: Kind.DIRECTIVE;
@@ -484,7 +484,7 @@ export type kitchensinkDocument = {
                               kind: Kind.NAME;
                               value: 'onField';
                             };
-                            arguments: [];
+                            arguments: undefined;
                           },
                         ];
                         alias: undefined;
@@ -534,7 +534,7 @@ export type kitchensinkDocument = {
             kind: Kind.NAME;
             value: 'onSubscription';
           };
-          arguments: [];
+          arguments: undefined;
         },
       ];
       selectionSet: {
@@ -574,7 +574,7 @@ export type kitchensinkDocument = {
                     value: 'story';
                   };
                   alias: undefined;
-                  arguments: [];
+                  arguments: undefined;
                   directives: undefined;
                   selectionSet: {
                     kind: Kind.SELECTION_SET;
@@ -586,7 +586,7 @@ export type kitchensinkDocument = {
                           value: 'likers';
                         };
                         alias: undefined;
-                        arguments: [];
+                        arguments: undefined;
                         directives: undefined;
                         selectionSet: {
                           kind: Kind.SELECTION_SET;
@@ -599,7 +599,7 @@ export type kitchensinkDocument = {
                               };
                               alias: undefined;
                               selectionSet: undefined;
-                              arguments: [];
+                              arguments: undefined;
                               directives: undefined;
                             },
                           ];
@@ -612,7 +612,7 @@ export type kitchensinkDocument = {
                           value: 'likeSentence';
                         };
                         alias: undefined;
-                        arguments: [];
+                        arguments: undefined;
                         directives: undefined;
                         selectionSet: {
                           kind: Kind.SELECTION_SET;
@@ -625,7 +625,7 @@ export type kitchensinkDocument = {
                               };
                               alias: undefined;
                               selectionSet: undefined;
-                              arguments: [];
+                              arguments: undefined;
                               directives: undefined;
                             },
                           ];
@@ -660,7 +660,7 @@ export type kitchensinkDocument = {
             kind: Kind.NAME;
             value: 'onFragmentDefinition';
           };
-          arguments: [];
+          arguments: undefined;
         },
       ];
       selectionSet: {
@@ -806,7 +806,7 @@ export type kitchensinkDocument = {
             };
             alias: undefined;
             selectionSet: undefined;
-            arguments: [];
+            arguments: undefined;
             directives: undefined;
           },
         ];
@@ -832,7 +832,7 @@ export type kitchensinkDocument = {
             };
             alias: undefined;
             selectionSet: undefined;
-            arguments: [];
+            arguments: undefined;
             directives: undefined;
           },
         ];

--- a/src/__tests__/fixtures/kitchensinkQuery.ts
+++ b/src/__tests__/fixtures/kitchensinkQuery.ts
@@ -100,7 +100,7 @@ export type kitchensinkDocument = {
             };
           };
           defaultValue: undefined;
-          directives: [];
+          directives: undefined;
         },
         {
           kind: Kind.VARIABLE_DEFINITION;
@@ -122,7 +122,7 @@ export type kitchensinkDocument = {
             kind: Kind.ENUM;
             value: 'MOBILE';
           };
-          directives: [];
+          directives: undefined;
         },
       ];
       directives: [
@@ -170,7 +170,7 @@ export type kitchensinkDocument = {
                 };
               },
             ];
-            directives: [];
+            directives: undefined;
             selectionSet: {
               kind: Kind.SELECTION_SET;
               selections: [
@@ -181,7 +181,7 @@ export type kitchensinkDocument = {
                     value: 'id';
                   };
                   arguments: [];
-                  directives: [];
+                  directives: undefined;
                   alias: undefined;
                   selectionSet: undefined;
                 },
@@ -215,7 +215,7 @@ export type kitchensinkDocument = {
                         };
                         alias: undefined;
                         arguments: [];
-                        directives: [];
+                        directives: undefined;
                         selectionSet: {
                           kind: Kind.SELECTION_SET;
                           selections: [
@@ -226,7 +226,7 @@ export type kitchensinkDocument = {
                                 value: 'id';
                               };
                               arguments: [];
-                              directives: [];
+                              directives: undefined;
                               alias: undefined;
                               selectionSet: undefined;
                             },
@@ -302,7 +302,7 @@ export type kitchensinkDocument = {
                                       value: 'id';
                                     };
                                     arguments: [];
-                                    directives: [];
+                                    directives: undefined;
                                     alias: undefined;
                                     selectionSet: undefined;
                                   },
@@ -370,7 +370,7 @@ export type kitchensinkDocument = {
                           value: 'id';
                         };
                         arguments: [];
-                        directives: [];
+                        directives: undefined;
                         alias: undefined;
                         selectionSet: undefined;
                       },
@@ -380,7 +380,7 @@ export type kitchensinkDocument = {
                 {
                   kind: Kind.INLINE_FRAGMENT;
                   typeCondition: undefined;
-                  directives: [];
+                  directives: undefined;
                   selectionSet: {
                     kind: Kind.SELECTION_SET;
                     selections: [
@@ -391,7 +391,7 @@ export type kitchensinkDocument = {
                           value: 'id';
                         };
                         arguments: [];
-                        directives: [];
+                        directives: undefined;
                         alias: undefined;
                         selectionSet: undefined;
                       },
@@ -466,7 +466,7 @@ export type kitchensinkDocument = {
                   };
                   alias: undefined;
                   arguments: [];
-                  directives: [];
+                  directives: undefined;
                   selectionSet: {
                     kind: Kind.SELECTION_SET;
                     selections: [
@@ -523,7 +523,7 @@ export type kitchensinkDocument = {
               value: 'StoryLikeSubscribeInput';
             };
           };
-          directives: [];
+          directives: undefined;
           defaultValue: undefined;
         },
       ];
@@ -563,7 +563,7 @@ export type kitchensinkDocument = {
                 };
               },
             ];
-            directives: [];
+            directives: undefined;
             selectionSet: {
               kind: Kind.SELECTION_SET;
               selections: [
@@ -575,7 +575,7 @@ export type kitchensinkDocument = {
                   };
                   alias: undefined;
                   arguments: [];
-                  directives: [];
+                  directives: undefined;
                   selectionSet: {
                     kind: Kind.SELECTION_SET;
                     selections: [
@@ -587,7 +587,7 @@ export type kitchensinkDocument = {
                         };
                         alias: undefined;
                         arguments: [];
-                        directives: [];
+                        directives: undefined;
                         selectionSet: {
                           kind: Kind.SELECTION_SET;
                           selections: [
@@ -600,7 +600,7 @@ export type kitchensinkDocument = {
                               alias: undefined;
                               selectionSet: undefined;
                               arguments: [];
-                              directives: [];
+                              directives: undefined;
                             },
                           ];
                         };
@@ -613,7 +613,7 @@ export type kitchensinkDocument = {
                         };
                         alias: undefined;
                         arguments: [];
-                        directives: [];
+                        directives: undefined;
                         selectionSet: {
                           kind: Kind.SELECTION_SET;
                           selections: [
@@ -626,7 +626,7 @@ export type kitchensinkDocument = {
                               alias: undefined;
                               selectionSet: undefined;
                               arguments: [];
-                              directives: [];
+                              directives: undefined;
                             },
                           ];
                         };
@@ -737,7 +737,7 @@ export type kitchensinkDocument = {
                 };
               },
             ];
-            directives: [];
+            directives: undefined;
           },
         ];
       };
@@ -750,7 +750,7 @@ export type kitchensinkDocument = {
         value: 'teeny';
       };
       variableDefinitions: [];
-      directives: [];
+      directives: undefined;
       selectionSet: {
         kind: Kind.SELECTION_SET;
         selections: [
@@ -796,7 +796,7 @@ export type kitchensinkDocument = {
                 };
               },
             ];
-            directives: [];
+            directives: undefined;
           },
           {
             kind: Kind.FIELD;
@@ -807,7 +807,7 @@ export type kitchensinkDocument = {
             alias: undefined;
             selectionSet: undefined;
             arguments: [];
-            directives: [];
+            directives: undefined;
           },
         ];
       };
@@ -820,7 +820,7 @@ export type kitchensinkDocument = {
         value: 'tiny';
       };
       variableDefinitions: [];
-      directives: [];
+      directives: undefined;
       selectionSet: {
         kind: Kind.SELECTION_SET;
         selections: [
@@ -833,7 +833,7 @@ export type kitchensinkDocument = {
             alias: undefined;
             selectionSet: undefined;
             arguments: [];
-            directives: [];
+            directives: undefined;
           },
         ];
       };

--- a/src/__tests__/parser.test-d.ts
+++ b/src/__tests__/parser.test-d.ts
@@ -200,7 +200,7 @@ describe('takeVarDefinitions', () => {
               kind: Kind.NAME;
               value: 'bar';
             };
-            arguments: [];
+            arguments: undefined;
           },
         ];
       },
@@ -253,7 +253,7 @@ describe('takeOperationDefinition', () => {
                 kind: Kind.NAME;
                 value: 'mutationField';
               };
-              arguments: [];
+              arguments: undefined;
               alias: undefined;
               selectionSet: undefined;
               directives: undefined;
@@ -287,7 +287,7 @@ describe('takeOperationDefinition', () => {
                 kind: Kind.NAME;
                 value: 'mutationField';
               };
-              arguments: [];
+              arguments: undefined;
               alias: undefined;
               selectionSet: undefined;
               directives: undefined;
@@ -328,7 +328,7 @@ describe('takeOperationDefinition', () => {
                 kind: Kind.NAME;
                 value: 'field';
               };
-              arguments: [];
+              arguments: undefined;
               alias: undefined;
               selectionSet: undefined;
               directives: undefined;
@@ -354,7 +354,7 @@ describe('takeField', () => {
     type expected = [
       {
         kind: Kind.FIELD;
-        arguments: [];
+        arguments: undefined;
         alias: {
           kind: Kind.NAME;
           value: 'alias';
@@ -393,7 +393,7 @@ describe('takeField', () => {
                 kind: Kind.NAME;
                 value: 'child';
               };
-              arguments: [];
+              arguments: undefined;
               alias: undefined;
               selectionSet: undefined;
               directives: undefined;
@@ -510,7 +510,7 @@ describe('takeFragmentSpread', () => {
                 kind: Kind.NAME;
                 value: 'field';
               };
-              arguments: [];
+              arguments: undefined;
               alias: undefined;
               selectionSet: undefined;
               directives: undefined;
@@ -541,7 +541,7 @@ describe('takeFragmentSpread', () => {
                 kind: Kind.NAME;
                 value: 'field';
               };
-              arguments: [];
+              arguments: undefined;
               alias: undefined;
               selectionSet: undefined;
               directives: undefined;

--- a/src/__tests__/parser.test-d.ts
+++ b/src/__tests__/parser.test-d.ts
@@ -82,7 +82,7 @@ describe('takeVarDefinitions', () => {
             };
           };
           defaultValue: undefined;
-          directives: [];
+          directives: undefined;
         },
       ],
       '',
@@ -111,7 +111,7 @@ describe('takeVarDefinitions', () => {
             };
           };
           defaultValue: undefined;
-          directives: [];
+          directives: undefined;
         },
         {
           kind: Kind.VARIABLE_DEFINITION;
@@ -130,7 +130,7 @@ describe('takeVarDefinitions', () => {
             };
           };
           defaultValue: undefined;
-          directives: [];
+          directives: undefined;
         },
       ],
       '',
@@ -162,7 +162,7 @@ describe('takeVarDefinitions', () => {
           value: string;
           block: false;
         };
-        directives: [];
+        directives: undefined;
       },
       '',
     ];
@@ -219,7 +219,7 @@ describe('takeSelectionSet', () => {
         selections: [
           {
             kind: Kind.FRAGMENT_SPREAD;
-            directives: [];
+            directives: undefined;
             name: {
               kind: Kind.NAME;
               value: 'On';
@@ -243,7 +243,7 @@ describe('takeOperationDefinition', () => {
         operation: OperationTypeNode.MUTATION;
         name: undefined;
         variableDefinitions: [];
-        directives: [];
+        directives: undefined;
         selectionSet: {
           kind: Kind.SELECTION_SET;
           selections: [
@@ -256,7 +256,7 @@ describe('takeOperationDefinition', () => {
               arguments: [];
               alias: undefined;
               selectionSet: undefined;
-              directives: [];
+              directives: undefined;
             },
           ];
         };
@@ -277,7 +277,7 @@ describe('takeOperationDefinition', () => {
           value: 'Foo';
         };
         variableDefinitions: [];
-        directives: [];
+        directives: undefined;
         selectionSet: {
           kind: Kind.SELECTION_SET;
           selections: [
@@ -290,7 +290,7 @@ describe('takeOperationDefinition', () => {
               arguments: [];
               alias: undefined;
               selectionSet: undefined;
-              directives: [];
+              directives: undefined;
             },
           ];
         };
@@ -318,7 +318,7 @@ describe('takeOperationDefinition', () => {
             value: 'Type';
           };
         };
-        directives: [];
+        directives: undefined;
         selectionSet: {
           kind: Kind.SELECTION_SET;
           selections: [
@@ -331,7 +331,7 @@ describe('takeOperationDefinition', () => {
               arguments: [];
               alias: undefined;
               selectionSet: undefined;
-              directives: [];
+              directives: undefined;
             },
           ];
         };
@@ -396,7 +396,7 @@ describe('takeField', () => {
               arguments: [];
               alias: undefined;
               selectionSet: undefined;
-              directives: [];
+              directives: undefined;
             },
           ];
         };
@@ -441,7 +441,7 @@ describe('takeField', () => {
             };
           },
         ];
-        directives: [];
+        directives: undefined;
         selectionSet: undefined;
       },
       '',
@@ -500,7 +500,7 @@ describe('takeFragmentSpread', () => {
             value: 'Test';
           };
         };
-        directives: [];
+        directives: undefined;
         selectionSet: {
           kind: Kind.SELECTION_SET;
           selections: [
@@ -513,7 +513,7 @@ describe('takeFragmentSpread', () => {
               arguments: [];
               alias: undefined;
               selectionSet: undefined;
-              directives: [];
+              directives: undefined;
             },
           ];
         };
@@ -531,7 +531,7 @@ describe('takeFragmentSpread', () => {
       {
         kind: Kind.INLINE_FRAGMENT;
         typeCondition: undefined;
-        directives: [];
+        directives: undefined;
         selectionSet: {
           kind: Kind.SELECTION_SET;
           selections: [
@@ -544,7 +544,7 @@ describe('takeFragmentSpread', () => {
               arguments: [];
               alias: undefined;
               selectionSet: undefined;
-              directives: [];
+              directives: undefined;
             },
           ];
         };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -170,11 +170,14 @@ export type takeDirective<In, Const> = In extends `${'@'}${infer In}`
     : void
   : void;
 
-export type takeDirectives<In, Const> = takeDirective<In, Const> extends [infer Directive, infer In]
-  ? takeDirectives<skipIgnored<In>, Const> extends [[...infer Directives], infer In]
-    ? [[Directive, ...Directives], In]
-    : [[], In]
-  : [[], In];
+type takeDirectivesRec<Directives extends any[], In, Const> = takeDirective<In, Const> extends [
+  infer Directive,
+  infer In,
+]
+  ? takeDirectivesRec<[...Directives, Directive], skipIgnored<In>, Const>
+  : Directives extends []
+    ? [undefined, In]
+    : [Directives, In];
 
 type takeFieldName<In> = takeName<In> extends [infer MaybeAlias, infer In]
   ? skipIgnored<In> extends `${':'}${infer In}`
@@ -186,7 +189,7 @@ type takeFieldName<In> = takeName<In> extends [infer MaybeAlias, infer In]
 
 export type takeField<In> = takeFieldName<In> extends [infer Alias, infer Name, infer In]
   ? takeArguments<skipIgnored<In>, false> extends [infer Arguments, infer In]
-    ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
+    ? takeDirectivesRec<[], skipIgnored<In>, false> extends [infer Directives, infer In]
       ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
         ? [
             {
@@ -237,7 +240,7 @@ type takeTypeCondition<In> = In extends `${'on'}${infer In}`
 export type takeFragmentSpread<In> = In extends `${'...'}${infer In}`
   ? skipIgnored<In> extends `${'on'}${infer In}`
     ? takeName<skipIgnored<In>> extends [infer Name, infer In]
-      ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
+      ? takeDirectivesRec<[], skipIgnored<In>, false> extends [infer Directives, infer In]
         ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
           ? [
               {
@@ -252,10 +255,10 @@ export type takeFragmentSpread<In> = In extends `${'...'}${infer In}`
         : void
       : void
     : takeName<skipIgnored<In>> extends [infer Name, infer In]
-      ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
+      ? takeDirectivesRec<[], skipIgnored<In>, false> extends [infer Directives, infer In]
         ? [{ kind: Kind.FRAGMENT_SPREAD; name: Name; directives: Directives }, In]
         : void
-      : takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
+      : takeDirectivesRec<[], skipIgnored<In>, false> extends [infer Directives, infer In]
         ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
           ? [
               {
@@ -287,7 +290,7 @@ export type takeVarDefinition<In> = TakeVariable<In, false> extends [infer Varia
     ? takeType<skipIgnored<In>> extends [infer Type, infer In]
       ? skipIgnored<In> extends `${'='}${infer In}`
         ? takeValue<skipIgnored<In>, true> extends [infer DefaultValue, infer In]
-          ? takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
+          ? takeDirectivesRec<[], skipIgnored<In>, true> extends [infer Directives, infer In]
             ? [
                 {
                   kind: Kind.VARIABLE_DEFINITION;
@@ -300,7 +303,7 @@ export type takeVarDefinition<In> = TakeVariable<In, false> extends [infer Varia
               ]
             : void
           : void
-        : takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
+        : takeDirectivesRec<[], skipIgnored<In>, true> extends [infer Directives, infer In]
           ? [
               {
                 kind: Kind.VARIABLE_DEFINITION;
@@ -328,7 +331,7 @@ export type takeVarDefinitions<In> = skipIgnored<In> extends `${'('}${infer In}`
 export type takeFragmentDefinition<In> = In extends `${'fragment'}${infer In}`
   ? takeName<skipIgnored<In>> extends [infer Name, infer In]
     ? takeTypeCondition<skipIgnored<In>> extends [infer TypeCondition, infer In]
-      ? takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
+      ? takeDirectivesRec<[], skipIgnored<In>, true> extends [infer Directives, infer In]
         ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
           ? [
               {
@@ -357,7 +360,7 @@ type TakeOperation<In> = In extends `${'query'}${infer In}`
 export type takeOperationDefinition<In> = TakeOperation<In> extends [infer Operation, infer In]
   ? takeOptionalName<skipIgnored<In>> extends [infer Name, infer In]
     ? takeVarDefinitions<skipIgnored<In>> extends [infer VarDefinitions, infer In]
-      ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
+      ? takeDirectivesRec<[], skipIgnored<In>, false> extends [infer Directives, infer In]
         ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
           ? [
               {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -160,7 +160,7 @@ type _takeArgumentsRec<Arguments extends any[], In, Const> = In extends `${')'}$
     : void;
 export type takeArguments<In, Const> = In extends `${'('}${infer In}`
   ? _takeArgumentsRec<[], skipIgnored<In>, Const>
-  : [[], In];
+  : [undefined, In];
 
 export type takeDirective<In, Const> = In extends `${'@'}${infer In}`
   ? takeName<In> extends [infer Name, infer In]


### PR DESCRIPTION
## Summary

This simply updates `directives: []` and `arguments: []` to become `directives: undefined` and `arguments: undefined` for empty matches.

In either case, these are legal outputs for the GraphQL AST types, and they may simplify some matches that are going on in our selection types.

## Set of changes

- Output `directives: undefined` when directives are not present
- Output `arguments: undefined` when arguments are not present
