### PR TITLE
fix: Fix input object field introspection with missing `defaultValue` properties

### DIFF
--- a/.changeset/strange-nails-ring.md
+++ b/.changeset/strange-nails-ring.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+'gql.tada': patch
 ---
 
 fix(getInputObjectTypeRec): Correctly infer type of field with no default value (should be non-optional and non-nullable)

--- a/.changeset/strange-nails-ring.md
+++ b/.changeset/strange-nails-ring.md
@@ -2,4 +2,4 @@
 'gql.tada': patch
 ---
 
-fix(getInputObjectTypeRec): Correctly infer type of field with no default value (should be non-optional and non-nullable)
+Handle inference of input object fields with missing `defaultValue` properties in introspection.

--- a/.changeset/strange-nails-ring.md
+++ b/.changeset/strange-nails-ring.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(getInputObjectTypeRec): Correctly infer type of field with no default value (should be non-optional and non-nullable)

--- a/src/__tests__/fixtures/simpleIntrospection.ts
+++ b/src/__tests__/fixtures/simpleIntrospection.ts
@@ -29,6 +29,17 @@ export type simpleIntrospection = {
             defaultValue: null,
           },
           {
+            name: 'description',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+          },
+          {
             name: 'complete',
             type: {
               kind: 'SCALAR',

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -232,6 +232,17 @@ export type simpleSchema = {
           defaultValue: null;
         },
         {
+          name: 'description';
+          type: {
+            kind: 'NON_NULL';
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        },
+        {
           name: 'complete';
           type: {
             kind: 'SCALAR';

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -29,7 +29,7 @@ describe('getVariablesType', () => {
 
     expectTypeOf<variables>().toEqualTypeOf<{
       id: string | number;
-      input: { title: string; complete?: boolean | null };
+      input: { title: string; complete?: boolean | null; description: string };
     }>();
   });
 
@@ -93,7 +93,7 @@ describe('getScalarType', () => {
   });
 
   it('gets the type of an input object', () => {
-    type expected = { title: string; complete?: boolean | null };
+    type expected = { title: string; complete?: boolean | null; description: string };
     expectTypeOf<getScalarType<'TodoPayload', schema>>().toEqualTypeOf<expected>();
   });
 });

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -12,20 +12,9 @@ type getInputObjectTypeRec<
       Rest,
       Introspection,
       (InputField extends { name: any; type: any }
-        ? InputField extends { type: { kind: 'NON_NULL' } }
-          ? InputField extends { defaultValue: infer DefaultValue }
-            ? DefaultValue extends undefined | null
-              ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
-              : {
-                  [Name in InputField['name']]?: unwrapType<
-                    InputField['type'],
-                    Introspection
-                  > | null;
-                }
-            : { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
-          : {
-              [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> | null;
-            }
+        ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
+          ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
+          : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> | null }
         : {}) &
         InputObject
     >

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -12,9 +12,20 @@ type getInputObjectTypeRec<
       Rest,
       Introspection,
       (InputField extends { name: any; type: any }
-        ? InputField extends { defaultValue: undefined | null; type: { kind: 'NON_NULL' } }
-          ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
-          : { [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> | null }
+        ? InputField extends { type: { kind: 'NON_NULL' } }
+          ? InputField extends { defaultValue: infer DefaultValue }
+            ? DefaultValue extends undefined | null
+              ? { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
+              : {
+                  [Name in InputField['name']]?: unwrapType<
+                    InputField['type'],
+                    Introspection
+                  > | null;
+                }
+            : { [Name in InputField['name']]: unwrapType<InputField['type'], Introspection> }
+          : {
+              [Name in InputField['name']]?: unwrapType<InputField['type'], Introspection> | null;
+            }
         : {}) &
         InputObject
     >


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

If I have no `defaultValue`, `getInputObjectTypeRec` will infer my field as `foo?: string | null` when it should be `foo: string`. This is because `getInputObjectTypeRec` only checks for explicity `undefined | null`. Add a test case and fix for this.

## Set of changes

* Additional "description" field in test fixture, which has no `defaultValue`
* Bugfix and test