### PR TITLE
fix: Fix spreading abstract fragments into abstract selections widening the result type

### DIFF
--- a/.changeset/serious-pears-shave.md
+++ b/.changeset/serious-pears-shave.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Keep the possible types that are iterated through narrow through repeated abstract type fragment spreads, and provide an optional `__typename?: PossibleType` field by default so the type checker has an exact property to merge types on.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -395,7 +395,7 @@ describe('unsafe_readResult', () => {
 
     type query = parseDocument<`
       query Test {
-        latestTodo {
+        todos {
           id
           ...Fields
         }
@@ -406,10 +406,12 @@ describe('unsafe_readResult', () => {
     type document = getDocumentNode<query, schema, getFragmentsOfDocumentsRec<[fragmentDoc]>>;
 
     const result = unsafe_readResult({} as document, {
-      latestTodo: {
-        id: 'id',
-        fields: 'id',
-      },
+      todos: [
+        {
+          id: 'id',
+          fields: 'id',
+        },
+      ],
     });
 
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();

--- a/src/__tests__/fixtures/simpleIntrospection.ts
+++ b/src/__tests__/fixtures/simpleIntrospection.ts
@@ -104,6 +104,19 @@ export type simpleIntrospection = {
               },
             },
           },
+          {
+            name: 'itodo',
+            args: [],
+            type: {
+              kind: 'NON_NULL',
+              name: null,
+              ofType: {
+                kind: 'INTERFACE',
+                name: 'ITodo',
+                ofType: null,
+              },
+            },
+          },
         ],
         inputFields: null,
         interfaces: [],

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -32,6 +32,19 @@ export type simpleSchema = {
             };
           };
         };
+        itodo: {
+          name: 'itodo';
+          type: {
+            kind: 'NON_NULL';
+            name: null;
+            ofType: {
+              kind: 'INTERFACE';
+              name: 'ITodo';
+              ofType: null;
+            };
+          };
+        };
+
         test: {
           name: 'test';
           type: {

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -325,6 +325,37 @@ test('infers fragment spreads on unions', () => {
   }
 });
 
+test('infers fragment spreads inside fragment spreads on interfaces', () => {
+  type query = parseDocument</* GraphQL */ `
+    query {
+      itodo {
+        ...ITodo
+        ... on BigTodo {
+          wallOfText
+        }
+        ... on SmallTodo {
+          id
+          maxLength
+        }
+      }
+    }
+
+    fragment ITodo on ITodo {
+      __typename
+      id
+    }
+  `>;
+
+  type actual = getDocumentType<query, schema>;
+  type expected = {
+    itodo:
+      | { wallOfText: string | null; id: string | number; __typename: 'BigTodo' }
+      | { maxLength: number | null; id: string | number; __typename: 'SmallTodo' };
+  };
+
+  expectTypeOf<expected>().toEqualTypeOf<actual>();
+});
+
 test('infers mutations', () => {
   type query = parseDocument</* GraphQL */ `
     mutation ($id: ID!, $input: TodoPayload!) {


### PR DESCRIPTION
Resolves #100

## Summary

This improves the type inference for two cases specifically.

When spreading a fragment of an interface (potentially itself) into an interface selection, the type wasn't narrowed even if we had the fragment available and were doing a submatch. This lead to poor type matches when a user wasn't specifying `__typename` above and below the spread although this isn't necessary, since we have all necessary type information.
We can generically solve this by keeping the `PossibleType` narrow, specifically by skipping `getSelection` and using `getPossibleTypeSelectionRec` directly.

Specifically, when using an **unmasked** fragment document and repeating the above a similar issue would occur. In such a case the type checker would be forced to accept two unions of two types that aren't mergeable.

There isn't a great solution for this without refactoring a whole lot and making output types less readable, while hurting performance in the process.
There is however a simple solution.

We now always attach a `__typename?: PossibleType` optional property to possible type selections. This attaches a type to match against for the type checker to merge all possible types’ selections.
While not the perfect solution, this shouldn't have any negative consequences.

- The property is optional, so unlikely to be freely used without being requested
- The property may explicitly become `never` when a branch is missing a typename providing a visual indicator that `__typename` isn't selected in all cases
- The property is already likely to be requested, and even if it's aliased, this should work correctly
- `__typename` is unlikely to be aliased (which we can also lint for), since it's a system field and unique in behaviour

## Set of changes

- Skip `getSelection` and use `getPossibleTypeSelectionRec` directly, where possible
  - Provide the narrowed `PossibleType` in nested fragment selections
- Add a `__typename?: PossibleType` property to possible type selections
- Add tests for these cases
