### PR TITLE
fix cli schema path resolver

### DIFF
--- a/.changeset/rich-boxes-smash.md
+++ b/.changeset/rich-boxes-smash.md
@@ -1,5 +1,5 @@
 ---
-'gql.tada': minor
+'gql.tada': patch
 ---
 
 Fix schema pathname resolution in CLI

--- a/.changeset/rich-boxes-smash.md
+++ b/.changeset/rich-boxes-smash.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Fix schema pathname resolution in CLI

--- a/packages/cli-utils/src/tada.ts
+++ b/packages/cli-utils/src/tada.ts
@@ -149,7 +149,7 @@ export const loadSchema = async (
     }
   } else if (typeof schema === 'string') {
     const isJson = path.extname(schema) === '.json';
-    const resolvedPath = path.resolve(path.dirname(root), schema);
+    const resolvedPath = path.resolve(root, schema);
 
     const contents = await fs.readFile(resolvedPath, 'utf-8');
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

`npx gql.tada generate` is resolving the schema.graphql file path from *parent* of CWD instead of the CWD.

e.g.
```json
// tsconfig.json
{
  "plugins": [
    {
      "name": "@0no-co/graphqlsp",
      "schema": "./graphql/schema.graphql",
      "tadaOutputLocation": "./types/graphql-env.d.ts"
    }
  ]
}
```

Assume CWD is `/path/to/my_projects/my_app`
Run `npx gql.tada generate` gets error:
```
Something went wrong while writing the introspection file [Error: ENOENT: no such file or directory, open '/path/to/my_projects/graphql/schema.graphql']
```

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- remove `path.dirname()`

NOTE: I would add a test-case but I don't see tests for CLI yet
