### PR TITLE
feat: Add `unsafe_readResult()` and `maskFragments()` utilities

### DIFF
--- a/.changeset/dry-seals-laugh.md
+++ b/.changeset/dry-seals-laugh.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Add `maskFragments` to cast data to fragment masks of a given set of fragments.

--- a/.changeset/witty-moose-kiss.md
+++ b/.changeset/witty-moose-kiss.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Add `unsafe_readResult` to unsafely cast data to the result data of a given document.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -5,7 +5,9 @@ import type { simpleIntrospection } from './fixtures/simpleIntrospection';
 
 import type { parseDocument } from '../parser';
 import type { $tada } from '../namespace';
-import { readFragment, initGraphQLTada } from '../api';
+import type { obj } from '../utils';
+
+import { readFragment, maskFragments, initGraphQLTada } from '../api';
 
 import type {
   ResultOf,
@@ -223,6 +225,77 @@ describe('readFragment', () => {
 
     type document = getDocumentNode<fragment, schema>;
     const result = readFragment({} as document, {} as FragmentOf<document>);
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
+  });
+});
+
+describe('maskFragments', () => {
+  it('should not mask empty objects', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    // @ts-expect-error
+    const result = maskFragments([{} as document], {});
+    expectTypeOf<typeof result>().toBeNever();
+  });
+
+  it('masks fragments', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = maskFragments([{} as document], { id: 'id' });
+    expectTypeOf<typeof result>().toEqualTypeOf<FragmentOf<document>>();
+  });
+
+  it('masks arrays of fragment data', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = maskFragments([{} as document], [{ id: 'id' }]);
+    expectTypeOf<typeof result>().toEqualTypeOf<readonly FragmentOf<document>[]>();
+  });
+
+  it('masks multiple fragments', () => {
+    type fragmentA = parseDocument<`
+      fragment FieldsA on Todo {
+        a: id
+      }
+    `>;
+
+    type fragmentB = parseDocument<`
+      fragment FieldsB on Todo {
+        b: id
+      }
+    `>;
+
+    type documentA = getDocumentNode<fragmentA, schema>;
+    type documentB = getDocumentNode<fragmentB, schema>;
+    const result = maskFragments([{} as documentA, {} as documentB], { a: 'id', b: 'id' });
+    type expected = obj<FragmentOf<documentA> & FragmentOf<documentB>>;
+    expectTypeOf<typeof result>().toEqualTypeOf<expected>();
+  });
+
+  it('should behave correctly on unmasked fragments', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo @_unmask {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = maskFragments([{} as document], { id: 'id' });
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -12,6 +12,7 @@ import type {
   getFragmentsOfDocumentsRec,
   makeDefinitionDecoration,
   decorateFragmentDef,
+  omitFragmentRefsRec,
   makeFragmentRef,
 } from './namespace';
 
@@ -410,9 +411,56 @@ function maskFragments<
   return data as any;
 }
 
+/** For testing, converts document data without fragment refs to their result type.
+ *
+ * @param _document - A GraphQL document, created using {@link graphql}.
+ * @param data - The result data of the GraphQL document with optional fragment refs.
+ * @returns The masked result data of the document.
+ *
+ * @remarks
+ * When creating test data, you may define data for documents that’s unmasked, but
+ * need to cast the data to match the result type of your document.
+ *
+ * This means that you may have to use {@link unsafe_readResult} to cast
+ * them to the result type, instead of doing `as any as ResultOf<typeof document>`.
+ *
+ * This function is inherently unsafe, since it doesn't check that your document
+ * actually contains the masked fragment data!
+ *
+ * @example
+ * ```
+ * import { FragmentOf, ResultOf, graphql, unsafe_readResult } from 'gql.tada';
+ *
+ * const bookFragment = graphql(`
+ *   fragment BookComponent on Book {
+ *     id
+ *     title
+ *   }
+ * `);
+ *
+ * const query = graphql(`
+ *   query {
+ *     book {
+ *       ...BookComponent
+ *     }
+ *   }
+ * `, [bookFragment]);
+ *
+ * const data = unsafe_readResult(query, { book: { id: 'id', title: 'book' } });
+ * ```
+ *
+ * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
+ */
+function unsafe_readResult<
+  const Document extends DocumentDecoration<any, any>,
+  const Data extends omitFragmentRefsRec<ResultOf<Document>>,
+>(_document: Document, data: Data): ResultOf<Document> {
+  return data as any;
+}
+
 const graphql: GraphQLTadaAPI<schemaOfConfig<setupSchema>> = initGraphQLTada();
 
-export { parse, graphql, readFragment, maskFragments, initGraphQLTada };
+export { parse, graphql, readFragment, maskFragments, unsafe_readResult, initGraphQLTada };
 
 export type {
   setupSchema,

--- a/src/api.ts
+++ b/src/api.ts
@@ -369,6 +369,35 @@ function readFragment<
   return fragment as any;
 }
 
+/** For testing, masks fragment data for given data and fragments.
+ *
+ * @param _fragments - A list of GraphQL documents of fragments, created using {@link graphql}.
+ * @param data - The combined result data of the fragments, which can be wrapped in arrays.
+ * @returns The masked data of the fragments.
+ *
+ * @remarks
+ * When creating test data, you may define data for fragments that’s unmasked, making it
+ * unusable in parent fragments or queries that require masked data.
+ *
+ * This means that you may have to use {@link maskFragments} to mask your data first
+ * for TypeScript to not report an error.
+ *
+ * @example
+ * ```
+ * import { FragmentOf, ResultOf, graphql, maskFragments } from 'gql.tada';
+ *
+ * const bookFragment = graphql(`
+ *   fragment BookComponent on Book {
+ *     id
+ *     title
+ *   }
+ * `);
+ *
+ * const data = maskFragments([bookFragment], { id: 'id', title: 'book' });
+ * ```
+ *
+ * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
+ */
 function maskFragments<
   const Fragments extends readonly [...makeDefinitionDecoration[]],
   const Data extends resultOfTypeRec<resultOfFragmentsRec<Fragments>>,

--- a/src/api.ts
+++ b/src/api.ts
@@ -306,7 +306,9 @@ type resultOfFragmentsRec<Fragments extends readonly any[]> = Fragments extends 
 
 type fragmentOfTypeRec<Document extends makeDefinitionDecoration> =
   | readonly fragmentOfTypeRec<Document>[]
-  | FragmentOf<Document>;
+  | FragmentOf<Document>
+  | undefined
+  | null;
 
 type resultOfTypeRec<Data> = readonly resultOfTypeRec<Data>[] | Data | undefined | null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { parse, graphql, readFragment, initGraphQLTada } from './api';
+export { parse, graphql, readFragment, maskFragments, initGraphQLTada } from './api';
 
 export type {
   setupSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-export { parse, graphql, readFragment, maskFragments, initGraphQLTada } from './api';
+export {
+  parse,
+  graphql,
+  readFragment,
+  maskFragments,
+  unsafe_readResult,
+  initGraphQLTada,
+} from './api';
 
 export type {
   setupSchema,

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -96,6 +96,18 @@ type makeFragmentRef<Document> = Document extends { [$tada.definition]?: infer D
     : never
   : never;
 
+type omitFragmentRefsRec<Data> = Data extends readonly (infer Value)[]
+  ? readonly omitFragmentRefsRec<Value>[]
+  : Data extends null
+    ? null
+    : Data extends undefined
+      ? undefined
+      : Data extends {}
+        ? {
+            [Key in Exclude<keyof Data, $tada.fragmentRefs>]: omitFragmentRefsRec<Data[Key]>;
+          }
+        : Data;
+
 type makeUndefinedFragmentRef<FragmentName extends string> = {
   [$tada.fragmentRefs]: {
     [Name in FragmentName]: 'Undefined Fragment';
@@ -110,6 +122,7 @@ export type {
   $tada,
   decorateFragmentDef,
   getFragmentsOfDocumentsRec,
+  omitFragmentRefsRec,
   makeDefinitionDecoration,
   makeFragmentRef,
   makeUndefinedFragmentRef,

--- a/website/src/content/docs/reference/gql-tada-api.mdx
+++ b/website/src/content/docs/reference/gql-tada-api.mdx
@@ -144,6 +144,61 @@ const bookFragment = graphql(`
 const data = maskFragments([bookFragment], { id: 'id', title: 'book' });
 ```
 
+### `unsafe_readResult()`
+
+| | Description |
+| ----------- | ----------- |
+| `_document` argument | A GraphQL document, created using [`graphql()`](#graphql). |
+| `data` argument | The result data of the GraphQL document with optional fragment refs. |
+| returns | The masked result data of the document. | 
+
+:::caution
+Unlike, [`maskFragments()`](#maskfragments), this utility is unsafe, and
+should only be used when you know that data matches the expected shape
+of a GraphQL query you created.
+
+While useful, this utility is only a slightly safer alternative to `as any`
+and doesn’t type check the result shape against the masked fragments in your
+document.
+
+You shouldn’t have to use it in your regular app code.
+:::
+
+When [`graphql()`](#graphql) is used to compose fragments into a document,
+the resulting type will by default be masked, [unless the `@_unmask`
+directive is used.](../../guides/fragment-colocation/#fragment-masking)
+
+This means that when we’re writing tests and are creating “fake data”,
+for instance for a query, that we cannot convert this data to the query’s
+result type, if it contains masked fragment refs.
+
+To address this, the `unsafe_readResult` utility accepts the document and
+converts a query’s data to masked data.
+
+#### Example
+
+```ts
+import { graphql, unsafe_readResult } from 'gql.tada';
+
+const bookFragment = graphql(`
+  fragment BookComponent on Book {
+    id
+    title
+  }
+`);
+
+const query = graphql(`
+  query {
+    book {
+      ...BookComponent
+    }
+  }
+`, [bookFragment]);
+
+// `data` will be cast (unsafely!) to the result type of `query`.
+const data = unsafe_readResult(query, { book: { id: 'id', title: 'book' } });
+```
+
 ### `initGraphQLTada()`
 
 | | Description |

--- a/website/src/content/docs/reference/gql-tada-api.mdx
+++ b/website/src/content/docs/reference/gql-tada-api.mdx
@@ -98,6 +98,52 @@ const getQuery = (data: ResultOf<typeof bookQuery>) => {
 };
 ```
 
+### `maskFragments()`
+
+| | Description |
+| ----------- | ----------- |
+| `_fragments` argument | A list of GraphQL documents of fragments, created using [`graphql()`](#graphql). |
+| `data` argument | The combined result data of the fragments, which can be wrapped in arrays. |
+| returns | The masked data of the fragments. | 
+
+:::note
+While useful, `maskFragments()` is mostly meant to be used in tests or as
+an escape hatch to convert data to masked fragments.
+
+You shouldn’t have to use it in your regular component code.
+:::
+
+When [`graphql()`](#graphql) is used to compose fragments into another fragment or
+operation, the resulting type will by default be masked, [unless the `@_unmask`
+directive is used.](../../guides/fragment-colocation/#fragment-masking)
+
+This means that when we’re writing tests or are creating “fake data” without
+inferring types from a full document, the types in TypeScript may not match,
+since our testing data will not be masked and will be equal to [the result type](#resultof)
+of the fragments.
+
+To address this, the `maskFragments` utility takes a list of fragments and masks data (or an array of data)
+to match the masked fragment types of the fragments.
+
+- [Read more about fragment masking on the “Writing GraphQL” page.](../../get-started/writing-graphql/#fragment-masking)
+- [For the reverse operation, see `readFragment()`.](#readfragment)
+
+#### Example
+
+```ts
+import { graphql, maskFragments } from 'gql.tada';
+
+const bookFragment = graphql(`
+  fragment BookComponent on Book {
+    id
+    title
+  }
+`);
+
+// `data` will be typed as the fragment mask of `bookFragment`.
+const data = maskFragments([bookFragment], { id: 'id', title: 'book' });
+```
+
 ### `initGraphQLTada()`
 
 | | Description |


### PR DESCRIPTION
Resolve #38

## Summary

This PR, when applied, adds two new utilities, as documented in the website changes.

- `maskFragments` accepts a list of fragments and the combined data (or a list of such) matching the fragments’ result type, and returns the combined fragment masks of the fragments.
- `unsafe_readResult` accepts a document and its result type (without fragment refs) and **unsafely** casts it to the result type (as an alternative to `as any as ResultType<typeof document>`

The former operation is safe but cumbersome when creating test data.
The latter is unsafe, but safer than an `as any` cast.

## Set of changes

- Add `maskFragments`
- Add `unsafe_readResult`
