### PR TITLE
feat: Add `graphql.persisted()` utility to create persisted stand-in documents

### DIFF
--- a/.changeset/orange-badgers-decide.md
+++ b/.changeset/orange-badgers-decide.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Add `graphql.persisted()` to create an API for persisted documents that omits a query’s definitions from the output bundle.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -446,3 +446,28 @@ describe('unsafe_readResult', () => {
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 });
+
+describe('graphql.persisted()', () => {
+  const graphql = initGraphQLTada<{ introspection: simpleIntrospection }>();
+
+  const query = graphql(`
+    query Test {
+      __typename
+    }
+  `);
+
+  it('should take on the value of the document', () => {
+    const persisted = graphql.persisted<typeof query>('Test');
+    expectTypeOf<typeof persisted>().toMatchTypeOf<typeof query>();
+    expectTypeOf<ResultOf<typeof persisted>>().toEqualTypeOf<ResultOf<typeof query>>();
+    expectTypeOf<VariablesOf<typeof persisted>>().toEqualTypeOf<VariablesOf<typeof query>>();
+  });
+
+  it('should require a document to be passed as a generic', () => {
+    const persisted = graphql.persisted('Test');
+    expectTypeOf<typeof persisted>().toBeNever();
+
+    // @ts-expect-error
+    graphql.persisted<number>('Test');
+  });
+});

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -9,7 +9,7 @@ const testTypeHost = test.each([
   { strictNullChecks: true },
 ]);
 
-describe('graphql function', () => {
+describe('graphql()', () => {
   it('should strip @_unmask from fragment documents', () => {
     const graphql = initGraphQLTada<{ introspection: simpleIntrospection }>();
 
@@ -27,6 +27,25 @@ describe('graphql function', () => {
           directives: [],
         },
       ],
+    });
+  });
+});
+
+describe('graphql.persisted()', () => {
+  it('should return an empty document with a given ID', () => {
+    const graphql = initGraphQLTada<{ introspection: simpleIntrospection }>();
+
+    const query = graphql(`
+      query Test {
+        __typename
+      }
+    `);
+
+    const persisted = graphql.persisted<typeof query>('Test');
+
+    expect(persisted).toMatchObject({
+      definitions: [],
+      id: 'Test',
     });
   });
 });

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -45,7 +45,7 @@ describe('graphql.persisted()', () => {
 
     expect(persisted).toMatchObject({
       definitions: [],
-      id: 'Test',
+      documentId: 'Test',
     });
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -173,6 +173,10 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends Ab
     name: Name,
     value?: getScalarType<Name, Schema>
   ): getScalarType<Name, Schema>;
+
+  persisted<const Document extends DocumentNodeLike>(
+    id: string
+  ): getPersistedDocumentNode<Document>;
 }
 
 type schemaOfSetup<Setup extends AbstractSetupSchema> = mapIntrospection<
@@ -239,6 +243,14 @@ function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
     return value;
   };
 
+  graphql.persisted = function persisted(id: string): TadaPersistedDocumentNode {
+    return {
+      kind: Kind.DOCUMENT,
+      definitions: [],
+      id,
+    };
+  };
+
   return graphql as GraphQLTadaAPI<Schema, Config>;
 }
 
@@ -292,6 +304,15 @@ interface TadaDocumentNode<
 > extends DocumentNode,
     DocumentDecoration<Result, Variables>,
     makeDefinitionDecoration<Decoration> {}
+
+interface TadaPersistedDocumentNode<
+  Result = { [key: string]: any },
+  Variables = { [key: string]: any },
+> extends DocumentNode,
+    DocumentDecoration<Result, Variables> {
+  definitions: readonly [];
+  id: string;
+}
 
 /** A utility type returning the `Result` type of typed GraphQL documents.
  *
@@ -375,6 +396,11 @@ type fragmentOfTypeRec<Document extends makeDefinitionDecoration> =
   | null;
 
 type resultOfTypeRec<Data> = readonly resultOfTypeRec<Data>[] | Data | undefined | null;
+
+type getPersistedDocumentNode<Document extends DocumentNodeLike> =
+  Document extends DocumentDecoration<infer Result, infer Variables>
+    ? TadaPersistedDocumentNode<Result, Variables>
+    : never;
 
 /** Unmasks a fragment mask for a given fragment document and data.
  *
@@ -537,6 +563,7 @@ export type {
   AbstractSetupSchema,
   GraphQLTadaAPI,
   TadaDocumentNode,
+  TadaPersistedDocumentNode,
   ResultOf,
   VariablesOf,
   FragmentOf,

--- a/src/api.ts
+++ b/src/api.ts
@@ -202,7 +202,7 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends Ab
    * ```
    */
   persisted<Document extends DocumentNodeLike = never>(
-    id: string
+    documentId: string
   ): Document extends DocumentDecoration<infer Result, infer Variables>
     ? TadaPersistedDocumentNode<Result, Variables>
     : never;
@@ -272,11 +272,11 @@ function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
     return value;
   };
 
-  graphql.persisted = function persisted(id: string): TadaPersistedDocumentNode {
+  graphql.persisted = function persisted(documentId: string): TadaPersistedDocumentNode {
     return {
       kind: Kind.DOCUMENT,
       definitions: [],
-      id,
+      documentId,
     };
   };
 
@@ -350,7 +350,7 @@ interface TadaPersistedDocumentNode<
 > extends DocumentNode,
     DocumentDecoration<Result, Variables> {
   definitions: readonly [];
-  id: string;
+  documentId: string;
 }
 
 /** A utility type returning the `Result` type of typed GraphQL documents.

--- a/src/api.ts
+++ b/src/api.ts
@@ -201,7 +201,7 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends Ab
    * const persisted = graphql.persisted<typeof query>('MyQuery');
    * ```
    */
-  persisted<const Document extends DocumentNodeLike>(
+  persisted<Document extends DocumentNodeLike = never>(
     id: string
   ): Document extends DocumentDecoration<infer Result, infer Variables>
     ? TadaPersistedDocumentNode<Result, Variables>

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   AbstractSetupSchema,
   GraphQLTadaAPI,
   TadaDocumentNode,
+  TadaPersistedDocumentNode,
   ResultOf,
   VariablesOf,
   FragmentOf,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -418,7 +418,7 @@ type parseOperation<In> = TakeOperation<skipIgnored<In>> extends [infer Node, st
 
 export type DocumentNodeLike = {
   kind: Kind.DOCUMENT;
-  definitions: any[];
+  definitions: readonly any[];
 };
 
 export type { parseConstValue, parseOperation, parseDocument, parseValue, parseType };


### PR DESCRIPTION
Related to #77
Related to https://github.com/0no-co/GraphQLSP/pull/240
Related to https://github.com/urql-graphql/urql/pull/3515

## Summary

This implements a `graphql.persisted()` function, as per the RFC in #77.

This accepts a `documentId` string and returns a value that matches a GraphQL.js `DocumentNode` shape but contains no definitions. The resulting value contains no reference to the original document, while the return type of `graphql.persisted()` matches the document’s type that's been passed in.

The returned type is also transformed to a more strict type that clearly indicates that the `documentId` is present but that no `definitions` are present.

## Set of changes

- Add `graphql.persisted()`
- Add `TadaPersistedDocumentNode`
