### PR TITLE
Increase tail-recursive conditional types from 50 to 1000 for variables

### DIFF
--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -425,4 +425,583 @@ export type simpleSchema = {
       };
     };
   };
+
+  typesList: [
+    {
+      kind: 'INPUT_OBJECT';
+      name: 'TodoPayload';
+      fields: null;
+      inputFields: [
+        {
+          name: 'title';
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: null;
+        },
+        {
+          name: 'complete';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+          defaultValue: null;
+        },
+      ];
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'OBJECT';
+      name: 'Query';
+      fields: [
+        {
+          name: 'todos';
+          args: [];
+          type: {
+            kind: 'LIST';
+            name: null;
+            ofType: {
+              kind: 'OBJECT';
+              name: 'Todo';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'test';
+          args: [];
+          type: {
+            kind: 'UNION';
+            name: 'Search';
+            ofType: null;
+          };
+        },
+        {
+          name: 'latestTodo';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'UNION';
+              name: 'LatestTodoResult';
+              ofType: null;
+            };
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      name: 'LatestTodoResult';
+      kind: 'UNION';
+      args: [];
+      possibleTypes: [
+        {
+          kind: 'OBJECT';
+          name: 'Todo';
+          ofType: null;
+        },
+        {
+          kind: 'OBJECT';
+          name: 'NoTodosError';
+          ofType: null;
+        },
+      ];
+    },
+    {
+      kind: 'OBJECT';
+      name: 'NoTodosError';
+      interfaces: [];
+      fields: [
+        {
+          name: 'message';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+      ];
+    },
+    {
+      kind: 'OBJECT';
+      name: 'Todo';
+      fields: [
+        {
+          name: 'id';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'text';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'complete';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        },
+        {
+          name: 'test';
+          args: [];
+          type: {
+            kind: 'ENUM';
+            name: 'test';
+            ofType: null;
+          };
+        },
+        {
+          name: 'author';
+          args: [];
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'SCALAR';
+      name: 'ID';
+      fields: null;
+      inputFields: null;
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'SCALAR';
+      name: 'String';
+      fields: null;
+      inputFields: null;
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'SCALAR';
+      name: 'Boolean';
+      fields: null;
+      inputFields: null;
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'OBJECT';
+      name: 'Author';
+      fields: [
+        {
+          name: 'id';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'name';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'known';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'OBJECT';
+      name: 'Mutation';
+      fields: [
+        {
+          name: 'updateTodo';
+          args: [
+            {
+              name: 'id';
+              type: {
+                kind: 'NON_NULL';
+                name: null;
+                ofType: {
+                  kind: 'SCALAR';
+                  name: 'ID';
+                  ofType: null;
+                };
+              };
+              defaultValue: null;
+            },
+            {
+              name: 'input';
+              type: {
+                kind: 'NON_NULL';
+                name: null;
+                ofType: {
+                  kind: 'INPUT_OBJECT';
+                  name: 'TodoPayload';
+                  ofType: null;
+                };
+              };
+              defaultValue: null;
+            },
+          ];
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        },
+        {
+          name: 'toggleTodo';
+          args: [
+            {
+              name: 'id';
+              type: {
+                kind: 'NON_NULL';
+                name: null;
+                ofType: {
+                  kind: 'SCALAR';
+                  name: 'ID';
+                  ofType: null;
+                };
+              };
+            },
+          ];
+          type: {
+            kind: 'OBJECT';
+            name: 'Todo';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'OBJECT';
+      name: 'Subscription';
+      fields: [
+        {
+          name: 'newTodo';
+          args: [];
+          type: {
+            kind: 'OBJECT';
+            name: 'Todo';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'ENUM';
+      name: 'test';
+      fields: null;
+      inputFields: null;
+      interfaces: null;
+      enumValues: [{ name: 'value' }, { name: 'more' }];
+    },
+    {
+      kind: 'INTERFACE';
+      name: 'ITodo';
+      fields: [
+        {
+          name: 'id';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'text';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'complete';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        },
+        {
+          name: 'author';
+          args: [];
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: [
+        {
+          kind: 'OBJECT';
+          name: 'BigTodo';
+          ofType: null;
+        },
+        {
+          kind: 'OBJECT';
+          name: 'SmallTodo';
+          ofType: null;
+        },
+      ];
+    },
+    {
+      kind: 'OBJECT';
+      name: 'BigTodo';
+      fields: [
+        {
+          name: 'id';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'text';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'complete';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        },
+        {
+          name: 'author';
+          args: [];
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        },
+        {
+          name: 'wallOfText';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'String';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [
+        {
+          kind: 'INTERFACE';
+          name: 'ITodo';
+          ofType: null;
+        },
+      ];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'OBJECT';
+      name: 'SmallTodo';
+      fields: [
+        {
+          name: 'id';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'text';
+          args: [];
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+        {
+          name: 'complete';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        },
+        {
+          name: 'author';
+          args: [];
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        },
+        {
+          name: 'maxLength';
+          args: [];
+          type: {
+            kind: 'SCALAR';
+            name: 'Int';
+            ofType: null;
+          };
+        },
+      ];
+      inputFields: null;
+      interfaces: [
+        {
+          kind: 'INTERFACE';
+          name: 'ITodo';
+          ofType: null;
+        },
+      ];
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'SCALAR';
+      name: 'Int';
+      fields: null;
+      inputFields: null;
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: null;
+    },
+    {
+      kind: 'UNION';
+      name: 'Search';
+      fields: null;
+      inputFields: null;
+      interfaces: null;
+      enumValues: null;
+      possibleTypes: [
+        {
+          kind: 'OBJECT';
+          name: 'SmallTodo';
+          ofType: null;
+        },
+        {
+          kind: 'OBJECT';
+          name: 'BigTodo';
+          ofType: null;
+        },
+      ];
+    },
+  ];
 };

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -221,11 +221,16 @@ type mapIntrospection<
     ? Query['__schema']['subscriptionType']['name']
     : never;
   types: mapIntrospectionTypes<Query, Scalars>;
+  introspection: Query;
+  typesList: Query['__schema']['types'];
 };
 
 type getScalarTypeNames<Schema extends IntrospectionLikeType> =
-  Schema['types'][keyof Schema['types']] extends infer Type
-    ? Type extends { kind: 'SCALAR' | 'ENUM'; name: any }
+  Schema['typesList'][number] extends infer Type
+    ? Type extends {
+        kind: 'ENUM' | 'SCALAR';
+        name: any;
+      }
       ? Type['name']
       : never
     : never;
@@ -248,6 +253,8 @@ export type IntrospectionLikeType = {
   mutation?: any;
   subscription?: any;
   types: { [name: string]: any };
+  introspection?: any;
+  typesList?: any;
 };
 
 export type { mapIntrospectionTypes, mapIntrospection, getScalarType, getScalarTypeNames };

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -6,7 +6,7 @@ import type { obj } from './utils';
 type _getInputObjectTypeRec<
   InputFields,
   Introspection extends IntrospectionLikeType,
-  ResultType,
+  IntersectionAccumulator,
 > = InputFields extends [infer InputField, ...infer Rest]
   ? _getInputObjectTypeRec<
       Rest,
@@ -25,9 +25,9 @@ type _getInputObjectTypeRec<
               [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection>;
             }
         : {}) &
-        ResultType
+        IntersectionAccumulator
     >
-  : ResultType;
+  : IntersectionAccumulator;
 
 type getInputObjectTypeRec<
   InputFields,


### PR DESCRIPTION
## Summary

Hello again! As we use gql.tada in our production code, there's an issue arises with variables causing `Type instantiation is excessively deep and possibly infinite`. This is because Hasura's GraphQL variables enable infinite conditions in relationship.

fix #47

## Set of changes

Increase tail-recursive conditional types from 50 to 1000 https://github.com/microsoft/TypeScript/pull/45711