### PR TITLE
fix: Remove generic constraint on `graphql.scalar`’s type name to improve performance

### DIFF
--- a/.changeset/cuddly-kiwis-cheer.md
+++ b/.changeset/cuddly-kiwis-cheer.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Remove type name constraint from `graphql.scalar`’s type name to improve type checking performance.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -106,6 +106,14 @@ describe('graphql()', () => {
 describe('graphql.scalar()', () => {
   const graphql = initGraphQLTada<{ introspection: simpleIntrospection }>();
 
+  it('should reject invalid types', () => {
+    type actual = ReturnType<typeof graphql.scalar<'invalid'>>;
+    expectTypeOf<actual>().toEqualTypeOf<never>();
+
+    // @ts-expect-error
+    const actual = graphql.scalar('invalid', 123);
+  });
+
   it('should return the type of a given enum', () => {
     type actual = ReturnType<typeof graphql.scalar<'test'>>;
     type expected = 'value' | 'more';

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -18,6 +18,10 @@ describe('mapIntrospection', () => {
 });
 
 describe('getScalarType', () => {
+  it('resolves to never for invalid types', () => {
+    expectTypeOf<getScalarType<simpleSchema, 'invalid'>>().toEqualTypeOf<never>();
+  });
+
   it('gets the type of a scalar', () => {
     expectTypeOf<getScalarType<simpleSchema, 'String'>>().toEqualTypeOf<string>();
   });

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type { simpleIntrospection } from './fixtures/simpleIntrospection';
 import type { simpleSchema } from './fixtures/simpleSchema';
-import type { mapIntrospection, getScalarType, getScalarTypeNames } from '../introspection';
+import type { mapIntrospection, getScalarType } from '../introspection';
 
 describe('mapIntrospection', () => {
   it('prepares sample schema', () => {
@@ -24,12 +24,5 @@ describe('getScalarType', () => {
 
   it('gets the type of an enum', () => {
     expectTypeOf<getScalarType<simpleSchema, 'test'>>().toEqualTypeOf<'value' | 'more'>();
-  });
-});
-
-describe('getScalarTypeNames', () => {
-  it('gets the names of all scalars and enums', () => {
-    type actual = getScalarTypeNames<simpleSchema>;
-    expectTypeOf<actual>().toEqualTypeOf<'test' | 'ID' | 'String' | 'Boolean' | 'Int'>();
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -151,7 +151,7 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType> {
    */
   scalar<
     const Name extends stringLiteral<Name>,
-    const Value extends getScalarType<Schema, Name> | null | undefined,
+    const Value extends getScalarType<Schema, Name, null | undefined>,
   >(
     name: Name,
     value: Value
@@ -159,7 +159,7 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType> {
 
   scalar<const Name extends stringLiteral<Name>>(
     name: Name,
-    value: getScalarType<Schema, Name>
+    value?: getScalarType<Schema, Name>
   ): getScalarType<Schema, Name>;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,6 @@ import type {
   ScalarsLike,
   IntrospectionLikeType,
   mapIntrospection,
-  getScalarTypeNames,
   getScalarType,
 } from './introspection';
 
@@ -151,14 +150,14 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType> {
    * ```
    */
   scalar<
-    const Name extends getScalarTypeNames<Schema>,
+    const Name extends stringLiteral<Name>,
     const Value extends getScalarType<Schema, Name> | null | undefined,
   >(
     name: Name,
     value: Value
   ): Value;
 
-  scalar<const Name extends getScalarTypeNames<Schema>>(
+  scalar<const Name extends stringLiteral<Name>>(
     name: Name,
     value: getScalarType<Schema, Name>
   ): getScalarType<Schema, Name>;

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -226,10 +226,11 @@ type mapIntrospection<
 type getScalarType<
   Schema extends IntrospectionLikeType,
   Name extends string,
+  OrType = never,
 > = Schema['types'][Name] extends { kind: 'SCALAR'; type: infer Type }
-  ? Type
+  ? Type | OrType
   : Schema['types'][Name] extends { kind: 'ENUM'; type: infer Type }
-    ? Type
+    ? Type | OrType
     : never;
 
 export type ScalarsLike = {

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -223,16 +223,9 @@ type mapIntrospection<
   types: mapIntrospectionTypes<Query, Scalars>;
 };
 
-type getScalarTypeNames<Schema extends IntrospectionLikeType> =
-  Schema['types'][keyof Schema['types']] extends infer Type
-    ? Type extends { kind: 'SCALAR' | 'ENUM'; name: any }
-      ? Type['name']
-      : never
-    : never;
-
 type getScalarType<
   Schema extends IntrospectionLikeType,
-  Name extends keyof Schema['types'],
+  Name extends string,
 > = Schema['types'][Name] extends { kind: 'SCALAR'; type: infer Type }
   ? Type
   : Schema['types'][Name] extends { kind: 'ENUM'; type: infer Type }
@@ -250,4 +243,4 @@ export type IntrospectionLikeType = {
   types: { [name: string]: any };
 };
 
-export type { mapIntrospectionTypes, mapIntrospection, getScalarType, getScalarTypeNames };
+export type { mapIntrospectionTypes, mapIntrospection, getScalarType };


### PR DESCRIPTION
Resolves #47

## Summary

Retrieving a large `union` of type names and then potentially exposing the `tsserver` to it seems to cause a crash. Furthermore, evaluating the schema to retrieve all types, filter them by their kind, and then extracting the names seems to also cause issues.

I noticed that auto-complete in place of a generic isn't possible anyway, so we can save ourselves the effort. We can potentially readd it to the `graphql.scalar` argument itself, but it doesn't really seem worth it.

## Set of changes

- Remove `getScalarTypeNames`
- Remove type names constraint from `graphql.scalar`
