### PR TITLE
fix: Export `$tada` to fix `isolatedModules` projects

### DIFF
--- a/.changeset/nervous-socks-relate.md
+++ b/.changeset/nervous-socks-relate.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Fix `$tada` not being exported, which can cause projects with `isolatedModules: true` set from building.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,6 @@ export type {
   VariablesOf,
   FragmentOf,
 } from './api';
+
+// NOTE: This must be exported for `isolatedModules: true`
+export type { $tada } from './namespace';

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -3,6 +3,7 @@ import type { DocumentNodeLike } from './parser';
 import type { DocumentDecoration } from './utils';
 
 /** Private namespace holding our symbols for markers.
+ * @internal
  *
  * @remarks
  * Markers are used to indicate, for example, which fragments a given GraphQL document


### PR DESCRIPTION
## Summary

This is required for projects that are configured with `isolatedModules: true`.
When this is set, the `$tada` symbols can't be referenced and hence an error is emitted by `tsserver`/`tsc`.

Exporting `$tada` fixes this.

## Set of changes

- Re-export `$tada`
- Mark `$tada` as `@internal` in ts docs
