### PR TITLE
feat: Tighten types to not accept operations where fragments are expected

### DIFF
--- a/.changeset/grumpy-dancers-jam.md
+++ b/.changeset/grumpy-dancers-jam.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Tighten up type strictness to not accept operation documents where fragment documents are expected.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -130,6 +130,19 @@ describe('mirrorFragmentTypeRec', () => {
 });
 
 describe('readFragment', () => {
+  it('should not accept a non-fragment document', () => {
+    type query = parseDocument<`
+      query Test {
+        __typename
+      }
+    `>;
+
+    type document = getDocumentNode<query, schema>;
+    // @ts-expect-error
+    const result = readFragment({} as document, {} as FragmentOf<document>);
+    expectTypeOf<typeof result>().toBeNever();
+  });
+
   it('should not unmask empty objects', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,6 @@ import type {
 } from './introspection';
 
 import type {
-  DocumentDefDecorationLike,
   getFragmentsOfDocumentsRec,
   makeDefinitionDecoration,
   decorateFragmentDef,
@@ -116,7 +115,7 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType> {
    */
   <
     const In extends stringLiteral<In>,
-    const Fragments extends readonly [...DocumentDefDecorationLike[]],
+    const Fragments extends readonly [...makeDefinitionDecoration[]],
   >(
     input: In,
     fragments?: Fragments
@@ -224,7 +223,7 @@ export type getDocumentNode<
 interface TadaDocumentNode<
   Result = { [key: string]: any },
   Variables = { [key: string]: any },
-  Decoration = never,
+  Decoration = void,
 > extends DocumentNode,
     DocumentDecoration<Result, Variables>,
     makeDefinitionDecoration<Decoration> {}
@@ -278,7 +277,7 @@ type VariablesOf<Document> = Document extends DocumentDecoration<any, infer Vari
  *
  * @see {@link readFragment} for how to read from fragment masks.
  */
-type FragmentOf<Document extends DocumentDefDecorationLike> = makeFragmentRef<Document>;
+type FragmentOf<Document extends makeDefinitionDecoration> = makeFragmentRef<Document>;
 
 export type mirrorFragmentTypeRec<Fragment, Data> = Fragment extends (infer Value)[]
   ? mirrorFragmentTypeRec<Value, Data>[]
@@ -290,7 +289,7 @@ export type mirrorFragmentTypeRec<Fragment, Data> = Fragment extends (infer Valu
         ? undefined
         : Data;
 
-type fragmentOfTypeRec<Document extends DocumentDefDecorationLike> =
+type fragmentOfTypeRec<Document extends makeDefinitionDecoration> =
   | readonly fragmentOfTypeRec<Document>[]
   | FragmentOf<Document>
   | undefined
@@ -345,7 +344,7 @@ type fragmentOfTypeRec<Document extends DocumentDefDecorationLike> =
  * @see {@link readFragment} for how to read from fragment masks.
  */
 function readFragment<
-  const Document extends DocumentDefDecorationLike & DocumentDecoration<any, any>,
+  const Document extends makeDefinitionDecoration & DocumentDecoration<any, any>,
   const Fragment extends fragmentOfTypeRec<Document>,
 >(
   _document: Document,

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -27,10 +27,6 @@ interface FragmentDefDecorationLike {
   masked: any;
 }
 
-interface DocumentDefDecorationLike {
-  [$tada.definition]?: FragmentDefDecorationLike;
-}
-
 type isMaskedRec<Directives extends readonly unknown[] | undefined> = Directives extends readonly [
   infer Directive,
   ...infer Rest,
@@ -51,7 +47,7 @@ type decorateFragmentDef<Document extends DocumentNodeLike> = Document['definiti
       on: Document['definitions'][0]['typeCondition']['name']['value'];
       masked: isMaskedRec<Document['definitions'][0]['directives']>;
     }
-  : never;
+  : void;
 
 type getFragmentsOfDocumentsRec<Documents> = Documents extends readonly [
   infer Document,
@@ -106,10 +102,8 @@ type makeUndefinedFragmentRef<FragmentName extends string> = {
   };
 };
 
-type makeDefinitionDecoration<Definition> = {
-  [$tada.definition]?: Definition extends DocumentDefDecorationLike[$tada.definition]
-    ? Definition
-    : never;
+type makeDefinitionDecoration<Definition = FragmentDefDecorationLike> = {
+  [Key in $tada.definition]?: Definition;
 };
 
 export type {
@@ -120,5 +114,4 @@ export type {
   makeFragmentRef,
   makeUndefinedFragmentRef,
   FragmentDefDecorationLike,
-  DocumentDefDecorationLike,
 };


### PR DESCRIPTION
## Summary

Currently we allow any documents where fragment definition documents are expected specifically,
- `FragmentOf<typeof fragment>` must only accept fragments
- `readFragment(fragment, data)` must only accept fragments

Instead, `[$tada.definition]?: never` was basically allowing any documents, which is why it's being replaced in this PR with `[$tada.definition]?: void` for operation documents

## Set of changes

- Replace `DocumentDefDecorationLike` to clean up duplicate type
- Default decorations to `void` rather than `never`
