### PR TITLE
fix: Allow `graphql.scalar` to resolve types for input objects

### DIFF
--- a/.changeset/breezy-queens-bow.md
+++ b/.changeset/breezy-queens-bow.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Allow `graphql.scalar` to resolve types for input objects.

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type { simpleIntrospection } from './fixtures/simpleIntrospection';
 import type { simpleSchema } from './fixtures/simpleSchema';
-import type { mapIntrospection, getScalarType } from '../introspection';
+import type { mapIntrospection } from '../introspection';
 
 describe('mapIntrospection', () => {
   it('prepares sample schema', () => {
@@ -14,19 +14,5 @@ describe('mapIntrospection', () => {
 
     type idScalar = expected['types']['ID']['type'];
     expectTypeOf<idScalar>().toEqualTypeOf<'ID'>();
-  });
-});
-
-describe('getScalarType', () => {
-  it('resolves to never for invalid types', () => {
-    expectTypeOf<getScalarType<simpleSchema, 'invalid'>>().toEqualTypeOf<never>();
-  });
-
-  it('gets the type of a scalar', () => {
-    expectTypeOf<getScalarType<simpleSchema, 'String'>>().toEqualTypeOf<string>();
-  });
-
-  it('gets the type of an enum', () => {
-    expectTypeOf<getScalarType<simpleSchema, 'test'>>().toEqualTypeOf<'value' | 'more'>();
   });
 });

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -81,7 +81,7 @@ describe('getVariablesType', () => {
 
 describe('getScalarType', () => {
   it('resolves to unknown for invalid types', () => {
-    expectTypeOf<getScalarType<'invalid', schema>>().toEqualTypeOf<unknown>();
+    expectTypeOf<getScalarType<'invalid', schema>>().toEqualTypeOf<never>();
   });
 
   it('gets the type of a scalar', () => {

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -80,7 +80,7 @@ describe('getVariablesType', () => {
 });
 
 describe('getScalarType', () => {
-  it('resolves to never for invalid types', () => {
+  it('resolves to unknown for invalid types', () => {
     expectTypeOf<getScalarType<'invalid', schema>>().toEqualTypeOf<unknown>();
   });
 
@@ -90,5 +90,10 @@ describe('getScalarType', () => {
 
   it('gets the type of an enum', () => {
     expectTypeOf<getScalarType<'test', schema>>().toEqualTypeOf<'value' | 'more'>();
+  });
+
+  it('gets the type of an input object', () => {
+    type expected = { title: string; complete?: boolean | null };
+    expectTypeOf<getScalarType<'TodoPayload', schema>>().toEqualTypeOf<expected>();
   });
 });

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -1,78 +1,94 @@
-import { expectTypeOf, test } from 'vitest';
+import { describe, it, expectTypeOf } from 'vitest';
 import type { simpleSchema as schema } from './fixtures/simpleSchema';
 import type { parseDocument } from '../parser';
-import type { getVariablesType } from '../variables';
+import type { getVariablesType, getScalarType } from '../variables';
 
-test('parses document-variables correctly', () => {
-  const query = `
-    mutation ($id: ID!) {
-      toggleTodo { id }
-    }
-  `;
+describe('getVariablesType', () => {
+  it('parses document-variables correctly', () => {
+    const query = `
+      mutation ($id: ID!) {
+        toggleTodo { id }
+      }
+    `;
 
-  type doc = parseDocument<typeof query>;
-  type variables = getVariablesType<doc, schema>;
+    type doc = parseDocument<typeof query>;
+    type variables = getVariablesType<doc, schema>;
 
-  expectTypeOf<variables>().toEqualTypeOf<{ id: string | number }>();
+    expectTypeOf<variables>().toEqualTypeOf<{ id: string | number }>();
+  });
+
+  it('works for input-objects', () => {
+    const query = `
+      mutation ($id: ID!, $input: TodoPayload!) {
+        toggleTodo (id: $id input: $input) { id }
+      }
+    `;
+
+    type doc = parseDocument<typeof query>;
+    type variables = getVariablesType<doc, schema>;
+
+    expectTypeOf<variables>().toEqualTypeOf<{
+      id: string | number;
+      input: { title: string; complete?: boolean | null };
+    }>();
+  });
+
+  it('allows optionals for default values', () => {
+    const query = `
+      mutation ($id: ID! = "default") {
+        toggleTodo (id: $id) { id }
+      }
+    `;
+
+    type doc = parseDocument<typeof query>;
+    type variables = getVariablesType<doc, schema>;
+
+    expectTypeOf<variables>().toEqualTypeOf<{ id?: string | number | undefined }>();
+    expectTypeOf<variables['id']>().toEqualTypeOf<string | number | undefined>();
+  });
+
+  it('allows optionals for default values inside input-objects', () => {
+    const query = `
+      mutation ($input: DefaultPayload!) {
+        __typename
+      }
+    `;
+
+    type doc = parseDocument<typeof query>;
+    type variables = getVariablesType<doc, schema>;
+
+    expectTypeOf<variables>().toEqualTypeOf<{
+      input: {
+        value?: string | null | undefined;
+      };
+    }>();
+  });
+
+  it('allows optionals for nullable values', () => {
+    const query = `
+      mutation ($id: ID) {
+        toggleTodo (id: $id) { id }
+      }
+    `;
+
+    type doc = parseDocument<typeof query>;
+    type variables = getVariablesType<doc, schema>;
+
+    expectTypeOf<variables>().toEqualTypeOf<{ id?: string | number | null | undefined }>();
+    expectTypeOf<variables['id']>().toEqualTypeOf<string | number | null | undefined>();
+  });
 });
 
-test('works for input-objects', () => {
-  const query = `
-    mutation ($id: ID!, $input: TodoPayload!) {
-      toggleTodo (id: $id input: $input) { id }
-    }
-  `;
+describe('getScalarType', () => {
+  it('resolves to never for invalid types', () => {
+    expectTypeOf<getScalarType<'invalid', schema>>().toEqualTypeOf<unknown>();
+  });
 
-  type doc = parseDocument<typeof query>;
-  type variables = getVariablesType<doc, schema>;
+  it('gets the type of a scalar', () => {
+    expectTypeOf<getScalarType<'String', schema>>().toEqualTypeOf<string>();
+  });
 
-  expectTypeOf<variables>().toEqualTypeOf<{
-    id: string | number;
-    input: { title: string; complete?: boolean | null };
-  }>();
-});
-
-test('allows optionals for default values', () => {
-  const query = `
-    mutation ($id: ID! = "default") {
-      toggleTodo (id: $id) { id }
-    }
-  `;
-
-  type doc = parseDocument<typeof query>;
-  type variables = getVariablesType<doc, schema>;
-
-  expectTypeOf<variables>().toEqualTypeOf<{ id?: string | number | undefined }>();
-  expectTypeOf<variables['id']>().toEqualTypeOf<string | number | undefined>();
-});
-
-test('allows optionals for default values inside input-objects', () => {
-  const query = `
-    mutation ($input: DefaultPayload!) {
-      __typename
-    }
-  `;
-
-  type doc = parseDocument<typeof query>;
-  type variables = getVariablesType<doc, schema>;
-
-  expectTypeOf<variables>().toEqualTypeOf<{
-    input: {
-      value?: string | null | undefined;
-    };
-  }>();
-});
-
-test('allows optionals for nullable values', () => {
-  const query = `
-    mutation ($id: ID) {
-      toggleTodo (id: $id) { id }
-    }
-  `;
-
-  type doc = parseDocument<typeof query>;
-  type variables = getVariablesType<doc, schema>;
-
-  expectTypeOf<variables>().toEqualTypeOf<{ id?: string | number | null | undefined }>();
-  expectTypeOf<variables['id']>().toEqualTypeOf<string | number | null | undefined>();
+  it('gets the type of an enum', () => {
+    expectTypeOf<getScalarType<'test', schema>>().toEqualTypeOf<'value' | 'more'>();
+  });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,6 @@ import type {
   ScalarsLike,
   IntrospectionLikeType,
   mapIntrospection,
-  getScalarType,
 } from './introspection';
 
 import type {
@@ -18,8 +17,8 @@ import type {
 } from './namespace';
 
 import type { getDocumentType } from './selection';
-import type { getVariablesType } from './variables';
 import type { parseDocument, DocumentNodeLike } from './parser';
+import type { getVariablesType, getScalarType } from './variables';
 import type { stringLiteral, obj, matchOr, writable, DocumentDecoration } from './utils';
 
 /** Abstract configuration type input for your schema and scalars.
@@ -164,7 +163,7 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends Ab
    */
   scalar<
     const Name extends stringLiteral<Name>,
-    const Value extends getScalarType<Schema, Name, null | undefined>,
+    const Value extends getScalarType<Name, Schema, null | undefined>,
   >(
     name: Name,
     value: Value
@@ -172,8 +171,8 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends Ab
 
   scalar<const Name extends stringLiteral<Name>>(
     name: Name,
-    value?: getScalarType<Schema, Name>
-  ): getScalarType<Schema, Name>;
+    value?: getScalarType<Name, Schema>
+  ): getScalarType<Name, Schema>;
 }
 
 type schemaOfSetup<Setup extends AbstractSetupSchema> = mapIntrospection<

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -223,16 +223,6 @@ type mapIntrospection<
   types: mapIntrospectionTypes<Query, Scalars>;
 };
 
-type getScalarType<
-  Schema extends IntrospectionLikeType,
-  Name extends string,
-  OrType = never,
-> = Schema['types'][Name] extends { kind: 'SCALAR'; type: infer Type }
-  ? Type | OrType
-  : Schema['types'][Name] extends { kind: 'ENUM'; type: infer Type }
-    ? Type | OrType
-    : never;
-
 export type ScalarsLike = {
   [name: string]: any;
 };
@@ -244,4 +234,4 @@ export type IntrospectionLikeType = {
   types: { [name: string]: any };
 };
 
-export type { mapIntrospectionTypes, mapIntrospection, getScalarType };
+export type { mapIntrospectionTypes, mapIntrospection };

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -20,17 +20,6 @@ type getInputObjectTypeRec<
     >
   : InputObject;
 
-type _getScalarType<
-  TypeName,
-  Introspection extends IntrospectionLikeType,
-> = TypeName extends keyof Introspection['types']
-  ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
-    ? Introspection['types'][TypeName]['type']
-    : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
-      ? obj<getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>>
-      : never
-  : unknown;
-
 type _unwrapTypeRec<TypeRef, Introspection extends IntrospectionLikeType> = TypeRef extends {
   kind: 'NON_NULL';
   ofType: any;
@@ -104,14 +93,31 @@ type getVariablesType<
   ? obj<_getVariablesRec<Document['definitions'][0]['variableDefinitions'], Introspection>>
   : {};
 
+type _getScalarType<
+  TypeName,
+  Introspection extends IntrospectionLikeType,
+> = TypeName extends keyof Introspection['types']
+  ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+    ? Introspection['types'][TypeName]['type']
+    : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
+      ? obj<getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>>
+      : never
+  : unknown;
+
 type getScalarType<
   TypeName,
   Introspection extends IntrospectionLikeType,
   OrType = never,
-> = _getScalarType<TypeName, Introspection> extends infer Type
-  ? unknown extends Type
-    ? never
-    : Type | OrType
+> = TypeName extends keyof Introspection['types']
+  ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+    ? Introspection['types'][TypeName]['type'] | OrType
+    : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
+      ?
+          | obj<
+              getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
+            >
+          | OrType
+      : never
   : never;
 
 export type { getVariablesType, getScalarType };

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -23,11 +23,16 @@ type getInputObjectTypeRec<
 type getScalarType<
   TypeName,
   Introspection extends IntrospectionLikeType,
+  OrType = never,
 > = TypeName extends keyof Introspection['types']
   ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
-    ? Introspection['types'][TypeName]['type']
+    ? Introspection['types'][TypeName]['type'] | OrType
     : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
-      ? obj<getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>>
+      ?
+          | obj<
+              getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
+            >
+          | OrType
       : never
   : unknown;
 
@@ -104,4 +109,4 @@ type getVariablesType<
   ? obj<_getVariablesRec<Document['definitions'][0]['variableDefinitions'], Introspection>>
   : {};
 
-export type { getVariablesType };
+export type { getVariablesType, getScalarType };


### PR DESCRIPTION
## Summary

`graphql.scalar()` currently allows scalars and enums to be resolved from the given introspection schema, however, it differed from `getScalarType` in `variables.ts` in that it didn't resolve input objects.

## Set of changes

- Reuse logic in `variables.ts` for `graphql.scalar`
