### PR TITLE
refactor: Merge type unwrapping for types into one step type aliases

### DIFF
--- a/.changeset/long-hornets-develop.md
+++ b/.changeset/long-hornets-develop.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Refactor type unwrapping for `NON_NULL` field types (with `@_optional` and `@_required`), input types, and variable types.


### PR DESCRIPTION
## Summary

Previously, to unwrap `NON_NULL`-like type references, we would have an outer type handling `T | null` for nullable types, and an inner type handling other refrences.
These two steps can be merged by adding an extra argument to the recursive parts of the type reference handler.

This should make some of these types more compact.

## Set of changes

- Merge `unwrapType` with `_unwrapTypeRec` into `unwrapTypeRec` in `selection.ts`
- Merge `unwrapType` with `_unwrapTypeRec` into `unwrapTypeRec` in `variables.ts`
- Merge `unwrapTypeRef` with `_unwrapTypeRefRec` into `unwrapTypeRefRec` in `variables.ts`
