### PR TITLE
feat: Add `gql.tada/ts-plugin` alias

### DIFF
--- a/.changeset/big-ravens-drum.md
+++ b/.changeset/big-ravens-drum.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Add `gql.tada/ts-plugin` to the init and doctor command

--- a/.changeset/spotty-crabs-report.md
+++ b/.changeset/spotty-crabs-report.md
@@ -1,0 +1,6 @@
+---
+"gql.tada": minor
+"@gql.tada/internal": patch
+---
+
+Add `gql.tada/ts-plugin` alias for `@0no-co/graphqlsp`

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 /tsconfig.vitest-temp.json
 /cli
 /internal
+/ts-plugin

--- a/examples/example-pokemon-api/package.json
+++ b/examples/example-pokemon-api/package.json
@@ -13,7 +13,7 @@
     "urql": "^4.0.7"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.12.0",
+    "@0no-co/graphqlsp": "^1.12.9",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
     "@vitejs/plugin-react": "^4.2.1",

--- a/examples/example-pokemon-api/package.json
+++ b/examples/example-pokemon-api/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
     "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.2",
     "vite": "^5.2.10"
   }
 }

--- a/examples/example-pokemon-svelte/package.json
+++ b/examples/example-pokemon-svelte/package.json
@@ -12,7 +12,7 @@
     "svelte": "^4.0.5"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.12.0",
+    "@0no-co/graphqlsp": "^1.12.9",
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
     "typescript": "^5.5.2",
     "vite": "^5.2.10"

--- a/examples/example-pokemon-svelte/package.json
+++ b/examples/example-pokemon-svelte/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@0no-co/graphqlsp": "^1.12.0",
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.2",
     "vite": "^5.2.10"
   }
 }

--- a/examples/example-pokemon-vue/package.json
+++ b/examples/example-pokemon-vue/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@0no-co/graphqlsp": "^1.12.0",
     "@vitejs/plugin-vue": "^5.0.4",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.2",
     "vite": "^5.2.10",
     "vue-tsc": "^2.0.14"
   }

--- a/examples/example-pokemon-vue/package.json
+++ b/examples/example-pokemon-vue/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.4.25"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.12.0",
+    "@0no-co/graphqlsp": "^1.12.9",
     "@vitejs/plugin-vue": "^5.0.4",
     "typescript": "^5.5.2",
     "vite": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,12 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5",
-    "@0no-co/graphqlsp": "^1.10.3",
+    "@0no-co/graphqlsp": "^1.12.8",
     "@gql.tada/cli-utils": "workspace:*",
     "@gql.tada/internal": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
   },
   "public": true,
   "keywords": [
@@ -101,7 +104,8 @@
       "gql.tada": "workspace:*",
       "@gql.tada/internal": "workspace:*",
       "astro-expressive-code": "^0.31.0",
-      "typescript": "^5.3.3"
+      "typescript": "^5.3.3",
+      "@0no-co/graphqlsp": "^1.12.8"
     }
   },
   "devDependencies": {
@@ -136,9 +140,6 @@
     "terser": "^5.26.0",
     "typescript": "^5.3.3",
     "vitest": "1.1.3"
-  },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "LICENSE.md",
     "README.md",
     "cli/",
+    "ts-plugin/",
     "bin/",
     "dist/"
   ],
@@ -38,10 +39,17 @@
       "require": "./dist/gql-tada-internal.js",
       "source": "./src/internal/index.ts"
     },
+    "./ts-plugin": {
+      "types": "./dist/gql-tada-ts-plugin.d.ts",
+      "import": "./dist/gql-tada-ts-plugin.mjs",
+      "require": "./dist/gql-tada-ts-plugin.js",
+      "source": "./src/ts-plugin/index.ts"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5",
+    "@0no-co/graphqlsp": "^1.10.3",
     "@gql.tada/cli-utils": "workspace:*",
     "@gql.tada/internal": "workspace:*"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5",
-    "@0no-co/graphqlsp": "^1.12.8",
+    "@0no-co/graphqlsp": "^1.12.9",
     "@gql.tada/cli-utils": "workspace:*",
     "@gql.tada/internal": "workspace:*"
   },
@@ -105,7 +105,7 @@
       "@gql.tada/internal": "workspace:*",
       "astro-expressive-code": "^0.31.0",
       "typescript": "^5.5.2",
-      "@0no-co/graphqlsp": "^1.12.8"
+      "@0no-co/graphqlsp": "^1.12.9"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
       "gql.tada": "workspace:*",
       "@gql.tada/internal": "workspace:*",
       "astro-expressive-code": "^0.31.0",
-      "typescript": "^5.3.3",
+      "typescript": "^5.5.2",
       "@0no-co/graphqlsp": "^1.12.8"
     }
   },
@@ -138,7 +138,7 @@
     "rollup-plugin-cjs-check": "^1.0.3",
     "rollup-plugin-dts": "^6.1.0",
     "terser": "^5.26.0",
-    "typescript": "^5.3.3",
+    "typescript": "^5.5.2",
     "vitest": "1.1.3"
   },
   "publishConfig": {

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -64,6 +64,7 @@
     "svelte2tsx": "^0.7.6"
   },
   "peerDependencies": {
+    "@0no-co/graphqlsp": "^1.12.8",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "typescript": "^5.0.0"
   },

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -56,7 +56,7 @@
     "wonka": "^6.3.4"
   },
   "dependencies": {
-    "@0no-co/graphqlsp": "^1.12.8",
+    "@0no-co/graphqlsp": "^1.12.9",
     "@gql.tada/internal": "workspace:*",
     "@vue/compiler-dom": "^3.4.23",
     "@vue/language-core": "^2.0.17",
@@ -64,7 +64,7 @@
     "svelte2tsx": "^0.7.6"
   },
   "peerDependencies": {
-    "@0no-co/graphqlsp": "^1.12.8",
+    "@0no-co/graphqlsp": "^1.12.9",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "typescript": "^5.0.0"
   },

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -51,7 +51,7 @@
     "semiver": "^1.1.0",
     "typanion": "^3.14.0",
     "type-fest": "^4.10.2",
-    "typescript": "^5.3.3",
+    "typescript": "^5.5.2",
     "vscode-languageserver-textdocument": "^1.0.11",
     "wonka": "^6.3.4"
   },

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import semiver from 'semiver';
 
 import type { GraphQLSPConfig, LoadConfigResult } from '@gql.tada/internal';
 import { loadRef, loadConfig, parseConfig } from '@gql.tada/internal';
 
 import type { ComposeInput } from '../../term';
+import { MINIMUM_VERSIONS, semverComply } from '../../utils/semver';
 import { findGraphQLConfig } from './helpers/graphqlConfig';
 import * as vscode from './helpers/vscode';
 import * as logger from './logger';
@@ -22,11 +22,6 @@ const delay = (ms = 700) => {
   }
 };
 
-export const semiverComply = (version: string, compare: string) => {
-  const match = version.match(/\d+\.\d+\.\d+/);
-  return match ? semiver(match[0], compare) >= 0 : false;
-};
-
 const enum Messages {
   TITLE = 'Doctor',
   DESCRIPTION = 'Detects problems with your setup',
@@ -36,13 +31,6 @@ const enum Messages {
   CHECK_VSCODE = 'Checking VSCode setup',
   CHECK_SCHEMA = 'Checking schema',
 }
-
-export const MINIMUM_VERSIONS = {
-  typescript_embed_lsp: '5.5.0',
-  typescript: '4.1.0',
-  tada: '1.0.0',
-  lsp: '1.0.0',
-};
 
 export async function* run(): AsyncIterable<ComposeInput> {
   yield logger.title(Messages.TITLE, Messages.DESCRIPTION);
@@ -80,7 +68,7 @@ export async function* run(): AsyncIterable<ComposeInput> {
       `A version of ${logger.code('typescript')} was not found in your dependencies.\n` +
         logger.hint(`Is ${logger.code('typescript')} installed in this package?`)
     );
-  } else if (!semiverComply(typeScriptVersion[1], MINIMUM_VERSIONS.typescript)) {
+  } else if (!semverComply(typeScriptVersion[1], MINIMUM_VERSIONS.typescript)) {
     // TypeScript version lower than v4.1 which is when they introduced template lits
     yield logger.failedTask(Messages.CHECK_TS_VERSION);
     throw logger.errorMessage(
@@ -95,7 +83,7 @@ export async function* run(): AsyncIterable<ComposeInput> {
   yield logger.runningTask(Messages.CHECK_DEPENDENCIES);
   await delay();
 
-  const supportsEmbeddedLsp = semiverComply(
+  const supportsEmbeddedLsp = semverComply(
     typeScriptVersion[1],
     MINIMUM_VERSIONS.typescript_embed_lsp
   );
@@ -107,7 +95,7 @@ export async function* run(): AsyncIterable<ComposeInput> {
         `A version of ${logger.code('@0no-co/graphqlsp')} was not found in your dependencies.\n` +
           logger.hint(`Is ${logger.code('@0no-co/graphqlsp')} installed?`)
       );
-    } else if (!semiverComply(gqlspVersion[1], MINIMUM_VERSIONS.lsp)) {
+    } else if (!semverComply(gqlspVersion[1], MINIMUM_VERSIONS.lsp)) {
       yield logger.failedTask(Messages.CHECK_DEPENDENCIES);
       throw logger.errorMessage(
         `The version of ${logger.code(
@@ -127,7 +115,7 @@ export async function* run(): AsyncIterable<ComposeInput> {
       `A version of ${logger.code('gql.tada')} was not found in your dependencies.\n` +
         logger.hint(`Is ${logger.code('gql.tada')} installed?`)
     );
-  } else if (!semiverComply(gqlTadaVersion[1], '1.0.0')) {
+  } else if (!semverComply(gqlTadaVersion[1], '1.0.0')) {
     yield logger.failedTask(Messages.CHECK_DEPENDENCIES);
     throw logger.errorMessage(
       `The version of ${logger.code('gql.tada')} in your dependencies is out of date.\n` +

--- a/packages/cli-utils/src/commands/init/runner.ts
+++ b/packages/cli-utils/src/commands/init/runner.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { execa } from 'execa';
 
 import { readTSConfigFile } from '@gql.tada/internal';
+import { MINIMUM_VERSIONS, semiverComply } from '../doctor/runner';
 
 const s = spinner();
 
@@ -90,24 +91,51 @@ export async function run(target: string) {
     process.exit(0);
   }
 
+  let supportsEmbeddedLsp = false;
+  let packageJson: {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+  };
+
+  try {
+    const packageJsonPath = path.resolve(target, 'package.json');
+    const packageJsonContents = await fs.readFile(packageJsonPath, 'utf-8');
+    packageJson = JSON.parse(packageJsonContents);
+    const deps = Object.entries({
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    });
+
+    const typeScriptVersion = deps.find((x) => x[0] === 'typescript');
+    if (typeScriptVersion && typeof typeScriptVersion[1] === 'string') {
+      supportsEmbeddedLsp = semiverComply(
+        typeScriptVersion[1],
+        MINIMUM_VERSIONS.typescript_embed_lsp
+      );
+    }
+  } catch (e) {}
+
   if (shouldInstallDependencies) {
     s.start('Installing packages.');
-    await installPackages(getPkgManager(), target);
+    await installPackages(getPkgManager(), target, !supportsEmbeddedLsp);
     s.stop('Installed packages.');
   } else {
     s.start('Writing to package.json.');
     try {
       const packageJsonPath = path.resolve(target, 'package.json');
       const packageJsonContents = await fs.readFile(packageJsonPath, 'utf-8');
-      const packageJson = JSON.parse(packageJsonContents);
+      packageJson = JSON.parse(packageJsonContents);
+
       if (!packageJson.dependencies) packageJson.dependencies = {};
       if (!packageJson.dependencies['gql.tada']) {
         packageJson.dependencies['gql.tada'] = TADA_VERSION;
       }
 
-      if (!packageJson.devDependencies) packageJson.devDependencies = {};
-      if (!packageJson.devDependencies['@0no-co/graphqlsp']) {
-        packageJson.devDependencies['@0no-co/graphqlsp'] = LSP_VERSION;
+      if (!supportsEmbeddedLsp) {
+        if (!packageJson.devDependencies) packageJson.devDependencies = {};
+        if (!packageJson.devDependencies['@0no-co/graphqlsp']) {
+          packageJson.devDependencies['@0no-co/graphqlsp'] = LSP_VERSION;
+        }
       }
 
       await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
@@ -129,7 +157,7 @@ export async function run(target: string) {
       ...tsConfig.compilerOptions,
       plugins: [
         {
-          name: '@0no-co/graphqlsp',
+          name: supportsEmbeddedLsp ? 'gql.tada/ts-plugin' : '@0no-co/graphqlsp',
           schema: isFile ? path.relative(target, schemaLocation) : schemaLocation,
           tadaOutputLocation: path.relative(target, tadaLocation),
         } as any,
@@ -143,20 +171,27 @@ export async function run(target: string) {
 }
 
 type PackageManager = 'yarn' | 'pnpm' | 'npm';
-async function installPackages(packageManager: PackageManager, target: string) {
-  await execa(
-    packageManager,
-    [
-      // `yarn add` will fail if nothing is provided
-      packageManager === 'yarn' ? 'add' : 'install',
-      '-D',
-      '@0no-co/graphqlsp',
-    ],
-    {
-      stdio: 'ignore',
-      cwd: target,
-    }
-  );
+async function installPackages(
+  packageManager: PackageManager,
+  target: string,
+  shouldInstallGraphQLSP
+) {
+  if (shouldInstallGraphQLSP) {
+    await execa(
+      packageManager,
+      [
+        // `yarn add` will fail if nothing is provided
+        packageManager === 'yarn' ? 'add' : 'install',
+        '-D',
+        '@0no-co/graphqlsp',
+      ],
+      {
+        stdio: 'ignore',
+        cwd: target,
+      }
+    );
+  }
+
   await execa(packageManager, [packageManager === 'yarn' ? 'add' : 'install', 'gql.tada'], {
     stdio: 'ignore',
     cwd: target,

--- a/packages/cli-utils/src/commands/init/runner.ts
+++ b/packages/cli-utils/src/commands/init/runner.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execa } from 'execa';
 
+import { MINIMUM_VERSIONS, semverComply } from '../../utils/semver';
 import { readTSConfigFile } from '@gql.tada/internal';
-import { MINIMUM_VERSIONS, semiverComply } from '../doctor/runner';
 
 const s = spinner();
 
@@ -108,7 +108,7 @@ export async function run(target: string) {
 
     const typeScriptVersion = deps.find((x) => x[0] === 'typescript');
     if (typeScriptVersion && typeof typeScriptVersion[1] === 'string') {
-      supportsEmbeddedLsp = semiverComply(
+      supportsEmbeddedLsp = semverComply(
         typeScriptVersion[1],
         MINIMUM_VERSIONS.typescript_embed_lsp
       );

--- a/packages/cli-utils/src/utils/semver.ts
+++ b/packages/cli-utils/src/utils/semver.ts
@@ -1,0 +1,13 @@
+import semiver from 'semiver';
+
+export const MINIMUM_VERSIONS = {
+  typescript_embed_lsp: '5.5.0',
+  typescript: '4.1.0',
+  tada: '1.0.0',
+  lsp: '1.0.0',
+};
+
+export const semverComply = (version: string, compare: string) => {
+  const match = version.match(/\d+\.\d+\.\d+/);
+  return match ? semiver(match[0], compare) >= 0 : false;
+};

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -48,7 +48,7 @@
     "rollup": "^4.9.4",
     "sade": "^1.8.1",
     "type-fest": "^4.10.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5"

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -62,7 +62,10 @@ const getPluginConfig = (tsconfig: TsConfigJson | null): Record<string, unknown>
     tsconfig.compilerOptions &&
     tsconfig.compilerOptions.plugins &&
     tsconfig.compilerOptions.plugins.find(
-      (x) => x.name === '@0no-co/graphqlsp' || x.name === 'gql.tada/lsp'
+      (x) =>
+        x.name === '@0no-co/graphqlsp' ||
+        x.name === 'gql.tada/lsp' ||
+        x.name === 'gql.tada/ts-plugin'
     )) ||
   null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
   typescript: ^5.5.2
-  '@0no-co/graphqlsp': ^1.12.8
+  '@0no-co/graphqlsp': ^1.12.9
 
 importers:
 
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.7(graphql@16.8.1)
       '@0no-co/graphqlsp':
-        specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
+        specifier: ^1.12.9
+        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@gql.tada/cli-utils':
         specifier: workspace:*
         version: link:packages/cli-utils
@@ -141,8 +141,8 @@ importers:
         version: 4.0.7(graphql@16.8.1)(react@18.3.1)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
+        specifier: ^1.12.9
+        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.1
@@ -175,8 +175,8 @@ importers:
         version: 4.2.15
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
+        specifier: ^1.12.9
+        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
         version: 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))
@@ -206,8 +206,8 @@ importers:
         version: 3.4.25(typescript@5.5.2)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
+        specifier: ^1.12.9
+        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.5.2))
@@ -224,8 +224,8 @@ importers:
   packages/cli-utils:
     dependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
+        specifier: ^1.12.9
+        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@gql.tada/internal':
         specifier: workspace:*
         version: link:../internal
@@ -378,8 +378,8 @@ packages:
       graphql:
         optional: true
 
-  '@0no-co/graphqlsp@1.12.8':
-    resolution: {integrity: sha512-arW3ZzifyKIJhehoAlsP069AX73EN6q358bOCf+8z00PmfPR2DSxq7uGGSj0oFNe3vEDtGYl88HmFEWQ+0+dwQ==}
+  '@0no-co/graphqlsp@1.12.9':
+    resolution: {integrity: sha512-eb9KIzw23svuLmjXQ3QF1pxrn5E16O+KJF5h8suEH6ZRetjMB8Bda2rMWhadpzp0f52+T1zpbLd2Q58GTFNPiQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.5.2
@@ -3879,7 +3879,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.8.1
 
-  '@0no-co/graphqlsp@1.12.8(graphql@16.8.1)(typescript@5.5.2)':
+  '@0no-co/graphqlsp@1.12.9(graphql@16.8.1)(typescript@5.5.2)':
     dependencies:
       '@gql.tada/internal': link:packages/internal
       graphql: 16.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   gql.tada: workspace:*
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
-  typescript: ^5.3.3
+  typescript: ^5.5.2
   '@0no-co/graphqlsp': ^1.12.8
 
 importers:
@@ -20,7 +20,7 @@ importers:
         version: 1.0.7(graphql@16.8.1)
       '@0no-co/graphqlsp':
         specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
+        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
       '@gql.tada/cli-utils':
         specifier: workspace:*
         version: link:packages/cli-utils
@@ -66,10 +66,10 @@ importers:
         version: 20.11.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.18.1
-        version: 6.18.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
+        version: 6.18.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^6.18.1
-        version: 6.18.1(eslint@8.56.0)(typescript@5.4.5)
+        version: 6.18.1(eslint@8.56.0)(typescript@5.5.2)
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -111,13 +111,13 @@ importers:
         version: 1.0.3(rollup@4.16.4)
       rollup-plugin-dts:
         specifier: ^6.1.0
-        version: 6.1.0(rollup@4.16.4)(typescript@5.4.5)
+        version: 6.1.0(rollup@4.16.4)(typescript@5.5.2)
       terser:
         specifier: ^5.26.0
         version: 5.26.0
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.2
+        version: 5.5.2
       vitest:
         specifier: 1.1.3
         version: 1.1.3(@types/node@20.11.0)(terser@5.26.0)
@@ -142,7 +142,7 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
+        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.1
@@ -153,8 +153,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.2
+        version: 5.5.2
       vite:
         specifier: ^5.2.10
         version: 5.2.10(@types/node@20.12.12)(terser@5.31.0)
@@ -176,13 +176,13 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
+        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
         version: 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.2
+        version: 5.5.2
       vite:
         specifier: ^5.2.10
         version: 5.2.10(@types/node@20.12.12)(terser@5.31.0)
@@ -194,7 +194,7 @@ importers:
         version: 5.0.2(graphql@16.8.1)
       '@urql/vue':
         specifier: ^1.1.3
-        version: 1.1.3(graphql@16.8.1)(vue@3.4.25(typescript@5.4.5))
+        version: 1.1.3(graphql@16.8.1)(vue@3.4.25(typescript@5.5.2))
       gql.tada:
         specifier: workspace:*
         version: link:../..
@@ -203,29 +203,29 @@ importers:
         version: 16.8.1
       vue:
         specifier: ^3.4.25
-        version: 3.4.25(typescript@5.4.5)
+        version: 3.4.25(typescript@5.5.2)
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
+        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.4.5))
+        version: 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.5.2))
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.2
+        version: 5.5.2
       vite:
         specifier: ^5.2.10
         version: 5.2.10(@types/node@20.12.12)(terser@5.31.0)
       vue-tsc:
         specifier: ^2.0.14
-        version: 2.0.14(typescript@5.4.5)
+        version: 2.0.14(typescript@5.5.2)
 
   packages/cli-utils:
     dependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.8
-        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
+        version: 1.12.8(graphql@16.8.1)(typescript@5.5.2)
       '@gql.tada/internal':
         specifier: workspace:*
         version: link:../internal
@@ -234,13 +234,13 @@ importers:
         version: 3.4.25
       '@vue/language-core':
         specifier: ^2.0.17
-        version: 2.0.17(typescript@5.4.5)
+        version: 2.0.17(typescript@5.5.2)
       graphql:
         specifier: ^15.5.0 || ^16.0.0 || ^17.0.0
         version: 16.8.1
       svelte2tsx:
         specifier: ^0.7.6
-        version: 0.7.6(svelte@4.2.17)(typescript@5.4.5)
+        version: 0.7.6(svelte@4.2.17)(typescript@5.5.2)
     devDependencies:
       '@clack/prompts':
         specifier: ^0.7.0
@@ -276,8 +276,8 @@ importers:
         specifier: ^4.10.2
         version: 4.10.2
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.2
+        version: 5.5.2
       vscode-languageserver-textdocument:
         specifier: ^1.0.11
         version: 1.0.11
@@ -313,8 +313,8 @@ importers:
         specifier: ^4.10.2
         version: 4.10.2
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.2
+        version: 5.5.2
 
   website:
     dependencies:
@@ -347,7 +347,7 @@ importers:
         version: 4.0.7(graphql@16.8.1)(react@18.3.1)
       vue:
         specifier: ^3.4.21
-        version: 3.4.25(typescript@5.4.5)
+        version: 3.4.25(typescript@5.5.2)
     devDependencies:
       '@shikijs/core':
         specifier: ^1.3.0
@@ -360,13 +360,13 @@ importers:
         version: 0.10.2
       shikiji-twoslash:
         specifier: ^0.10.2
-        version: 0.10.2(typescript@5.4.5)
+        version: 0.10.2(typescript@5.5.2)
       vitepress:
         specifier: 1.1.3
-        version: 1.1.3(@algolia/client-search@4.23.3)(@types/node@20.12.12)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5)
+        version: 1.1.3(@algolia/client-search@4.23.3)(@types/node@20.12.12)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.5.2)
       vitepress-plugin-twoslash:
         specifier: ^0.10.2
-        version: 0.10.2(typescript@5.4.5)
+        version: 0.10.2(typescript@5.5.2)
 
 packages:
 
@@ -382,7 +382,7 @@ packages:
     resolution: {integrity: sha512-arW3ZzifyKIJhehoAlsP069AX73EN6q358bOCf+8z00PmfPR2DSxq7uGGSj0oFNe3vEDtGYl88HmFEWQ+0+dwQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   '@0no-co/typescript.js@5.3.2-2':
     resolution: {integrity: sha512-IGQZZ7vcVD/GOUKLJckpQiq8F5raQZLR7kOVhxN5nHOywl1dB9EFMA7FJkyNoCEig7EkCb291X8FswMwwrz9yg==}
@@ -1449,7 +1449,7 @@ packages:
   '@vue/language-core@1.8.27':
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1457,7 +1457,7 @@ packages:
   '@vue/language-core@2.0.14':
     resolution: {integrity: sha512-3q8mHSNcGTR7sfp2X6jZdcb4yt8AjBXAfKk0qkZIh7GAJxOnoZ10h5HToZglw4ToFvAnq+xu/Z2FFbglh9Icag==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1465,7 +1465,7 @@ packages:
   '@vue/language-core@2.0.17':
     resolution: {integrity: sha512-tHw2J6G9yL4kn3jN5MftOHEq86Y6qnuohBQ1OHkJ73fAv3OYgwDI1cfX7ds0OEJEycOMG64BA3ql5bDgDa41zw==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3168,7 +3168,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   rollup@4.16.4:
     resolution: {integrity: sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==}
@@ -3424,7 +3424,7 @@ packages:
     resolution: {integrity: sha512-awHvYsakyiGjRqqSOhb2F+qJ6lUT9klQe0UQofAcdHNaKKeDHA8kEZ8zYKGG3BiDPurKYMGvH5/lZ+jeIoG7yQ==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   svelte@4.2.15:
     resolution: {integrity: sha512-j9KJSccHgLeRERPlhMKrCXpk2TqL2m5Z+k+OBTQhZOhIdCCd3WfqV+ylPWeipEwq17P/ekiSFWwrVQv93i3bsg==}
@@ -3499,7 +3499,7 @@ packages:
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   ts-invariant@0.10.3:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
@@ -3520,12 +3520,12 @@ packages:
   twoslash-vue@0.1.2:
     resolution: {integrity: sha512-LCD3VTw0+gKVMXou/nP8OAtpajGAoKuzFx9oyGteBkeMRgDj2DO95WDBHy/o+ihkckYZ0lUbvIFFjzmDy7zHag==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   twoslash@0.1.2:
     resolution: {integrity: sha512-q0jnapnD3b0umNGCJCRlo6Em1oSFl2OBPwsXqhLzijtEzuORrGVrJffG7E1k1KPHFlwBSRX2q6yYA61etn5hSg==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
@@ -3577,8 +3577,8 @@ packages:
   typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3751,12 +3751,12 @@ packages:
     resolution: {integrity: sha512-DgAO3U1cnCHOUO7yB35LENbkapeRsBZ7Ugq5hGz/QOHny0+1VQN8eSwSBjYbjLVPfvfw6EY7sNPjbuHHUhckcg==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
 
   vue@3.4.25:
     resolution: {integrity: sha512-HWyDqoBHMgav/OKiYA2ZQg+kjfMgLt/T0vg4cbIF7JbXAjDexRf5JRg+PWAfrAkSmTd2I8aPSXtooBFWHB98cg==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.5.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3879,11 +3879,11 @@ snapshots:
     optionalDependencies:
       graphql: 16.8.1
 
-  '@0no-co/graphqlsp@1.12.8(graphql@16.8.1)(typescript@5.4.5)':
+  '@0no-co/graphqlsp@1.12.8(graphql@16.8.1)(typescript@5.5.2)':
     dependencies:
       '@gql.tada/internal': link:packages/internal
       graphql: 16.8.1
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   '@0no-co/typescript.js@5.3.2-2': {}
 
@@ -4989,13 +4989,13 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@typescript-eslint/eslint-plugin@6.18.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@6.18.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.18.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.18.1(eslint@8.56.0)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 6.18.1
-      '@typescript-eslint/type-utils': 6.18.1(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.18.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 6.18.1(eslint@8.56.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 6.18.1(eslint@8.56.0)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 6.18.1
       debug: 4.3.4
       eslint: 8.56.0
@@ -5003,22 +5003,22 @@ snapshots:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.6.0
-      ts-api-utils: 1.0.3(typescript@5.4.5)
+      ts-api-utils: 1.0.3(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.18.1
       '@typescript-eslint/types': 6.18.1
-      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 6.18.1
       debug: 4.3.4
       eslint: 8.56.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5027,21 +5027,21 @@ snapshots:
       '@typescript-eslint/types': 6.18.1
       '@typescript-eslint/visitor-keys': 6.18.1
 
-  '@typescript-eslint/type-utils@6.18.1(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@6.18.1(eslint@8.56.0)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.18.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.5.2)
+      '@typescript-eslint/utils': 6.18.1(eslint@8.56.0)(typescript@5.5.2)
       debug: 4.3.4
       eslint: 8.56.0
-      ts-api-utils: 1.0.3(typescript@5.4.5)
+      ts-api-utils: 1.0.3(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@6.18.1': {}
 
-  '@typescript-eslint/typescript-estree@6.18.1(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@6.18.1(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 6.18.1
       '@typescript-eslint/visitor-keys': 6.18.1
@@ -5050,20 +5050,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.0
-      ts-api-utils: 1.0.3(typescript@5.4.5)
+      ts-api-utils: 1.0.3(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.18.1(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@6.18.1(eslint@8.56.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.18.1
       '@typescript-eslint/types': 6.18.1
-      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.5.2)
       eslint: 8.56.0
       semver: 7.6.0
     transitivePeerDependencies:
@@ -5112,10 +5112,10 @@ snapshots:
     transitivePeerDependencies:
       - graphql
 
-  '@urql/vue@1.1.3(graphql@16.8.1)(vue@3.4.25(typescript@5.4.5))':
+  '@urql/vue@1.1.3(graphql@16.8.1)(vue@3.4.25(typescript@5.5.2))':
     dependencies:
       '@urql/core': 5.0.2(graphql@16.8.1)
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
       wonka: 6.3.4
     transitivePeerDependencies:
       - graphql
@@ -5131,10 +5131,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.5.2))':
     dependencies:
       vite: 5.2.10(@types/node@20.12.12)(terser@5.31.0)
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
 
   '@vitest/expect@1.1.3':
     dependencies:
@@ -5228,26 +5228,26 @@ snapshots:
       '@vue/compiler-dom': 3.4.25
       '@vue/shared': 3.4.25
 
-  '@vue/devtools-api@7.1.3(vue@3.4.25(typescript@5.4.5))':
+  '@vue/devtools-api@7.1.3(vue@3.4.25(typescript@5.5.2))':
     dependencies:
-      '@vue/devtools-kit': 7.1.3(vue@3.4.25(typescript@5.4.5))
+      '@vue/devtools-kit': 7.1.3(vue@3.4.25(typescript@5.5.2))
     transitivePeerDependencies:
       - vue
 
-  '@vue/devtools-kit@7.1.3(vue@3.4.25(typescript@5.4.5))':
+  '@vue/devtools-kit@7.1.3(vue@3.4.25(typescript@5.5.2))':
     dependencies:
       '@vue/devtools-shared': 7.1.3
       hookable: 5.5.3
       mitt: 3.0.1
       perfect-debounce: 1.0.0
       speakingurl: 14.0.1
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
 
   '@vue/devtools-shared@7.1.3':
     dependencies:
       rfdc: 1.3.1
 
-  '@vue/language-core@1.8.27(typescript@5.4.5)':
+  '@vue/language-core@1.8.27(typescript@5.5.2)':
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
@@ -5259,9 +5259,9 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
-  '@vue/language-core@2.0.14(typescript@5.4.5)':
+  '@vue/language-core@2.0.14(typescript@5.5.2)':
     dependencies:
       '@volar/language-core': 2.2.0-alpha.10
       '@vue/compiler-dom': 3.4.25
@@ -5271,9 +5271,9 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
-  '@vue/language-core@2.0.17(typescript@5.4.5)':
+  '@vue/language-core@2.0.17(typescript@5.5.2)':
     dependencies:
       '@volar/language-core': 2.2.2
       '@vue/compiler-dom': 3.4.25
@@ -5283,7 +5283,7 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   '@vue/reactivity@3.4.25':
     dependencies:
@@ -5300,31 +5300,31 @@ snapshots:
       '@vue/shared': 3.4.25
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.25(vue@3.4.25(typescript@5.4.5))':
+  '@vue/server-renderer@3.4.25(vue@3.4.25(typescript@5.5.2))':
     dependencies:
       '@vue/compiler-ssr': 3.4.25
       '@vue/shared': 3.4.25
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
 
   '@vue/shared@3.4.25': {}
 
   '@vue/shared@3.4.27': {}
 
-  '@vueuse/core@10.9.0(vue@3.4.25(typescript@5.4.5))':
+  '@vueuse/core@10.9.0(vue@3.4.25(typescript@5.5.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.9.0
-      '@vueuse/shared': 10.9.0(vue@3.4.25(typescript@5.4.5))
-      vue-demi: 0.14.7(vue@3.4.25(typescript@5.4.5))
+      '@vueuse/shared': 10.9.0(vue@3.4.25(typescript@5.5.2))
+      vue-demi: 0.14.7(vue@3.4.25(typescript@5.5.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@10.9.0(focus-trap@7.5.4)(vue@3.4.25(typescript@5.4.5))':
+  '@vueuse/integrations@10.9.0(focus-trap@7.5.4)(vue@3.4.25(typescript@5.5.2))':
     dependencies:
-      '@vueuse/core': 10.9.0(vue@3.4.25(typescript@5.4.5))
-      '@vueuse/shared': 10.9.0(vue@3.4.25(typescript@5.4.5))
-      vue-demi: 0.14.7(vue@3.4.25(typescript@5.4.5))
+      '@vueuse/core': 10.9.0(vue@3.4.25(typescript@5.5.2))
+      '@vueuse/shared': 10.9.0(vue@3.4.25(typescript@5.5.2))
+      vue-demi: 0.14.7(vue@3.4.25(typescript@5.5.2))
     optionalDependencies:
       focus-trap: 7.5.4
     transitivePeerDependencies:
@@ -5333,9 +5333,9 @@ snapshots:
 
   '@vueuse/metadata@10.9.0': {}
 
-  '@vueuse/shared@10.9.0(vue@3.4.25(typescript@5.4.5))':
+  '@vueuse/shared@10.9.0(vue@3.4.25(typescript@5.5.2))':
     dependencies:
-      vue-demi: 0.14.7(vue@3.4.25(typescript@5.4.5))
+      vue-demi: 0.14.7(vue@3.4.25(typescript@5.5.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -6008,11 +6008,11 @@ snapshots:
 
   flatted@3.2.9: {}
 
-  floating-vue@5.2.2(vue@3.4.25(typescript@5.4.5)):
+  floating-vue@5.2.2(vue@3.4.25(typescript@5.5.2)):
     dependencies:
       '@floating-ui/dom': 1.1.1
-      vue: 3.4.25(typescript@5.4.5)
-      vue-resize: 2.0.0-alpha.1(vue@3.4.25(typescript@5.4.5))
+      vue: 3.4.25(typescript@5.5.2)
+      vue-resize: 2.0.0-alpha.1(vue@3.4.25(typescript@5.5.2))
 
   focus-trap@7.5.4:
     dependencies:
@@ -7165,11 +7165,11 @@ snapshots:
       cjs-module-lexer: 1.2.3
       rollup: 4.16.4
 
-  rollup-plugin-dts@6.1.0(rollup@4.16.4)(typescript@5.4.5):
+  rollup-plugin-dts@6.1.0(rollup@4.16.4)(typescript@5.5.2):
     dependencies:
       magic-string: 0.30.10
       rollup: 4.16.4
-      typescript: 5.4.5
+      typescript: 5.5.2
     optionalDependencies:
       '@babel/code-frame': 7.24.2
 
@@ -7280,10 +7280,10 @@ snapshots:
 
   shikiji-core@0.10.2: {}
 
-  shikiji-twoslash@0.10.2(typescript@5.4.5):
+  shikiji-twoslash@0.10.2(typescript@5.5.2):
     dependencies:
       shikiji-core: 0.10.2
-      twoslash: 0.1.2(typescript@5.4.5)
+      twoslash: 0.1.2(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7449,12 +7449,12 @@ snapshots:
     dependencies:
       svelte: 4.2.15
 
-  svelte2tsx@0.7.6(svelte@4.2.17)(typescript@5.4.5):
+  svelte2tsx@0.7.6(svelte@4.2.17)(typescript@5.5.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
       svelte: 4.2.17
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   svelte@4.2.15:
     dependencies:
@@ -7540,9 +7540,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@1.0.3(typescript@5.4.5):
+  ts-api-utils@1.0.3(typescript@5.5.2):
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   ts-invariant@0.10.3:
     dependencies:
@@ -7562,18 +7562,18 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  twoslash-vue@0.1.2(typescript@5.4.5):
+  twoslash-vue@0.1.2(typescript@5.5.2):
     dependencies:
-      '@vue/language-core': 1.8.27(typescript@5.4.5)
-      twoslash: 0.1.2(typescript@5.4.5)
-      typescript: 5.4.5
+      '@vue/language-core': 1.8.27(typescript@5.5.2)
+      twoslash: 0.1.2(typescript@5.5.2)
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  twoslash@0.1.2(typescript@5.4.5):
+  twoslash@0.1.2(typescript@5.5.2):
     dependencies:
       '@typescript/vfs': 1.5.0
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7624,7 +7624,7 @@ snapshots:
       for-each: 0.3.3
       is-typed-array: 1.1.12
 
-  typescript@5.4.5: {}
+  typescript@5.5.2: {}
 
   ufo@1.3.2: {}
 
@@ -7745,38 +7745,38 @@ snapshots:
     optionalDependencies:
       vite: 5.2.10(@types/node@20.12.12)(terser@5.31.0)
 
-  vitepress-plugin-twoslash@0.10.2(typescript@5.4.5):
+  vitepress-plugin-twoslash@0.10.2(typescript@5.5.2):
     dependencies:
-      floating-vue: 5.2.2(vue@3.4.25(typescript@5.4.5))
+      floating-vue: 5.2.2(vue@3.4.25(typescript@5.5.2))
       mdast-util-from-markdown: 2.0.0
       mdast-util-gfm: 3.0.0
       mdast-util-to-hast: 13.1.0
       shikiji: 0.10.2
-      shikiji-twoslash: 0.10.2(typescript@5.4.5)
-      twoslash-vue: 0.1.2(typescript@5.4.5)
-      vue: 3.4.25(typescript@5.4.5)
+      shikiji-twoslash: 0.10.2(typescript@5.5.2)
+      twoslash-vue: 0.1.2(typescript@5.5.2)
+      vue: 3.4.25(typescript@5.5.2)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
       - typescript
 
-  vitepress@1.1.3(@algolia/client-search@4.23.3)(@types/node@20.12.12)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5):
+  vitepress@1.1.3(@algolia/client-search@4.23.3)(@types/node@20.12.12)(@types/react@18.3.1)(postcss@8.4.38)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.5.2):
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)
       '@shikijs/core': 1.3.0
       '@shikijs/transformers': 1.3.0
       '@types/markdown-it': 14.0.1
-      '@vitejs/plugin-vue': 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.4.5))
-      '@vue/devtools-api': 7.1.3(vue@3.4.25(typescript@5.4.5))
-      '@vueuse/core': 10.9.0(vue@3.4.25(typescript@5.4.5))
-      '@vueuse/integrations': 10.9.0(focus-trap@7.5.4)(vue@3.4.25(typescript@5.4.5))
+      '@vitejs/plugin-vue': 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.5.2))
+      '@vue/devtools-api': 7.1.3(vue@3.4.25(typescript@5.5.2))
+      '@vueuse/core': 10.9.0(vue@3.4.25(typescript@5.5.2))
+      '@vueuse/integrations': 10.9.0(focus-trap@7.5.4)(vue@3.4.25(typescript@5.5.2))
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.3.0
       vite: 5.2.10(@types/node@20.12.12)(terser@5.31.0)
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
     optionalDependencies:
       postcss: 8.4.38
     transitivePeerDependencies:
@@ -7842,35 +7842,35 @@ snapshots:
 
   vscode-languageserver-textdocument@1.0.11: {}
 
-  vue-demi@0.14.7(vue@3.4.25(typescript@5.4.5)):
+  vue-demi@0.14.7(vue@3.4.25(typescript@5.5.2)):
     dependencies:
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
 
-  vue-resize@2.0.0-alpha.1(vue@3.4.25(typescript@5.4.5)):
+  vue-resize@2.0.0-alpha.1(vue@3.4.25(typescript@5.5.2)):
     dependencies:
-      vue: 3.4.25(typescript@5.4.5)
+      vue: 3.4.25(typescript@5.5.2)
 
   vue-template-compiler@2.7.16:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-tsc@2.0.14(typescript@5.4.5):
+  vue-tsc@2.0.14(typescript@5.5.2):
     dependencies:
       '@volar/typescript': 2.2.0-alpha.10
-      '@vue/language-core': 2.0.14(typescript@5.4.5)
+      '@vue/language-core': 2.0.14(typescript@5.5.2)
       semver: 7.6.0
-      typescript: 5.4.5
+      typescript: 5.5.2
 
-  vue@3.4.25(typescript@5.4.5):
+  vue@3.4.25(typescript@5.5.2):
     dependencies:
       '@vue/compiler-dom': 3.4.25
       '@vue/compiler-sfc': 3.4.25
       '@vue/runtime-dom': 3.4.25
-      '@vue/server-renderer': 3.4.25(vue@3.4.25(typescript@5.4.5))
+      '@vue/server-renderer': 3.4.25(vue@3.4.25(typescript@5.5.2))
       '@vue/shared': 3.4.25
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   wcwidth@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@0no-co/graphql.web':
         specifier: ^1.0.5
         version: 1.0.7(graphql@16.8.1)
+      '@0no-co/graphqlsp':
+        specifier: ^1.10.3
+        version: 1.11.0(typescript@5.4.5)
       '@gql.tada/cli-utils':
         specifier: workspace:*
         version: link:packages/cli-utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
   typescript: ^5.3.3
+  '@0no-co/graphqlsp': ^1.12.8
 
 importers:
 
@@ -18,8 +19,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.7(graphql@16.8.1)
       '@0no-co/graphqlsp':
-        specifier: ^1.10.3
-        version: 1.11.0(typescript@5.4.5)
+        specifier: ^1.12.8
+        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
       '@gql.tada/cli-utils':
         specifier: workspace:*
         version: link:packages/cli-utils
@@ -140,8 +141,8 @@ importers:
         version: 4.0.7(graphql@16.8.1)(react@18.3.1)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.0
-        version: 1.12.1(typescript@5.4.5)
+        specifier: ^1.12.8
+        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.1
@@ -174,8 +175,8 @@ importers:
         version: 4.2.15
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.0
-        version: 1.12.1(typescript@5.4.5)
+        specifier: ^1.12.8
+        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
         version: 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))
@@ -205,8 +206,8 @@ importers:
         version: 3.4.25(typescript@5.4.5)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.12.0
-        version: 1.12.1(typescript@5.4.5)
+        specifier: ^1.12.8
+        version: 1.12.8(graphql@16.8.1)(typescript@5.4.5)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.4.5))
@@ -376,11 +377,6 @@ packages:
     peerDependenciesMeta:
       graphql:
         optional: true
-
-  '@0no-co/graphqlsp@1.12.1':
-    resolution: {integrity: sha512-KHMs1a9qXoiwA4aUKGgcsyM38SXH6ddQFwu4Hf2p8XjUOkRKHy38pd4qYM0hgA1vpkUf8WSj5GyDAbezhApfpw==}
-    peerDependencies:
-      typescript: ^5.3.3
 
   '@0no-co/graphqlsp@1.12.8':
     resolution: {integrity: sha512-arW3ZzifyKIJhehoAlsP069AX73EN6q358bOCf+8z00PmfPR2DSxq7uGGSj0oFNe3vEDtGYl88HmFEWQ+0+dwQ==}
@@ -3882,15 +3878,6 @@ snapshots:
   '@0no-co/graphql.web@1.0.7(graphql@16.8.1)':
     optionalDependencies:
       graphql: 16.8.1
-
-  '@0no-co/graphqlsp@1.12.1(typescript@5.4.5)':
-    dependencies:
-      '@gql.tada/internal': link:packages/internal
-      graphql: 16.8.1
-      node-fetch: 2.7.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - encoding
 
   '@0no-co/graphqlsp@1.12.8(graphql@16.8.1)(typescript@5.4.5)':
     dependencies:

--- a/src/ts-plugin/index.ts
+++ b/src/ts-plugin/index.ts
@@ -1,0 +1,1 @@
+export { default } from '@0no-co/graphqlsp';


### PR DESCRIPTION
Dependent on https://github.com/microsoft/TypeScript/pull/57266
Resolves #75

## Summary

We're waiting for TypeScript to support sub-paths for tsserver plugins to ease the installation instructions back down to a single package and avoid having to explain the different between `@0no-co/graphqlsp` and `gql.tada` to people.

This would turn `gql.tada` into a standalone entrypoint package for its experience.

## Set of changes

- Add `gql.tada/ts-plugin` alias
