### PR TITLE
fix(cli): rename generate to generate-output

### DIFF
--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -53,7 +53,7 @@ function hasGraphQLSP(tsconfig: TsConfigJson): boolean {
 
 async function main() {
   prog
-    .command('generate')
+    .command('generate-output')
     .describe(
       'Generate the gql.tada types file, this will look for your "tsconfig.json" and use the "@0no-co/graphqlsp" configuration to generate the file.'
     )


### PR DESCRIPTION
This renames the command to generate-output so it's more in line with the RFC https://github.com/0no-co/gql.tada/issues/76