### PR TITLE
fix: Add missing case for input object fields with default value

### DIFF
--- a/.changeset/strong-ducks-shop.md
+++ b/.changeset/strong-ducks-shop.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Add missing support for input object fields with default values. Previously, input object fields with default values were still marked as required in variables.

--- a/src/__tests__/fixtures/simpleIntrospection.ts
+++ b/src/__tests__/fixtures/simpleIntrospection.ts
@@ -43,6 +43,29 @@ export type simpleIntrospection = {
         possibleTypes: null,
       },
       {
+        kind: 'INPUT_OBJECT',
+        name: 'DefaultPayload',
+        fields: null,
+        inputFields: [
+          {
+            name: 'value',
+            type: {
+              kind: 'NON_NULL',
+              name: null,
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            defaultValue: 'DEFAULT',
+          }
+        ],
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
+      },
+      {
         kind: 'OBJECT',
         name: 'Query',
         fields: [

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -243,6 +243,26 @@ export type simpleSchema = {
       ];
     };
 
+    DefaultPayload: {
+      kind: 'INPUT_OBJECT';
+      name: 'DefaultPayload';
+      inputFields: [
+        {
+          name: 'value';
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: 'DEFAULT';
+        },
+      ];
+    };
+
     LatestTodoResult: {
       kind: 'UNION';
       name: 'LatestTodoResult';

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -46,6 +46,23 @@ test('allows optionals for default values', () => {
   expectTypeOf<variables['id']>().toEqualTypeOf<string | number | undefined>();
 });
 
+test('allows optionals for default values inside input-objects', () => {
+  const query = `
+    mutation ($input: DefaultPayload!) {
+      __typename
+    }
+  `;
+
+  type doc = parseDocument<typeof query>;
+  type variables = getVariablesType<doc, schema>;
+
+  expectTypeOf<variables>().toEqualTypeOf<{
+    input: {
+      value?: string | null | undefined;
+    };
+  }>();
+});
+
 test('allows optionals for nullable values', () => {
   const query = `
     mutation ($id: ID) {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -12,9 +12,9 @@ type getInputObjectTypeRec<
       Rest,
       Introspection,
       (InputField extends { name: any; type: any }
-        ? InputField['type'] extends { kind: 'NON_NULL' }
+        ? InputField extends { defaultValue: undefined | null; type: { kind: 'NON_NULL' } }
           ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
-          : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> }
+          : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> | null }
         : {}) &
         InputObject
     >


### PR DESCRIPTION
Resolve #71

## Summary

The case of `defaultValue` not being `null | undefined` wasn't being handled when deriving types for input object fields in variables.
This PR adds the missing match.

## Set of changes

- Add match for `defaultValue` to input objects’ fields
