### PR TITLE
refactor: Address bad document node inference pattern (perf-cliff)

### DIFF
--- a/.changeset/bright-beds-buy.md
+++ b/.changeset/bright-beds-buy.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Address performance cliff for `getDocumentNode` inference and object-flattening utilities

--- a/src/api.ts
+++ b/src/api.ts
@@ -302,15 +302,13 @@ export type getDocumentNode<
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any } = {},
   isMaskingDisabled = false,
-> = getDocumentType<Document, Introspection, Fragments> extends infer Result
-  ? Result extends never
-    ? never
-    : TadaDocumentNode<
-        Result,
-        getVariablesType<Document, Introspection>,
-        decorateFragmentDef<Document, isMaskingDisabled>
-      >
-  : never;
+> = getDocumentType<Document, Introspection, Fragments> extends never
+  ? never
+  : TadaDocumentNode<
+      getDocumentType<Document, Introspection, Fragments>,
+      getVariablesType<Document, Introspection>,
+      decorateFragmentDef<Document, isMaskingDisabled>
+    >;
 
 /** A GraphQL `DocumentNode` with attached types for results and variables.
  *

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,6 +1,6 @@
 import type { Kind } from '@0no-co/graphql.web';
 
-import type { obj, objValues } from './utils';
+import type { obj } from './utils';
 import type { DocumentNodeLike } from './parser';
 
 import type { $tada, makeUndefinedFragmentRef } from './namespace';
@@ -126,27 +126,25 @@ type getSelection<
   Type extends ObjectLikeType,
   Introspection extends IntrospectionLikeType,
   Fragments extends { [name: string]: any },
-> = obj<
-  Type extends { kind: 'UNION' | 'INTERFACE'; possibleTypes: any }
-    ? objValues<{
-        [PossibleType in Type['possibleTypes']]: getPossibleTypeSelectionRec<
-          Selections,
-          PossibleType,
-          Type,
-          Introspection,
-          Fragments,
-          // NOTE: This is technically incorrect as the field may not be selected. However:
-          // - The `__typename` field is reserved and we can reasonable expect a user not to alias to it
-          // - Marking the field as optional makes it clear that it cannot just be used
-          // - It protects against a very specific edge case where users forget to select `__typename`
-          //   above and below an unmasked fragment, causing TypeScript to show unmergeable types
-          { __typename?: PossibleType }
-        >;
-      }>
-    : Type extends { kind: 'OBJECT'; name: any }
-      ? getPossibleTypeSelectionRec<Selections, Type['name'], Type, Introspection, Fragments, {}>
-      : {}
->;
+> = Type extends { kind: 'UNION' | 'INTERFACE'; possibleTypes: any }
+  ? {
+      [PossibleType in Type['possibleTypes']]: getPossibleTypeSelectionRec<
+        Selections,
+        PossibleType,
+        Type,
+        Introspection,
+        Fragments,
+        // NOTE: This is technically incorrect as the field may not be selected. However:
+        // - The `__typename` field is reserved and we can reasonable expect a user not to alias to it
+        // - Marking the field as optional makes it clear that it cannot just be used
+        // - It protects against a very specific edge case where users forget to select `__typename`
+        //   above and below an unmasked fragment, causing TypeScript to show unmergeable types
+        { __typename?: PossibleType }
+      >;
+    }[Type['possibleTypes']]
+  : Type extends { kind: 'OBJECT'; name: any }
+    ? getPossibleTypeSelectionRec<Selections, Type['name'], Type, Introspection, Fragments, {}>
+    : {};
 
 type getPossibleTypeSelectionRec<
   Selections,
@@ -200,7 +198,7 @@ type getPossibleTypeSelectionRec<
           : {}) &
         SelectionAcc
     >
-  : SelectionAcc;
+  : obj<SelectionAcc>;
 
 type getOperationSelectionType<
   Definition,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,18 +14,7 @@ export type matchOr<Constraint, T, Fallback> = Constraint extends T
  * This is typically used to make a TypeScript type appear as a flat object,
  * both in terms of type checking and for type hints and the tsserver output.
  */
-export type obj<T> = T extends { [key: string | number]: any }
-  ? T extends infer U
-    ? { [K in keyof U]: U[K] }
-    : never
-  : never;
-
-/** Retrieves all non-nullish value types of an object dictionary. */
-export type objValues<T> = T[keyof T] extends infer U
-  ? U extends null | undefined | never | void
-    ? never
-    : U
-  : never;
+export type obj<T> = T extends { [key: string | number]: any } ? { [K in keyof T]: T[K] } : never;
 
 /** Marks all properties as writable */
 export type writable<T> = { -readonly [K in keyof T]: T[K] };


### PR DESCRIPTION
- Removed separated `extends infer Result ? Result extends ...` pattern` in favour of duplicating type alias
- Remove `objValues` since it's only used once for more direct pattern (**no discernible perf effect**)
- Simplify `obj` and move usage (**no discernible perf effect**)
