### PR TITLE
chore: update actions to node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v3
         with:
           version: 8
           run_install: false
@@ -33,7 +33,7 @@ jobs:
         run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
       - name: Use pnpm store
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pnpm-cache
         with:
           path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,17 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v3
         with:
           version: 8
           run_install: false
@@ -51,7 +51,7 @@ jobs:
 
       - name: PR or Publish
         id: changesets
-        uses: changesets/action@v1.4.5
+        uses: changesets/action@v1.4.6
         with:
           version: pnpm changeset:version
           publish: pnpm changeset:publish

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,17 +20,17 @@ jobs:
       deployments: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v3
         with:
           version: 8
           run_install: false
@@ -40,7 +40,7 @@ jobs:
         run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
       - name: Use pnpm store
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pnpm-cache
         with:
           path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}


### PR DESCRIPTION
Currently we see a lot of warnings in the CI about updating our actions. https://github.com/0no-co/gql.tada/actions/runs/8067503114