### PR TITLE
fix: Add tail recursion where it's possible but missing

### DIFF
--- a/.changeset/short-teachers-begin.md
+++ b/.changeset/short-teachers-begin.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Improve performance of several smaller types (Thank you, [@deathemperor](https://github.com/deathemperor) & [@HaiNNT](https://github.com/HaiNNT))

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -134,45 +134,53 @@ type _getPossibleTypeSelectionRec<
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
+  SelectionAcc = {},
 > = Selections extends [infer Node, ...infer Rest]
-  ? (Node extends { kind: Kind.FRAGMENT_SPREAD | Kind.INLINE_FRAGMENT }
-      ? getSpreadSubtype<Node, Type, Introspection, Fragments> extends infer Subtype extends
-          ObjectLikeType
-        ? PossibleType extends getTypenameOfType<Subtype>
-          ?
-              | (isOptional<Node> extends true ? {} : never)
-              | getFragmentSelection<Node, Subtype, Introspection, Fragments>
-          : {}
-        : Node extends { kind: Kind.FRAGMENT_SPREAD; name: any }
-          ? makeUndefinedFragmentRef<Node['name']['value']>
-          : {}
-      : Node extends { kind: Kind.FIELD; name: any; selectionSet: any }
-        ? isOptional<Node> extends true
-          ? {
-              [Prop in getFieldAlias<Node>]?: Node['name']['value'] extends '__typename'
-                ? PossibleType
-                : unwrapType<
-                    Type['fields'][Node['name']['value']]['type'],
-                    Node['selectionSet'],
-                    Introspection,
-                    Fragments,
-                    getTypeDirective<Node>
-                  >;
-            }
-          : {
-              [Prop in getFieldAlias<Node>]: Node['name']['value'] extends '__typename'
-                ? PossibleType
-                : unwrapType<
-                    Type['fields'][Node['name']['value']]['type'],
-                    Node['selectionSet'],
-                    Introspection,
-                    Fragments,
-                    getTypeDirective<Node>
-                  >;
-            }
-        : {}) &
-      _getPossibleTypeSelectionRec<Rest, PossibleType, Type, Introspection, Fragments>
-  : {};
+  ? _getPossibleTypeSelectionRec<
+      Rest,
+      PossibleType,
+      Type,
+      Introspection,
+      Fragments,
+      (Node extends { kind: Kind.FRAGMENT_SPREAD | Kind.INLINE_FRAGMENT }
+        ? getSpreadSubtype<Node, Type, Introspection, Fragments> extends infer Subtype extends
+            ObjectLikeType
+          ? PossibleType extends getTypenameOfType<Subtype>
+            ?
+                | (isOptional<Node> extends true ? {} : never)
+                | getFragmentSelection<Node, Subtype, Introspection, Fragments>
+            : {}
+          : Node extends { kind: Kind.FRAGMENT_SPREAD; name: any }
+            ? makeUndefinedFragmentRef<Node['name']['value']>
+            : {}
+        : Node extends { kind: Kind.FIELD; name: any; selectionSet: any }
+          ? isOptional<Node> extends true
+            ? {
+                [Prop in getFieldAlias<Node>]?: Node['name']['value'] extends '__typename'
+                  ? PossibleType
+                  : unwrapType<
+                      Type['fields'][Node['name']['value']]['type'],
+                      Node['selectionSet'],
+                      Introspection,
+                      Fragments,
+                      getTypeDirective<Node>
+                    >;
+              }
+            : {
+                [Prop in getFieldAlias<Node>]: Node['name']['value'] extends '__typename'
+                  ? PossibleType
+                  : unwrapType<
+                      Type['fields'][Node['name']['value']]['type'],
+                      Node['selectionSet'],
+                      Introspection,
+                      Fragments,
+                      getTypeDirective<Node>
+                    >;
+              }
+          : {}) &
+        SelectionAcc
+    >
+  : SelectionAcc;
 
 type getOperationSelectionType<
   Definition,

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -6,14 +6,19 @@ import type { obj } from './utils';
 type getInputObjectTypeRec<
   InputFields,
   Introspection extends IntrospectionLikeType,
+  InputObject = {},
 > = InputFields extends [infer InputField, ...infer Rest]
-  ? (InputField extends { name: any; type: any }
-      ? InputField['type'] extends { kind: 'NON_NULL' }
-        ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
-        : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> }
-      : {}) &
-      getInputObjectTypeRec<Rest, Introspection>
-  : {};
+  ? getInputObjectTypeRec<
+      Rest,
+      Introspection,
+      (InputField extends { name: any; type: any }
+        ? InputField['type'] extends { kind: 'NON_NULL' }
+          ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
+          : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> }
+        : {}) &
+        InputObject
+    >
+  : InputObject;
 
 type getScalarType<
   TypeName,


### PR DESCRIPTION
See #46

## Summary

This is partially extracted from #46 and one other opportunity where tail recursion was missing. The changes have been carried over one-by-one and split up.

One change is missing (`UnionAcc`) since it doesn't trigger a tail recursion case in TypeScript, since it wasn't on a single type, i.e. non-mutually recursive type alias, but on several types, and hoisted too far. So, that change hasn't been carried over. The benchmarks also seem to confirm that that change isn't relevant for this PR.

(Note: In general, the benchmarks, when `selection` is run in isolation, give a good indicator of whether tail recursion is helping)

In some of these cases, tail recursion hasn't increased performance, but the opportunity to add them is good nonetheless.

## Set of changes

- Make `_getPossibleTypeSelectionRec` tail recursive
- Make `getInputObjectTypeRec` tail recursive
- Make `_getVariablesRec` tail recursive
