### PR TITLE
refactor: Add tokenizer phase to internal document parser

### DIFF
--- a/.changeset/real-goats-run.md
+++ b/.changeset/real-goats-run.md
@@ -2,4 +2,4 @@
 'gql.tada': patch
 ---
 
-Refactor internal GraphQL document parser to use a tokenizer phase
+Refactor internal GraphQL document parser to use a tokenizer phase, which further utilizes TypeScript’s tail recursion optimization. This should help to further improve type inference performance.

--- a/.changeset/real-goats-run.md
+++ b/.changeset/real-goats-run.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Refactor internal GraphQL document parser to use a tokenizer phase

--- a/src/__tests__/parser.bench.ts
+++ b/src/__tests__/parser.bench.ts
@@ -5,6 +5,7 @@ describe('Document', () => {
   (() => {
     const virtualHost = ts.createVirtualHost({
       ...ts.readVirtualModule('@0no-co/graphql.web'),
+      'tokenizer.ts': ts.readFileFromRoot('src/tokenizer.ts'),
       'parser.ts': ts.readFileFromRoot('src/parser.ts'),
       'index.ts': `
         import { parseDocument } from './parser';
@@ -27,6 +28,7 @@ describe('Document', () => {
     const virtualHost = ts.createVirtualHost({
       ...ts.readVirtualModule('@0no-co/graphql.web'),
       'kitchensinkQuery.ts': ts.readFileFromRoot('src/__tests__/fixtures/kitchensinkQuery.ts'),
+      'tokenizer.ts': ts.readFileFromRoot('src/tokenizer.ts'),
       'parser.ts': ts.readFileFromRoot('src/parser.ts'),
       'index.ts': `
         import { parseDocument } from './parser';

--- a/src/__tests__/parser.test-d.ts
+++ b/src/__tests__/parser.test-d.ts
@@ -237,7 +237,6 @@ describe('takeSelectionSet', () => {
     >;
 
     expectTypeOf<takeSelectionSet<tokenize<'{ ...On }'>>>().toEqualTypeOf<expected>();
-    expectTypeOf<takeSelectionSet<tokenize<'{ ...on }'>>>().toEqualTypeOf<void>();
   });
 });
 
@@ -414,7 +413,6 @@ describe('takeField', () => {
       []
     >;
 
-    expectTypeOf<takeField<tokenize<'field: '>>>().toEqualTypeOf<void>();
     expectTypeOf<takeField<tokenize<'alias: field('>>>().toEqualTypeOf<void>();
 
     expectTypeOf<

--- a/src/__tests__/parser.test-d.ts
+++ b/src/__tests__/parser.test-d.ts
@@ -493,9 +493,6 @@ describe('takeDirective', () => {
       []
     >;
 
-    expectTypeOf<takeDirective<tokenize<'@'>, false>>().toEqualTypeOf<void>();
-    expectTypeOf<takeDirective<tokenize<'@(test: null)'>, false>>().toEqualTypeOf<void>();
-
     expectTypeOf<takeDirective<tokenize<'@test(name: null)'>, false>>().toEqualTypeOf<expected>();
   });
 });

--- a/src/__tests__/parser.test-d.ts
+++ b/src/__tests__/parser.test-d.ts
@@ -12,9 +12,7 @@ import type {
   takeSelectionSet,
   takeOperationDefinition,
   takeFragmentDefinition,
-  takeFragmentSpread,
   takeDirective,
-  takeField,
 } from '../parser';
 
 describe('takeValue', () => {
@@ -362,107 +360,119 @@ describe('takeField', () => {
   it('parses fields', () => {
     type expected = _match<
       {
-        kind: Kind.FIELD;
-        arguments: [];
-        alias: {
-          kind: Kind.NAME;
-          value: 'alias';
-        };
-        name: {
-          kind: Kind.NAME;
-          value: 'field';
-        };
-        directives: [
+        kind: Kind.SELECTION_SET;
+        selections: [
           {
-            kind: Kind.DIRECTIVE;
+            kind: Kind.FIELD;
+            arguments: [];
+            alias: {
+              kind: Kind.NAME;
+              value: 'alias';
+            };
             name: {
               kind: Kind.NAME;
-              value: 'test';
+              value: 'field';
             };
-            arguments: [
+            directives: [
               {
-                kind: Kind.ARGUMENT;
+                kind: Kind.DIRECTIVE;
                 name: {
                   kind: Kind.NAME;
-                  value: 'arg';
+                  value: 'test';
                 };
-                value: {
-                  kind: Kind.NULL;
-                };
+                arguments: [
+                  {
+                    kind: Kind.ARGUMENT;
+                    name: {
+                      kind: Kind.NAME;
+                      value: 'arg';
+                    };
+                    value: {
+                      kind: Kind.NULL;
+                    };
+                  },
+                ];
               },
             ];
+            selectionSet: {
+              kind: Kind.SELECTION_SET;
+              selections: [
+                {
+                  kind: Kind.FIELD;
+                  name: {
+                    kind: Kind.NAME;
+                    value: 'child';
+                  };
+                  arguments: [];
+                  alias: undefined;
+                  selectionSet: undefined;
+                  directives: [];
+                },
+              ];
+            };
           },
         ];
-        selectionSet: {
-          kind: Kind.SELECTION_SET;
-          selections: [
-            {
-              kind: Kind.FIELD;
-              name: {
-                kind: Kind.NAME;
-                value: 'child';
-              };
-              arguments: [];
-              alias: undefined;
-              selectionSet: undefined;
-              directives: [];
-            },
-          ];
-        };
       },
       []
     >;
 
-    expectTypeOf<takeField<tokenize<'alias: field('>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ alias: field( }'>>>().toEqualTypeOf<void>();
 
     expectTypeOf<
-      takeField<tokenize<'alias: field @test(arg: null) { child }'>>
+      takeSelectionSet<tokenize<'{ alias: field @test(arg: null) { child } }'>>
     >().toEqualTypeOf<expected>();
   });
 
   it('parses arguments', () => {
     type expected = _match<
       {
-        kind: Kind.FIELD;
-        alias: undefined;
-        name: {
-          kind: Kind.NAME;
-          value: 'field';
-        };
-        arguments: [
+        kind: Kind.SELECTION_SET;
+        selections: [
           {
-            kind: Kind.ARGUMENT;
+            kind: Kind.FIELD;
+            alias: undefined;
             name: {
               kind: Kind.NAME;
-              value: 'a';
+              value: 'field';
             };
-            value: {
-              kind: Kind.NULL;
-            };
-          },
-          {
-            kind: Kind.ARGUMENT;
-            name: {
-              kind: Kind.NAME;
-              value: 'b';
-            };
-            value: {
-              kind: Kind.NULL;
-            };
+            arguments: [
+              {
+                kind: Kind.ARGUMENT;
+                name: {
+                  kind: Kind.NAME;
+                  value: 'a';
+                };
+                value: {
+                  kind: Kind.NULL;
+                };
+              },
+              {
+                kind: Kind.ARGUMENT;
+                name: {
+                  kind: Kind.NAME;
+                  value: 'b';
+                };
+                value: {
+                  kind: Kind.NULL;
+                };
+              },
+            ];
+            directives: [];
+            selectionSet: undefined;
           },
         ];
-        directives: [];
-        selectionSet: undefined;
       },
       []
     >;
 
-    expectTypeOf<takeField<tokenize<'field('>>>().toEqualTypeOf<void>();
-    expectTypeOf<takeField<tokenize<'field(name)'>>>().toEqualTypeOf<void>();
-    expectTypeOf<takeField<tokenize<'field(name:)'>>>().toEqualTypeOf<void>();
-    expectTypeOf<takeField<tokenize<'field(name: null'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ field( }'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ field(name) }'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ field(name:) }'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ field(name: null }'>>>().toEqualTypeOf<void>();
 
-    expectTypeOf<takeField<tokenize<'field(a: null, b: null)'>>>().toEqualTypeOf<expected>();
+    expectTypeOf<
+      takeSelectionSet<tokenize<'{ field(a: null, b: null) }'>>
+    >().toEqualTypeOf<expected>();
   });
 });
 
@@ -499,70 +509,82 @@ describe('takeFragmentSpread', () => {
   it('parses inline fragments', () => {
     type expected = _match<
       {
-        kind: Kind.INLINE_FRAGMENT;
-        typeCondition: {
-          kind: Kind.NAMED_TYPE;
-          name: {
-            kind: Kind.NAME;
-            value: 'Test';
-          };
-        };
-        directives: [];
-        selectionSet: {
-          kind: Kind.SELECTION_SET;
-          selections: [
-            {
-              kind: Kind.FIELD;
+        kind: Kind.SELECTION_SET;
+        selections: [
+          {
+            kind: Kind.INLINE_FRAGMENT;
+            typeCondition: {
+              kind: Kind.NAMED_TYPE;
               name: {
                 kind: Kind.NAME;
-                value: 'field';
+                value: 'Test';
               };
-              arguments: [];
-              alias: undefined;
-              selectionSet: undefined;
-              directives: [];
-            },
-          ];
-        };
+            };
+            directives: [];
+            selectionSet: {
+              kind: Kind.SELECTION_SET;
+              selections: [
+                {
+                  kind: Kind.FIELD;
+                  name: {
+                    kind: Kind.NAME;
+                    value: 'field';
+                  };
+                  arguments: [];
+                  alias: undefined;
+                  selectionSet: undefined;
+                  directives: [];
+                },
+              ];
+            };
+          },
+        ];
       },
       []
     >;
 
-    expectTypeOf<takeFragmentSpread<tokenize<'... on Test'>>>().toEqualTypeOf<void>();
-    expectTypeOf<takeFragmentSpread<tokenize<'...'>>>().toEqualTypeOf<void>();
-    expectTypeOf<takeFragmentSpread<tokenize<'... on Test { field }'>>>().toEqualTypeOf<expected>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ ... on Test }'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ ... }'>>>().toEqualTypeOf<void>();
+    expectTypeOf<
+      takeSelectionSet<tokenize<'{ ... on Test { field } }'>>
+    >().toEqualTypeOf<expected>();
   });
 
   it('parses conditionless inline fragments', () => {
     type expected = _match<
       {
-        kind: Kind.INLINE_FRAGMENT;
-        typeCondition: undefined;
-        directives: [];
-        selectionSet: {
-          kind: Kind.SELECTION_SET;
-          selections: [
-            {
-              kind: Kind.FIELD;
-              name: {
-                kind: Kind.NAME;
-                value: 'field';
-              };
-              arguments: [];
-              alias: undefined;
-              selectionSet: undefined;
-              directives: [];
-            },
-          ];
-        };
+        kind: Kind.SELECTION_SET;
+        selections: [
+          {
+            kind: Kind.INLINE_FRAGMENT;
+            typeCondition: undefined;
+            directives: [];
+            selectionSet: {
+              kind: Kind.SELECTION_SET;
+              selections: [
+                {
+                  kind: Kind.FIELD;
+                  name: {
+                    kind: Kind.NAME;
+                    value: 'field';
+                  };
+                  arguments: [];
+                  alias: undefined;
+                  selectionSet: undefined;
+                  directives: [];
+                },
+              ];
+            };
+          },
+        ];
       },
       []
     >;
 
-    expectTypeOf<takeFragmentSpread<tokenize<'... on Test'>>>().toEqualTypeOf<void>();
-    expectTypeOf<takeFragmentSpread<tokenize<'...'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ ... on Test }'>>>().toEqualTypeOf<void>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ ... }'>>>().toEqualTypeOf<void>();
 
-    expectTypeOf<takeFragmentSpread<tokenize<'... { field }'>>>().toEqualTypeOf<expected>();
+    expectTypeOf<takeSelectionSet<tokenize<'{ ... { field } }'>>>().toEqualTypeOf<expected>();
   });
 });
 

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -12,6 +12,7 @@ testTypeHost('parses kitchen sink query (%o)', (options) => {
     ...ts.readVirtualModule('@0no-co/graphql.web'),
     'kitchensinkQuery.ts': ts.readFileFromRoot('src/__tests__/fixtures/kitchensinkQuery.ts'),
     'parser.ts': ts.readFileFromRoot('src/parser.ts'),
+    'tokenizer.ts': ts.readFileFromRoot('src/tokenizer.ts'),
     'index.ts': `
       import { expectTypeOf } from 'expect-type';
       import { kitchensinkQuery, kitchensinkDocument } from './kitchensinkQuery';

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -3,14 +3,13 @@ import type { Token, tokenize } from '../tokenizer';
 
 describe('tokenize', () => {
   it('tokenizes symbols', () => {
-    type actual = tokenize<'... ! = : $ @ { } ( ) [ ]'>;
+    type actual = tokenize<'... ! = : @ { } ( ) [ ]'>;
 
     type expected = [
       Token.Spread,
       Token.Exclam,
       Token.Equal,
       Token.Colon,
-      Token.Dollar,
       Token.AtSign,
       Token.BraceOpen,
       Token.BraceClose,
@@ -49,7 +48,13 @@ describe('tokenize', () => {
 
   it('tokenizes names', () => {
     type actual = tokenize<'test x'>;
-    type expected = [{ kind: Token.Name; name: 'test' }];
+    type expected = [{ kind: Token.Name; name: 'test' }, { kind: Token.Name; name: 'x' }];
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('tokenizes variables', () => {
+    type actual = tokenize<'$test $x'>;
+    type expected = [{ kind: Token.Var; name: 'test' }, { kind: Token.Var; name: 'x' }];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 });

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -1,0 +1,61 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { Token, tokenize, AnonymousTokenNode } from '../tokenizer';
+
+describe('tokenize', () => {
+  it('tokenizes symbols', () => {
+    type actual = tokenize<'... ! = : $ @ { } ( ) [ ]'>;
+
+    type expected = [
+      AnonymousTokenNode<Token.Spread>,
+      AnonymousTokenNode<Token.Exclam>,
+      AnonymousTokenNode<Token.Equal>,
+      AnonymousTokenNode<Token.Colon>,
+      AnonymousTokenNode<Token.Dollar>,
+      AnonymousTokenNode<Token.AtSign>,
+      AnonymousTokenNode<Token.BraceOpen>,
+      AnonymousTokenNode<Token.BraceClose>,
+      AnonymousTokenNode<Token.ParenOpen>,
+      AnonymousTokenNode<Token.ParenClose>,
+      AnonymousTokenNode<Token.BracketOpen>,
+      AnonymousTokenNode<Token.BracketClose>,
+    ];
+
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('tokenizes integers', () => {
+    type actual = tokenize<'-1 1'>;
+
+    type expected = [AnonymousTokenNode<Token.Integer>, AnonymousTokenNode<Token.Integer>];
+
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('tokenizes floats', () => {
+    type actual = tokenize<'1.0 1e2 1.0E-2'>;
+
+    type expected = [
+      AnonymousTokenNode<Token.Float>,
+      AnonymousTokenNode<Token.Float>,
+      AnonymousTokenNode<Token.Float>,
+    ];
+
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('tokenizes strings', () => {
+    type actual = tokenize<'"x" "\\""'>;
+
+    type expected = [AnonymousTokenNode<Token.String>, AnonymousTokenNode<Token.String>];
+
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('tokenizes block strings', () => {
+    type actual = tokenize<'"""x""" """\\""""""'>;
+
+    type expected = [AnonymousTokenNode<Token.BlockString>, AnonymousTokenNode<Token.BlockString>];
+
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+});

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -3,14 +3,13 @@ import type { Token, tokenize } from '../tokenizer';
 
 describe('tokenize', () => {
   it('tokenizes symbols', () => {
-    type actual = tokenize<'... ! = : @ { } ( ) [ ]'>;
+    type actual = tokenize<'... ! = : { } ( ) [ ]'>;
 
     type expected = [
       Token.Spread,
       Token.Exclam,
       Token.Equal,
       Token.Colon,
-      Token.AtSign,
       Token.BraceOpen,
       Token.BraceClose,
       Token.ParenOpen,
@@ -55,6 +54,12 @@ describe('tokenize', () => {
   it('tokenizes variables', () => {
     type actual = tokenize<'$test $x'>;
     type expected = [{ kind: Token.Var; name: 'test' }, { kind: Token.Var; name: 'x' }];
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('tokenizes directives', () => {
+    type actual = tokenize<'@test @x'>;
+    type expected = [{ kind: Token.Directive; name: 'test' }, { kind: Token.Directive; name: 'x' }];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 });

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -1,23 +1,23 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type { Token, tokenize, AnonymousTokenNode } from '../tokenizer';
+import type { Token, tokenize } from '../tokenizer';
 
 describe('tokenize', () => {
   it('tokenizes symbols', () => {
     type actual = tokenize<'... ! = : $ @ { } ( ) [ ]'>;
 
     type expected = [
-      AnonymousTokenNode<Token.Spread>,
-      AnonymousTokenNode<Token.Exclam>,
-      AnonymousTokenNode<Token.Equal>,
-      AnonymousTokenNode<Token.Colon>,
-      AnonymousTokenNode<Token.Dollar>,
-      AnonymousTokenNode<Token.AtSign>,
-      AnonymousTokenNode<Token.BraceOpen>,
-      AnonymousTokenNode<Token.BraceClose>,
-      AnonymousTokenNode<Token.ParenOpen>,
-      AnonymousTokenNode<Token.ParenClose>,
-      AnonymousTokenNode<Token.BracketOpen>,
-      AnonymousTokenNode<Token.BracketClose>,
+      Token.Spread,
+      Token.Exclam,
+      Token.Equal,
+      Token.Colon,
+      Token.Dollar,
+      Token.AtSign,
+      Token.BraceOpen,
+      Token.BraceClose,
+      Token.ParenOpen,
+      Token.ParenClose,
+      Token.BracketOpen,
+      Token.BracketClose,
     ];
 
     expectTypeOf<actual>().toEqualTypeOf<expected>();
@@ -25,37 +25,31 @@ describe('tokenize', () => {
 
   it('tokenizes integers', () => {
     type actual = tokenize<'-1 1'>;
-
-    type expected = [AnonymousTokenNode<Token.Integer>, AnonymousTokenNode<Token.Integer>];
-
+    type expected = [Token.Integer, Token.Integer];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 
   it('tokenizes floats', () => {
     type actual = tokenize<'1.0 1e2 1.0E-2'>;
-
-    type expected = [
-      AnonymousTokenNode<Token.Float>,
-      AnonymousTokenNode<Token.Float>,
-      AnonymousTokenNode<Token.Float>,
-    ];
-
+    type expected = [Token.Float, Token.Float, Token.Float];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 
   it('tokenizes strings', () => {
     type actual = tokenize<'"x" "\\""'>;
-
-    type expected = [AnonymousTokenNode<Token.String>, AnonymousTokenNode<Token.String>];
-
+    type expected = [Token.String, Token.String];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 
   it('tokenizes block strings', () => {
     type actual = tokenize<'"""x""" """\\""""""'>;
+    type expected = [Token.BlockString, Token.BlockString];
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
 
-    type expected = [AnonymousTokenNode<Token.BlockString>, AnonymousTokenNode<Token.BlockString>];
-
+  it('tokenizes names', () => {
+    type actual = tokenize<'test'>;
+    type expected = [{ kind: Token.Name; name: 'test' }];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 });

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -48,7 +48,7 @@ describe('tokenize', () => {
   });
 
   it('tokenizes names', () => {
-    type actual = tokenize<'test'>;
+    type actual = tokenize<'test x'>;
     type expected = [{ kind: Token.Name; name: 'test' }];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,194 +1,140 @@
 import type { Kind, OperationTypeNode } from '@0no-co/graphql.web';
+import type { Token, tokenize } from './tokenizer';
 
-type digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+export interface _match<Out, In extends any[]> {
+  out: Out;
+  in: In;
+}
+
+interface _match2<OutA, OutB, In extends any[]> {
+  outA: OutA;
+  outB: OutB;
+  in: In;
+}
+
+type takeName<In extends any[]> = In extends [{ kind: Token.Name; name: infer Name }, ...infer In]
+  ? _match<{ kind: Kind.NAME; value: Name }, In>
+  : void;
+
+type takeOptionalName<In extends any[]> = In extends [
+  { kind: Token.Name; name: infer Name },
+  ...infer In,
+]
+  ? _match<{ kind: Kind.NAME; value: Name }, In>
+  : _match<undefined, In>;
 
 // prettier-ignore
-type letter =
-  | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M'
-  | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
-  | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
-  | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
-
-type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
-  ? skipIgnored<In>
-  : In extends `${' ' | '\n' | '\t' | '\r' | ',' | '\ufeff'}${infer In}`
-    ? skipIgnored<In>
-    : In extends string
-      ? In
-      : never;
-
-type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
-type skipInt<In> = In extends `${'-'}${digit}${infer In}`
-  ? skipDigits<In>
-  : In extends `${digit}${infer In}`
-    ? skipDigits<In>
+export type takeValue<In extends any[], Const extends boolean> =
+  In extends [Token.Float, ...infer In] ? _match<{ kind: Kind.FLOAT; value: string }, In>
+  : In extends [Token.Integer, ...infer In] ? _match<{ kind: Kind.INT; value: string }, In>
+  : In extends [Token.String, ...infer In] ? _match<{ kind: Kind.STRING; value: string, block: false }, In>
+  : In extends [Token.BlockString, ...infer In] ? _match<{ kind: Kind.STRING; value: string, block: true }, In>
+  : In extends [{ kind: Token.Name, name: 'null' }, ...infer In] ? _match<{ kind: Kind.NULL }, In>
+  : In extends [{ kind: Token.Name, name: 'true' | 'false' }, ...infer In] ? _match<{ kind: Kind.BOOLEAN; value: boolean }, In>
+  : In extends [{ kind: Token.Name, name: infer Name }, ...infer In] ? _match<{ kind: Kind.ENUM; value: Name }, In>
+  : In extends [Token.BracketOpen, ...infer In] ? takeListRec<[], In, Const>
+  : In extends [Token.BraceOpen, ...infer In] ? takeObjectRec<[], In, Const>
+  : Const extends false
+    ? In extends [{ kind: Token.Var, name: infer Name }, ...infer In]
+      ? _match<{ kind: Kind.VARIABLE; name: { kind: Kind.NAME; value: Name } }, In>
+      : void
     : void;
 
-type skipExponent<In> = In extends `${'e' | 'E'}${'+' | '-'}${infer In}`
-  ? skipDigits<In>
-  : In extends `${'e' | 'E'}${infer In}`
-    ? skipDigits<In>
-    : In;
-type skipFloat<In> = In extends `${'.'}${infer In}`
-  ? In extends `${digit}${infer In}`
-    ? skipExponent<skipDigits<In>>
-    : void
-  : In extends `${'e' | 'E'}${infer _}`
-    ? skipExponent<In>
+type takeListRec<Nodes extends any[], In extends any[], Const extends boolean> = In extends [
+  Token.BracketClose,
+  ...infer In,
+]
+  ? _match<{ kind: Kind.LIST; values: Nodes }, In>
+  : takeValue<In, Const> extends _match<infer Node, infer In>
+    ? takeListRec<[...Nodes, Node], In, Const>
     : void;
 
-type skipBlockString<In> = In extends `${infer Hd}${'"""'}${infer In}`
-  ? Hd extends `${infer _}${'\\'}`
-    ? skipBlockString<skipIgnored<In>>
-    : In
-  : void;
-type skipString<In> = In extends `${infer Hd}${'"'}${infer In}`
-  ? Hd extends `${infer _}${'\\'}`
-    ? skipString<In>
-    : In
-  : void;
-
-type _takeNameLiteralRec<PrevMatch extends string, In> = In extends `${infer Match}${infer Out}`
-  ? Match extends letter | digit | '_'
-    ? _takeNameLiteralRec<`${PrevMatch}${Match}`, Out>
-    : [PrevMatch, In]
-  : [PrevMatch, In];
-type takeNameLiteral<In> = In extends `${infer Match}${infer In}`
-  ? Match extends letter | '_'
-    ? _takeNameLiteralRec<Match, In>
+type takeObjectField<In extends any[], Const extends boolean> = In extends [
+  { kind: Token.Name; name: infer FieldName },
+  Token.Colon,
+  ...infer In,
+]
+  ? takeValue<In, Const> extends _match<infer Value, infer In>
+    ? _match<
+        { kind: Kind.OBJECT_FIELD; name: { kind: Kind.NAME; value: FieldName }; value: Value },
+        In
+      >
     : void
   : void;
 
-type takeName<In> = takeNameLiteral<In> extends [infer Out, infer In]
-  ? [{ kind: Kind.NAME; value: Out }, In]
-  : void;
+export type takeObjectRec<
+  Fields extends any[],
+  In extends any[],
+  Const extends boolean,
+> = In extends [Token.BraceClose, ...infer In]
+  ? _match<{ kind: Kind.OBJECT; fields: Fields }, In>
+  : takeObjectField<In, Const> extends _match<infer Field, infer In>
+    ? takeObjectRec<[...Fields, Field], In, Const>
+    : void;
 
-type takeOptionalName<In> = takeNameLiteral<In> extends [infer Out, infer In]
-  ? [{ kind: Kind.NAME; value: Out }, In]
-  : [undefined, In];
-
-type takeEnum<In> = takeNameLiteral<In> extends [infer Out, infer In]
-  ? [{ kind: Kind.ENUM; value: Out }, In]
-  : void;
-
-type TakeVariable<In, Const> = Const extends false
-  ? In extends `${'$'}${infer In}`
-    ? takeNameLiteral<In> extends [infer Out, infer In]
-      ? [{ kind: Kind.VARIABLE; name: { kind: Kind.NAME; value: Out } }, In]
+type takeArgument<In extends any[], Const extends boolean> = takeName<In> extends _match<
+  infer Name,
+  infer In
+>
+  ? In extends [Token.Colon, ...infer In]
+    ? takeValue<In, Const> extends _match<infer Value, infer In>
+      ? _match<{ kind: Kind.ARGUMENT; name: Name; value: Value }, In>
       : void
     : void
   : void;
 
-type takeNumber<In> = skipInt<In> extends `${infer In}`
-  ? skipFloat<In> extends `${infer In}`
-    ? [{ kind: Kind.FLOAT; value: string }, In]
-    : [{ kind: Kind.INT; value: string }, In]
-  : void;
-
-type takeString<In> = In extends `${'"""'}${infer In}`
-  ? skipBlockString<In> extends `${infer In}`
-    ? [{ kind: Kind.STRING; value: string; block: true }, In]
-    : void
-  : In extends `${'"'}${infer In}`
-    ? skipString<In> extends `${infer In}`
-      ? [{ kind: Kind.STRING; value: string; block: false }, In]
-      : void
+type _takeArgumentsRec<
+  Arguments extends any[],
+  In extends any[],
+  Const extends boolean,
+> = In extends [Token.ParenClose, ...infer In]
+  ? _match<Arguments, In>
+  : takeArgument<In, Const> extends _match<infer Argument, infer In>
+    ? _takeArgumentsRec<[...Arguments, Argument], In, Const>
     : void;
+export type takeArguments<In extends any[], Const extends boolean> = In extends [
+  Token.ParenOpen,
+  ...infer In,
+]
+  ? _takeArgumentsRec<[], In, Const>
+  : _match<[], In>;
 
-type takeLiteral<In> = In extends `${'null'}${infer In}`
-  ? [{ kind: Kind.NULL }, In]
-  : In extends `${'true' | 'false'}${infer In}`
-    ? [{ kind: Kind.BOOLEAN; value: boolean }, In]
-    : void;
-
-export type takeValue<In, Const> = takeLiteral<In> extends [infer Node, infer Rest]
-  ? [Node, Rest]
-  : TakeVariable<In, Const> extends [infer Node, infer Rest]
-    ? [Node, Rest]
-    : takeNumber<In> extends [infer Node, infer Rest]
-      ? [Node, Rest]
-      : takeEnum<In> extends [infer Node, infer Rest]
-        ? [Node, Rest]
-        : takeString<In> extends [infer Node, infer Rest]
-          ? [Node, Rest]
-          : takeList<In, Const> extends [infer Node, infer Rest]
-            ? [Node, Rest]
-            : takeObject<In, Const> extends [infer Node, infer Rest]
-              ? [Node, Rest]
-              : void;
-
-type _takeListRec<Nodes extends any[], In, Const> = In extends `${']'}${infer In}`
-  ? [{ kind: Kind.LIST; values: Nodes }, In]
-  : takeValue<skipIgnored<In>, Const> extends [infer Node, infer In]
-    ? _takeListRec<[...Nodes, Node], skipIgnored<In>, Const>
-    : void;
-export type takeList<In, Const> = In extends `${'['}${infer In}`
-  ? _takeListRec<[], skipIgnored<In>, Const>
-  : void;
-
-type takeObjectField<In, Const> = takeName<In> extends [infer Name, infer In]
-  ? skipIgnored<In> extends `${':'}${infer In}`
-    ? takeValue<skipIgnored<In>, Const> extends [infer Value, infer In]
-      ? [{ kind: Kind.OBJECT_FIELD; name: Name; value: Value }, In]
+export type takeDirective<In extends any[], Const extends boolean> = In extends [
+  Token.AtSign,
+  ...infer In,
+]
+  ? takeName<In> extends _match<infer Name, infer In>
+    ? takeArguments<In, Const> extends _match<infer Arguments, infer In>
+      ? _match<{ kind: Kind.DIRECTIVE; name: Name; arguments: Arguments }, In>
       : void
     : void
   : void;
 
-export type _takeObjectRec<Fields extends any[], In, Const> = In extends `${'}'}${infer In}`
-  ? [{ kind: Kind.OBJECT; fields: Fields }, In]
-  : takeObjectField<skipIgnored<In>, Const> extends [infer Field, infer In]
-    ? _takeObjectRec<[...Fields, Field], skipIgnored<In>, Const>
-    : void;
-type takeObject<In, Const> = In extends `${'{'}${infer In}`
-  ? _takeObjectRec<[], skipIgnored<In>, Const>
-  : void;
+export type takeDirectives<
+  In extends any[],
+  Const extends boolean,
+  Directives extends any[] = [],
+> = takeDirective<In, Const> extends _match<infer Directive, infer In>
+  ? takeDirectives<In, Const, [...Directives, Directive]>
+  : _match<Directives, In>;
 
-type takeArgument<In, Const> = takeName<In> extends [infer Name, infer In]
-  ? skipIgnored<In> extends `${':'}${infer In}`
-    ? takeValue<skipIgnored<In>, Const> extends [infer Value, infer In]
-      ? [{ kind: Kind.ARGUMENT; name: Name; value: Value }, In]
+type takeFieldName<In extends any[]> = takeName<In> extends _match<infer MaybeAlias, infer In>
+  ? In extends [Token.Colon, ...infer In]
+    ? takeName<In> extends _match<infer Name, infer In>
+      ? _match2<MaybeAlias, Name, In>
       : void
-    : void
+    : _match2<undefined, MaybeAlias, In>
   : void;
 
-type _takeArgumentsRec<Arguments extends any[], In, Const> = In extends `${')'}${infer In}`
-  ? Arguments extends []
-    ? void
-    : [Arguments, In]
-  : takeArgument<In, Const> extends [infer Argument, infer In]
-    ? _takeArgumentsRec<[...Arguments, Argument], skipIgnored<In>, Const>
-    : void;
-export type takeArguments<In, Const> = In extends `${'('}${infer In}`
-  ? _takeArgumentsRec<[], skipIgnored<In>, Const>
-  : [[], In];
-
-export type takeDirective<In, Const> = In extends `${'@'}${infer In}`
-  ? takeName<In> extends [infer Name, infer In]
-    ? takeArguments<skipIgnored<In>, Const> extends [infer Arguments, infer In]
-      ? [{ kind: Kind.DIRECTIVE; name: Name; arguments: Arguments }, In]
-      : void
-    : void
-  : void;
-
-export type takeDirectives<In, Const> = takeDirective<In, Const> extends [infer Directive, infer In]
-  ? takeDirectives<skipIgnored<In>, Const> extends [[...infer Directives], infer In]
-    ? [[Directive, ...Directives], In]
-    : [[], In]
-  : [[], In];
-
-type takeFieldName<In> = takeName<In> extends [infer MaybeAlias, infer In]
-  ? skipIgnored<In> extends `${':'}${infer In}`
-    ? takeName<skipIgnored<In>> extends [infer Name, infer In]
-      ? [MaybeAlias, Name, In]
-      : void
-    : [undefined, MaybeAlias, In]
-  : void;
-
-export type takeField<In> = takeFieldName<In> extends [infer Alias, infer Name, infer In]
-  ? takeArguments<skipIgnored<In>, false> extends [infer Arguments, infer In]
-    ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
-      ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
-        ? [
+export type takeField<In extends any[]> = takeFieldName<In> extends _match2<
+  infer Alias,
+  infer Name,
+  infer In
+>
+  ? takeArguments<In, false> extends _match<infer Arguments, infer In>
+    ? takeDirectives<In, false> extends _match<infer Directives, infer In>
+      ? takeSelectionSet<In> extends _match<infer SelectionSet, infer In>
+        ? _match<
             {
               kind: Kind.FIELD;
               alias: Alias;
@@ -197,9 +143,9 @@ export type takeField<In> = takeFieldName<In> extends [infer Alias, infer Name, 
               directives: Directives;
               selectionSet: SelectionSet;
             },
-            In,
-          ]
-        : [
+            In
+          >
+        : _match<
             {
               kind: Kind.FIELD;
               alias: Alias;
@@ -208,129 +154,143 @@ export type takeField<In> = takeFieldName<In> extends [infer Alias, infer Name, 
               directives: Directives;
               selectionSet: undefined;
             },
-            In,
-          ]
+            In
+          >
       : void
     : void
   : void;
 
-export type takeType<In> = In extends `${'['}${infer In}`
-  ? takeType<skipIgnored<In>> extends [infer Subtype, infer In]
-    ? In extends `${']'}${infer In}`
-      ? skipIgnored<In> extends `${'!'}${infer In}`
-        ? [{ kind: Kind.NON_NULL_TYPE; type: { kind: Kind.LIST_TYPE; type: Subtype } }, In]
-        : [{ kind: Kind.LIST_TYPE; type: Subtype }, In]
+export type takeType<In extends any[]> = In extends [Token.BracketOpen, ...infer In]
+  ? takeType<In> extends _match<infer Subtype, infer In>
+    ? In extends [Token.BracketClose, ...infer In]
+      ? In extends [Token.Exclam, ...infer In]
+        ? _match<{ kind: Kind.NON_NULL_TYPE; type: { kind: Kind.LIST_TYPE; type: Subtype } }, In>
+        : _match<{ kind: Kind.LIST_TYPE; type: Subtype }, In>
       : void
     : void
-  : takeName<skipIgnored<In>> extends [infer Name, infer In]
-    ? skipIgnored<In> extends `${'!'}${infer In}`
-      ? [{ kind: Kind.NON_NULL_TYPE; type: { kind: Kind.NAMED_TYPE; name: Name } }, In]
-      : [{ kind: Kind.NAMED_TYPE; name: Name }, In]
+  : takeName<In> extends _match<infer Name, infer In>
+    ? In extends [Token.Exclam, ...infer In]
+      ? _match<{ kind: Kind.NON_NULL_TYPE; type: { kind: Kind.NAMED_TYPE; name: Name } }, In>
+      : _match<{ kind: Kind.NAMED_TYPE; name: Name }, In>
     : void;
 
-type takeTypeCondition<In> = In extends `${'on'}${infer In}`
-  ? takeName<skipIgnored<In>> extends [infer Name, infer In]
-    ? [{ kind: Kind.NAMED_TYPE; name: Name }, In]
+type takeTypeCondition<In extends any[]> = In extends [
+  { kind: Token.Name; name: 'on' },
+  ...infer In,
+]
+  ? takeName<In> extends _match<infer Name, infer In>
+    ? _match<{ kind: Kind.NAMED_TYPE; name: Name }, In>
     : void
   : void;
 
-export type takeFragmentSpread<In> = In extends `${'...'}${infer In}`
-  ? skipIgnored<In> extends `${'on'}${infer In}`
-    ? takeName<skipIgnored<In>> extends [infer Name, infer In]
-      ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
-        ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
-          ? [
+export type takeFragmentSpread<In extends any[]> = In extends [Token.Spread, ...infer In]
+  ? In extends [{ kind: Token.Name; name: 'on' }, ...infer In]
+    ? takeName<In> extends _match<infer Name, infer In>
+      ? takeDirectives<In, false> extends _match<infer Directives, infer In>
+        ? takeSelectionSet<In> extends _match<infer SelectionSet, infer In>
+          ? _match<
               {
                 kind: Kind.INLINE_FRAGMENT;
                 typeCondition: { kind: Kind.NAMED_TYPE; name: Name };
                 directives: Directives;
                 selectionSet: SelectionSet;
               },
-              In,
-            ]
+              In
+            >
           : void
         : void
       : void
-    : takeName<skipIgnored<In>> extends [infer Name, infer In]
-      ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
-        ? [{ kind: Kind.FRAGMENT_SPREAD; name: Name; directives: Directives }, In]
+    : takeName<In> extends _match<infer Name, infer In>
+      ? takeDirectives<In, false> extends _match<infer Directives, infer In>
+        ? _match<{ kind: Kind.FRAGMENT_SPREAD; name: Name; directives: Directives }, In>
         : void
-      : takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
-        ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
-          ? [
+      : takeDirectives<In, false> extends _match<infer Directives, infer In>
+        ? takeSelectionSet<In> extends _match<infer SelectionSet, infer In>
+          ? _match<
               {
                 kind: Kind.INLINE_FRAGMENT;
                 typeCondition: undefined;
                 directives: Directives;
                 selectionSet: SelectionSet;
               },
-              In,
-            ]
+              In
+            >
           : void
         : void
   : void;
 
-type _takeSelectionRec<Selections extends any[], In> = In extends `${'}'}${infer In}`
-  ? [{ kind: Kind.SELECTION_SET; selections: Selections }, In]
-  : takeFragmentSpread<skipIgnored<In>> extends [infer Selection, infer In]
-    ? _takeSelectionRec<[...Selections, Selection], skipIgnored<In>>
-    : takeField<skipIgnored<In>> extends [infer Selection, infer In]
-      ? _takeSelectionRec<[...Selections, Selection], skipIgnored<In>>
+type _takeSelectionRec<Selections extends any[], In extends any[]> = In extends [
+  Token.BraceClose,
+  ...infer In,
+]
+  ? _match<{ kind: Kind.SELECTION_SET; selections: Selections }, In>
+  : takeFragmentSpread<In> extends _match<infer Selection, infer In>
+    ? _takeSelectionRec<[...Selections, Selection], In>
+    : takeField<In> extends _match<infer Selection, infer In>
+      ? _takeSelectionRec<[...Selections, Selection], In>
       : void;
 
-export type takeSelectionSet<In> = In extends `${'{'}${infer In}`
-  ? _takeSelectionRec<[], skipIgnored<In>>
+export type takeSelectionSet<In extends any[]> = In extends [Token.BraceOpen, ...infer In]
+  ? _takeSelectionRec<[], In>
   : void;
 
-export type takeVarDefinition<In> = TakeVariable<In, false> extends [infer Variable, infer In]
-  ? skipIgnored<In> extends `${':'}${infer In}`
-    ? takeType<skipIgnored<In>> extends [infer Type, infer In]
-      ? skipIgnored<In> extends `${'='}${infer In}`
-        ? takeValue<skipIgnored<In>, true> extends [infer DefaultValue, infer In]
-          ? takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
-            ? [
-                {
-                  kind: Kind.VARIABLE_DEFINITION;
-                  variable: Variable;
-                  type: Type;
-                  defaultValue: DefaultValue;
-                  directives: Directives;
-                },
-                In,
-              ]
-            : void
-          : void
-        : takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
-          ? [
+export type takeVarDefinition<In extends any[]> = In extends [
+  { kind: Token.Var; name: infer VarName },
+  Token.Colon,
+  ...infer In,
+]
+  ? takeType<In> extends _match<infer Type, infer In>
+    ? In extends [Token.Equal, ...infer In]
+      ? takeValue<In, true> extends _match<infer DefaultValue, infer In>
+        ? takeDirectives<In, true> extends _match<infer Directives, infer In>
+          ? _match<
               {
                 kind: Kind.VARIABLE_DEFINITION;
-                variable: Variable;
+                variable: { kind: Kind.VARIABLE; name: { kind: Kind.NAME; value: VarName } };
                 type: Type;
-                defaultValue: undefined;
+                defaultValue: DefaultValue;
                 directives: Directives;
               },
-              In,
-            ]
+              In
+            >
           : void
-      : void
+        : void
+      : takeDirectives<In, true> extends _match<infer Directives, infer In>
+        ? _match<
+            {
+              kind: Kind.VARIABLE_DEFINITION;
+              variable: { kind: Kind.VARIABLE; name: { kind: Kind.NAME; value: VarName } };
+              type: Type;
+              defaultValue: undefined;
+              directives: Directives;
+            },
+            In
+          >
+        : void
     : void
   : void;
 
-type _takeVarDefinitionRec<Definitions extends any[], In> = In extends `${')'}${infer In}`
-  ? [Definitions, In]
-  : takeVarDefinition<In> extends [infer Definition, infer In]
-    ? _takeVarDefinitionRec<[...Definitions, Definition], skipIgnored<In>>
+type _takeVarDefinitionRec<Definitions extends any[], In extends any[]> = In extends [
+  Token.ParenClose,
+  ...infer In,
+]
+  ? _match<Definitions, In>
+  : takeVarDefinition<In> extends _match<infer Definition, infer In>
+    ? _takeVarDefinitionRec<[...Definitions, Definition], In>
     : void;
-export type takeVarDefinitions<In> = skipIgnored<In> extends `${'('}${infer In}`
-  ? _takeVarDefinitionRec<[], skipIgnored<In>>
-  : [[], In];
+export type takeVarDefinitions<In extends any[]> = In extends [Token.ParenOpen, ...infer In]
+  ? _takeVarDefinitionRec<[], In>
+  : _match<[], In>;
 
-export type takeFragmentDefinition<In> = In extends `${'fragment'}${infer In}`
-  ? takeName<skipIgnored<In>> extends [infer Name, infer In]
-    ? takeTypeCondition<skipIgnored<In>> extends [infer TypeCondition, infer In]
-      ? takeDirectives<skipIgnored<In>, true> extends [infer Directives, infer In]
-        ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
-          ? [
+export type takeFragmentDefinition<In extends any[]> = In extends [
+  { kind: Token.Name; name: 'fragment' },
+  ...infer In,
+]
+  ? takeName<In> extends _match<infer Name, infer In>
+    ? takeTypeCondition<In> extends _match<infer TypeCondition, infer In>
+      ? takeDirectives<In, true> extends _match<infer Directives, infer In>
+        ? takeSelectionSet<In> extends _match<infer SelectionSet, infer In>
+          ? _match<
               {
                 kind: Kind.FRAGMENT_DEFINITION;
                 name: Name;
@@ -338,28 +298,31 @@ export type takeFragmentDefinition<In> = In extends `${'fragment'}${infer In}`
                 directives: Directives;
                 selectionSet: SelectionSet;
               },
-              In,
-            ]
+              In
+            >
           : void
         : void
       : void
     : void
   : void;
 
-type TakeOperation<In> = In extends `${'query'}${infer In}`
-  ? [OperationTypeNode.QUERY, In]
-  : In extends `${'mutation'}${infer In}`
-    ? [OperationTypeNode.MUTATION, In]
-    : In extends `${'subscription'}${infer In}`
-      ? [OperationTypeNode.SUBSCRIPTION, In]
+type takeOperation<In extends any[]> = In extends [{ kind: Token.Name; name: 'query' }, ...infer In]
+  ? _match<OperationTypeNode.QUERY, In>
+  : In extends [{ kind: Token.Name; name: 'mutation' }, ...infer In]
+    ? _match<OperationTypeNode.MUTATION, In>
+    : In extends [{ kind: Token.Name; name: 'subscription' }, ...infer In]
+      ? _match<OperationTypeNode.SUBSCRIPTION, In>
       : void;
 
-export type takeOperationDefinition<In> = TakeOperation<In> extends [infer Operation, infer In]
-  ? takeOptionalName<skipIgnored<In>> extends [infer Name, infer In]
-    ? takeVarDefinitions<skipIgnored<In>> extends [infer VarDefinitions, infer In]
-      ? takeDirectives<skipIgnored<In>, false> extends [infer Directives, infer In]
-        ? takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
-          ? [
+export type takeOperationDefinition<In extends any[]> = takeOperation<In> extends _match<
+  infer Operation,
+  infer In
+>
+  ? takeOptionalName<In> extends _match<infer Name, infer In>
+    ? takeVarDefinitions<In> extends _match<infer VarDefinitions, infer In>
+      ? takeDirectives<In, false> extends _match<infer Directives, infer In>
+        ? takeSelectionSet<In> extends _match<infer SelectionSet, infer In>
+          ? _match<
               {
                 kind: Kind.OPERATION_DEFINITION;
                 operation: Operation;
@@ -368,14 +331,14 @@ export type takeOperationDefinition<In> = TakeOperation<In> extends [infer Opera
                 directives: Directives;
                 selectionSet: SelectionSet;
               },
-              In,
-            ]
+              In
+            >
           : void
         : void
       : void
     : void
-  : takeSelectionSet<skipIgnored<In>> extends [infer SelectionSet, infer In]
-    ? [
+  : takeSelectionSet<In> extends _match<infer SelectionSet, infer In>
+    ? _match<
         {
           kind: Kind.OPERATION_DEFINITION;
           operation: OperationTypeNode.QUERY;
@@ -384,37 +347,37 @@ export type takeOperationDefinition<In> = TakeOperation<In> extends [infer Opera
           directives: [];
           selectionSet: SelectionSet;
         },
-        In,
-      ]
+        In
+      >
     : void;
 
-type _takeDocumentRec<Definitions extends any[], In> = takeFragmentDefinition<In> extends [
-  infer Definition,
-  infer In,
-]
-  ? _takeDocumentRec<[...Definitions, Definition], skipIgnored<In>>
-  : takeOperationDefinition<In> extends [infer Definition, infer In]
-    ? _takeDocumentRec<[...Definitions, Definition], skipIgnored<In>>
-    : [Definitions, In];
+type _takeDocumentRec<
+  Definitions extends any[],
+  In extends any[],
+> = takeFragmentDefinition<In> extends _match<infer Definition, infer In>
+  ? _takeDocumentRec<[...Definitions, Definition], In>
+  : takeOperationDefinition<In> extends _match<infer Definition, infer In>
+    ? _takeDocumentRec<[...Definitions, Definition], In>
+    : _match<Definitions, In>;
 
-type parseDocument<In> = _takeDocumentRec<[], skipIgnored<In>> extends [
+type parseDocument<In> = _takeDocumentRec<[], tokenize<In>> extends _match<
   [...infer Definitions],
-  infer _Rest,
-]
+  any
+>
   ? Definitions extends []
     ? never
     : { kind: Kind.DOCUMENT; definitions: Definitions }
   : never;
 
-type parseValue<In> = takeValue<skipIgnored<In>, false> extends [infer Node, string] ? Node : void;
+type parseValue<In> = takeValue<tokenize<In>, false> extends _match<infer Node, any> ? Node : void;
 
-type parseConstValue<In> = takeValue<skipIgnored<In>, true> extends [infer Node, string]
+type parseConstValue<In> = takeValue<tokenize<In>, true> extends _match<infer Node, any>
   ? Node
   : void;
 
-type parseType<In> = takeType<skipIgnored<In>> extends [infer Node, string] ? Node : void;
+type parseType<In> = takeType<tokenize<In>> extends _match<infer Node, any> ? Node : void;
 
-type parseOperation<In> = TakeOperation<skipIgnored<In>> extends [infer Node, string] ? Node : void;
+type parseOperation<In> = takeOperation<tokenize<In>> extends _match<infer Node, any> ? Node : void;
 
 export type DocumentNodeLike = {
   kind: Kind.DOCUMENT;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -100,13 +100,18 @@ export type takeArguments<In extends any[], Const extends boolean> = In extends 
   : _match<[], In>;
 
 export type takeDirective<In extends any[], Const extends boolean> = In extends [
-  Token.AtSign,
+  { kind: Token.Directive; name: infer DirectiveName },
   ...infer In,
 ]
-  ? takeName<In> extends _match<infer Name, infer In>
-    ? takeArguments<In, Const> extends _match<infer Arguments, infer In>
-      ? _match<{ kind: Kind.DIRECTIVE; name: Name; arguments: Arguments }, In>
-      : void
+  ? takeArguments<In, Const> extends _match<infer Arguments, infer In>
+    ? _match<
+        {
+          kind: Kind.DIRECTIVE;
+          name: { kind: Kind.NAME; value: DirectiveName };
+          arguments: Arguments;
+        },
+        In
+      >
     : void
   : void;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -379,7 +379,7 @@ type _takeDocumentRec<
     ? _takeDocumentRec<[...Definitions, Definition], In>
     : _match<Definitions, In>;
 
-type parseDocument<In extends string> = _takeDocumentRec<[], tokenize<In>> extends _match<
+export type parseDocument<In extends string> = _takeDocumentRec<[], tokenize<In>> extends _match<
   [...infer Definitions],
   any
 >
@@ -388,28 +388,7 @@ type parseDocument<In extends string> = _takeDocumentRec<[], tokenize<In>> exten
     : { kind: Kind.DOCUMENT; definitions: Definitions }
   : never;
 
-type parseValue<In extends string> = takeValue<tokenize<In>, false> extends _match<infer Node, any>
-  ? Node
-  : void;
-
-type parseConstValue<In extends string> = takeValue<tokenize<In>, true> extends _match<
-  infer Node,
-  any
->
-  ? Node
-  : void;
-
-type parseType<In extends string> = takeType<tokenize<In>> extends _match<infer Node, any>
-  ? Node
-  : void;
-
-type parseOperation<In extends string> = takeOperation<tokenize<In>> extends _match<infer Node, any>
-  ? Node
-  : void;
-
 export type DocumentNodeLike = {
   kind: Kind.DOCUMENT;
   definitions: readonly any[];
 };
-
-export type { parseConstValue, parseOperation, parseDocument, parseValue, parseType };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -360,7 +360,7 @@ type _takeDocumentRec<
     ? _takeDocumentRec<[...Definitions, Definition], In>
     : _match<Definitions, In>;
 
-type parseDocument<In> = _takeDocumentRec<[], tokenize<In>> extends _match<
+type parseDocument<In extends string> = _takeDocumentRec<[], tokenize<In>> extends _match<
   [...infer Definitions],
   any
 >
@@ -369,15 +369,24 @@ type parseDocument<In> = _takeDocumentRec<[], tokenize<In>> extends _match<
     : { kind: Kind.DOCUMENT; definitions: Definitions }
   : never;
 
-type parseValue<In> = takeValue<tokenize<In>, false> extends _match<infer Node, any> ? Node : void;
-
-type parseConstValue<In> = takeValue<tokenize<In>, true> extends _match<infer Node, any>
+type parseValue<In extends string> = takeValue<tokenize<In>, false> extends _match<infer Node, any>
   ? Node
   : void;
 
-type parseType<In> = takeType<tokenize<In>> extends _match<infer Node, any> ? Node : void;
+type parseConstValue<In extends string> = takeValue<tokenize<In>, true> extends _match<
+  infer Node,
+  any
+>
+  ? Node
+  : void;
 
-type parseOperation<In> = takeOperation<tokenize<In>> extends _match<infer Node, any> ? Node : void;
+type parseType<In extends string> = takeType<tokenize<In>> extends _match<infer Node, any>
+  ? Node
+  : void;
+
+type parseOperation<In extends string> = takeOperation<tokenize<In>> extends _match<infer Node, any>
+  ? Node
+  : void;
 
 export type DocumentNodeLike = {
   kind: Kind.DOCUMENT;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,0 +1,112 @@
+export const enum Token {
+  Name,
+  Spread,
+  Exclam,
+  Equal,
+  Colon,
+  Dollar,
+  AtSign,
+  BraceOpen,
+  BraceClose,
+  ParenOpen,
+  ParenClose,
+  BracketOpen,
+  BracketClose,
+  BlockString,
+  String,
+  Integer,
+  Float,
+}
+
+type digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+// prettier-ignore
+type letter =
+  | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M'
+  | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
+  | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
+  | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
+
+type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
+  ? skipIgnored<In>
+  : In extends `${' ' | '\n' | '\t' | '\r' | ',' | '\ufeff'}${infer In}`
+    ? skipIgnored<In>
+    : In extends string
+      ? In
+      : never;
+
+type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
+
+type skipFloat<In> = In extends `${'.'}${infer In}`
+  ? In extends `${digit}${infer In}`
+    ? In extends `${'e' | 'E'}${infer In}`
+      ? skipDigits<In extends `${'+' | '-'}${infer In}` ? In : In>
+      : In
+    : void
+  : In extends `${'e' | 'E'}${infer In}`
+    ? skipDigits<In extends `${'+' | '-'}${infer In}` ? In : In>
+    : void;
+
+type skipBlockString<In> = In extends `${infer Hd}${'"""'}${infer In}`
+  ? Hd extends `${string}${'\\'}`
+    ? skipBlockString<skipIgnored<In>>
+    : skipIgnored<In>
+  : In;
+type skipString<In> = In extends `${infer Hd}${'"'}${infer In}`
+  ? Hd extends `${string}${'\\'}`
+    ? skipString<In>
+    : skipIgnored<In>
+  : In;
+
+type takeNameLiteralRec<PrevMatch extends string, In> = In extends `${infer Match}${infer Out}`
+  ? Match extends letter | digit | '_'
+    ? takeNameLiteralRec<`${PrevMatch}${Match}`, Out>
+    : [Match, In]
+  : [PrevMatch, In];
+
+export interface AnonymousTokenNode<
+  Kind extends Exclude<Token, Token.Name> = Exclude<Token, Token.Name>,
+> {
+  kind: Kind;
+}
+
+export interface NameTokenNode<Name extends string = string> {
+  kind: Token.Name;
+  name: Name;
+}
+
+export type TokenNode = AnonymousTokenNode | NameTokenNode;
+
+// prettier-ignore
+type tokenizeRec<In extends string, Out extends TokenNode[]> =
+  In extends `...${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Spread>]>
+  : In extends `!${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Exclam>]>
+  : In extends `=${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Equal>]>
+  : In extends `:${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Colon>]>
+  : In extends `$${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Dollar>]>
+  : In extends `@${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.AtSign>]>
+  : In extends `{${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BraceOpen>]>
+  : In extends `}${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BraceClose>]>
+  : In extends `(${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.ParenOpen>]>
+  : In extends `)${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.ParenClose>]>
+  : In extends `[${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BracketOpen>]>
+  : In extends `]${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BracketClose>]>
+  : In extends `"""${infer In}` ? tokenizeRec<skipBlockString<In>, [...Out, AnonymousTokenNode<Token.BlockString>]>
+  : In extends `"${infer In}` ? tokenizeRec<skipString<In>, [...Out, AnonymousTokenNode<Token.String>]>
+  : In extends `-${digit}${infer In}` ?
+    (skipFloat<skipDigits<In>> extends `${infer In}`
+      ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Float>]>
+      : tokenizeRec<skipIgnored<skipDigits<In>>, [...Out, AnonymousTokenNode<Token.Integer>]>)
+  : In extends `${digit}${infer In}` ?
+    (skipFloat<skipDigits<In>> extends `${infer In}`
+      ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Float>]>
+      : tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Integer>]>)
+  : In extends `${infer Match}${infer In}` ?
+    (Match extends letter | '_'
+      ? takeNameLiteralRec<Match, In> extends [`${infer Match}`, infer In]
+        ? tokenizeRec<skipIgnored<In>, [...Out, NameTokenNode<Match>]>
+        : Out
+      : Out)
+  : Out;
+
+export type tokenize<In extends string> = tokenizeRec<skipIgnored<In>, []>;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -64,43 +64,37 @@ type takeNameLiteralRec<PrevMatch extends string, In> = In extends `${infer Matc
     : [Match, In]
   : [PrevMatch, In];
 
-export interface AnonymousTokenNode<
-  Kind extends Exclude<Token, Token.Name> = Exclude<Token, Token.Name>,
-> {
-  kind: Kind;
-}
-
 export interface NameTokenNode<Name extends string = string> {
   kind: Token.Name;
   name: Name;
 }
 
-export type TokenNode = AnonymousTokenNode | NameTokenNode;
+export type TokenNode = Token | NameTokenNode;
 
 // prettier-ignore
 type tokenizeRec<In extends string, Out extends TokenNode[]> =
-  In extends `...${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Spread>]>
-  : In extends `!${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Exclam>]>
-  : In extends `=${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Equal>]>
-  : In extends `:${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Colon>]>
-  : In extends `$${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Dollar>]>
-  : In extends `@${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.AtSign>]>
-  : In extends `{${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BraceOpen>]>
-  : In extends `}${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BraceClose>]>
-  : In extends `(${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.ParenOpen>]>
-  : In extends `)${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.ParenClose>]>
-  : In extends `[${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BracketOpen>]>
-  : In extends `]${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.BracketClose>]>
-  : In extends `"""${infer In}` ? tokenizeRec<skipBlockString<In>, [...Out, AnonymousTokenNode<Token.BlockString>]>
-  : In extends `"${infer In}` ? tokenizeRec<skipString<In>, [...Out, AnonymousTokenNode<Token.String>]>
+  In extends `...${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Spread]>
+  : In extends `!${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Exclam]>
+  : In extends `=${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Equal]>
+  : In extends `:${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Colon]>
+  : In extends `$${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Dollar]>
+  : In extends `@${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.AtSign]>
+  : In extends `{${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BraceOpen]>
+  : In extends `}${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BraceClose]>
+  : In extends `(${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.ParenOpen]>
+  : In extends `)${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.ParenClose]>
+  : In extends `[${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BracketOpen]>
+  : In extends `]${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BracketClose]>
+  : In extends `"""${infer In}` ? tokenizeRec<skipBlockString<In>, [...Out, Token.BlockString]>
+  : In extends `"${infer In}` ? tokenizeRec<skipString<In>, [...Out, Token.String]>
   : In extends `-${digit}${infer In}` ?
     (skipFloat<skipDigits<In>> extends `${infer In}`
-      ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Float>]>
-      : tokenizeRec<skipIgnored<skipDigits<In>>, [...Out, AnonymousTokenNode<Token.Integer>]>)
+      ? tokenizeRec<skipIgnored<In>, [...Out, Token.Float]>
+      : tokenizeRec<skipIgnored<skipDigits<In>>, [...Out, Token.Integer]>)
   : In extends `${digit}${infer In}` ?
     (skipFloat<skipDigits<In>> extends `${infer In}`
-      ? tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Float>]>
-      : tokenizeRec<skipIgnored<In>, [...Out, AnonymousTokenNode<Token.Integer>]>)
+      ? tokenizeRec<skipIgnored<In>, [...Out, Token.Float]>
+      : tokenizeRec<skipIgnored<In>, [...Out, Token.Integer]>)
   : In extends `${infer Match}${infer In}` ?
     (Match extends letter | '_'
       ? takeNameLiteralRec<Match, In> extends [`${infer Match}`, infer In]

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,11 +1,11 @@
 export const enum Token {
   Name,
   Var,
+  Directive,
   Spread,
   Exclam,
   Equal,
   Colon,
-  AtSign,
   BraceOpen,
   BraceClose,
   ParenOpen,
@@ -80,7 +80,12 @@ export interface NameTokenNode<Name extends string = string> {
   name: Name;
 }
 
-export type TokenNode = Token | NameTokenNode | VarTokenNode;
+export interface DirectiveTokenNode<Name extends string = string> {
+  kind: Token.Directive;
+  name: Name;
+}
+
+export type TokenNode = Token | NameTokenNode | VarTokenNode | DirectiveTokenNode;
 
 // prettier-ignore
 type tokenizeRec<In extends string, Out extends TokenNode[]> =
@@ -89,7 +94,6 @@ type tokenizeRec<In extends string, Out extends TokenNode[]> =
     : In extends `!${infer In}` ? tokenizeRec<In, [...Out, Token.Exclam]>
     : In extends `=${infer In}` ? tokenizeRec<In, [...Out, Token.Equal]>
     : In extends `:${infer In}` ? tokenizeRec<In, [...Out, Token.Colon]>
-    : In extends `@${infer In}` ? tokenizeRec<In, [...Out, Token.AtSign]>
     : In extends `{${infer In}` ? tokenizeRec<In, [...Out, Token.BraceOpen]>
     : In extends `}${infer In}` ? tokenizeRec<In, [...Out, Token.BraceClose]>
     : In extends `(${infer In}` ? tokenizeRec<In, [...Out, Token.ParenOpen]>
@@ -109,6 +113,10 @@ type tokenizeRec<In extends string, Out extends TokenNode[]> =
     : In extends `$${infer In}` ?
       (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
         ? tokenizeRec<In, [...Out, VarTokenNode<Match>]>
+        : Out)
+    : In extends `@${infer In}` ?
+      (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
+        ? tokenizeRec<In, [...Out, DirectiveTokenNode<Match>]>
         : Out)
     : In extends `${letter | '_'}${string}` ?
       (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -61,7 +61,7 @@ type skipString<In> = In extends `${infer Hd}${'"'}${infer In}`
 type takeNameLiteralRec<PrevMatch extends string, In> = In extends `${infer Match}${infer Out}`
   ? Match extends letter | digit | '_'
     ? takeNameLiteralRec<`${PrevMatch}${Match}`, Out>
-    : [Match, In]
+    : [PrevMatch, In]
   : [PrevMatch, In];
 
 export interface NameTokenNode<Name extends string = string> {
@@ -95,12 +95,10 @@ type tokenizeRec<In extends string, Out extends TokenNode[]> =
     (skipFloat<skipDigits<In>> extends `${infer In}`
       ? tokenizeRec<skipIgnored<In>, [...Out, Token.Float]>
       : tokenizeRec<skipIgnored<In>, [...Out, Token.Integer]>)
-  : In extends `${infer Match}${infer In}` ?
-    (Match extends letter | '_'
-      ? takeNameLiteralRec<Match, In> extends [`${infer Match}`, infer In]
-        ? tokenizeRec<skipIgnored<In>, [...Out, NameTokenNode<Match>]>
-        : Out
+  : In extends `${letter | '_'}${string}` ?
+    (takeNameLiteralRec<'', In> extends [`${infer Match}`, infer In]
+      ? tokenizeRec<skipIgnored<In>, [...Out, NameTokenNode<Match>]>
       : Out)
   : Out;
 
-export type tokenize<In extends string> = tokenizeRec<skipIgnored<In>, []>;
+export type tokenize<In> = tokenizeRec<skipIgnored<In>, []>;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -18,6 +18,11 @@ export const enum Token {
   Float,
 }
 
+export interface _match<Out extends string, In extends string> {
+  out: Out;
+  in: In;
+}
+
 type digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
 // prettier-ignore
@@ -27,13 +32,11 @@ type letter =
   | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
   | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
 
-type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
+type skipIgnored<In extends string> = In extends `#${infer _}\n${infer In}`
   ? skipIgnored<In>
   : In extends `${' ' | '\n' | '\t' | '\r' | ',' | '\ufeff'}${infer In}`
     ? skipIgnored<In>
-    : In extends string
-      ? In
-      : never;
+    : In;
 
 type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
 
@@ -49,20 +52,23 @@ type skipFloat<In> = In extends `${'.'}${infer In}`
 
 type skipBlockString<In> = In extends `${infer Hd}${'"""'}${infer In}`
   ? Hd extends `${string}${'\\'}`
-    ? skipBlockString<skipIgnored<In>>
-    : skipIgnored<In>
+    ? skipBlockString<In>
+    : In
   : In;
 type skipString<In> = In extends `${infer Hd}${'"'}${infer In}`
   ? Hd extends `${string}${'\\'}`
     ? skipString<In>
-    : skipIgnored<In>
+    : In
   : In;
 
-type takeNameLiteralRec<PrevMatch extends string, In> = In extends `${infer Match}${infer Out}`
+type takeNameLiteralRec<
+  PrevMatch extends string,
+  In extends string,
+> = In extends `${infer Match}${infer Out}`
   ? Match extends letter | digit | '_'
     ? takeNameLiteralRec<`${PrevMatch}${Match}`, Out>
-    : [PrevMatch, In]
-  : [PrevMatch, In];
+    : _match<PrevMatch, In>
+  : _match<PrevMatch, In>;
 
 export interface VarTokenNode<Name extends string = string> {
   kind: Token.Var;
@@ -78,35 +84,37 @@ export type TokenNode = Token | NameTokenNode | VarTokenNode;
 
 // prettier-ignore
 type tokenizeRec<In extends string, Out extends TokenNode[]> =
-  In extends `...${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Spread]>
-  : In extends `!${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Exclam]>
-  : In extends `=${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Equal]>
-  : In extends `:${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.Colon]>
-  : In extends `@${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.AtSign]>
-  : In extends `{${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BraceOpen]>
-  : In extends `}${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BraceClose]>
-  : In extends `(${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.ParenOpen]>
-  : In extends `)${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.ParenClose]>
-  : In extends `[${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BracketOpen]>
-  : In extends `]${infer In}` ? tokenizeRec<skipIgnored<In>, [...Out, Token.BracketClose]>
-  : In extends `"""${infer In}` ? tokenizeRec<skipBlockString<In>, [...Out, Token.BlockString]>
-  : In extends `"${infer In}` ? tokenizeRec<skipString<In>, [...Out, Token.String]>
-  : In extends `-${digit}${infer In}` ?
-    (skipFloat<skipDigits<In>> extends `${infer In}`
-      ? tokenizeRec<skipIgnored<In>, [...Out, Token.Float]>
-      : tokenizeRec<skipIgnored<skipDigits<In>>, [...Out, Token.Integer]>)
-  : In extends `${digit}${infer In}` ?
-    (skipFloat<skipDigits<In>> extends `${infer In}`
-      ? tokenizeRec<skipIgnored<In>, [...Out, Token.Float]>
-      : tokenizeRec<skipIgnored<skipDigits<In>>, [...Out, Token.Integer]>)
-  : In extends `$${infer In}` ?
-    (takeNameLiteralRec<'', In> extends [`${infer Match}`, infer In]
-      ? tokenizeRec<skipIgnored<In>, [...Out, VarTokenNode<Match>]>
-      : Out)
-  : In extends `${letter | '_'}${string}` ?
-    (takeNameLiteralRec<'', In> extends [`${infer Match}`, infer In]
-      ? tokenizeRec<skipIgnored<In>, [...Out, NameTokenNode<Match>]>
-      : Out)
-  : Out;
+  skipIgnored<In> extends `${infer In}` ? (
+    In extends `...${infer In}` ? tokenizeRec<In, [...Out, Token.Spread]>
+    : In extends `!${infer In}` ? tokenizeRec<In, [...Out, Token.Exclam]>
+    : In extends `=${infer In}` ? tokenizeRec<In, [...Out, Token.Equal]>
+    : In extends `:${infer In}` ? tokenizeRec<In, [...Out, Token.Colon]>
+    : In extends `@${infer In}` ? tokenizeRec<In, [...Out, Token.AtSign]>
+    : In extends `{${infer In}` ? tokenizeRec<In, [...Out, Token.BraceOpen]>
+    : In extends `}${infer In}` ? tokenizeRec<In, [...Out, Token.BraceClose]>
+    : In extends `(${infer In}` ? tokenizeRec<In, [...Out, Token.ParenOpen]>
+    : In extends `)${infer In}` ? tokenizeRec<In, [...Out, Token.ParenClose]>
+    : In extends `[${infer In}` ? tokenizeRec<In, [...Out, Token.BracketOpen]>
+    : In extends `]${infer In}` ? tokenizeRec<In, [...Out, Token.BracketClose]>
+    : In extends `"""${infer In}` ? tokenizeRec<skipBlockString<In>, [...Out, Token.BlockString]>
+    : In extends `"${infer In}` ? tokenizeRec<skipString<In>, [...Out, Token.String]>
+    : In extends `-${digit}${infer In}` ?
+      (skipFloat<skipDigits<In>> extends `${infer In}`
+        ? tokenizeRec<In, [...Out, Token.Float]>
+        : tokenizeRec<skipDigits<In>, [...Out, Token.Integer]>)
+    : In extends `${digit}${infer In}` ?
+      (skipFloat<skipDigits<In>> extends `${infer In}`
+        ? tokenizeRec<In, [...Out, Token.Float]>
+        : tokenizeRec<skipDigits<In>, [...Out, Token.Integer]>)
+    : In extends `$${infer In}` ?
+      (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
+        ? tokenizeRec<In, [...Out, VarTokenNode<Match>]>
+        : Out)
+    : In extends `${letter | '_'}${string}` ?
+      (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
+        ? tokenizeRec<In, [...Out, NameTokenNode<Match>]>
+        : Out)
+    : Out
+  ) : Out;
 
-export type tokenize<In> = tokenizeRec<skipIgnored<In>, []>;
+export type tokenize<In extends string> = tokenizeRec<In, []>;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -98,7 +98,7 @@ type tokenizeRec<In extends string, Out extends TokenNode[]> =
   : In extends `${digit}${infer In}` ?
     (skipFloat<skipDigits<In>> extends `${infer In}`
       ? tokenizeRec<skipIgnored<In>, [...Out, Token.Float]>
-      : tokenizeRec<skipIgnored<In>, [...Out, Token.Integer]>)
+      : tokenizeRec<skipIgnored<skipDigits<In>>, [...Out, Token.Integer]>)
   : In extends `$${infer In}` ?
     (takeNameLiteralRec<'', In> extends [`${infer Match}`, infer In]
       ? tokenizeRec<skipIgnored<In>, [...Out, VarTokenNode<Match>]>


### PR DESCRIPTION
> [!NOTE]  
> This PR is a change to address performance characteristics in a specific part of the type inference process. While it's intended to help with performance, more data and experimentation is needed to further improve `gql.tada`’s performance.
>
> If you have projects or code that can help us reproduce this, or are looking for more information, go to this issue: https://github.com/0no-co/gql.tada/issues/89

## Summary

Currently, the most expensive phase of parsing a GraphQL document is the phase of turning a string literal into the GraphQL document AST.

We've isolated this to the string literal parsing by basically changing the parser stages commit by commit and observing no discernible performance differences (See: https://github.com/0no-co/gql.tada/commits/refactor/parser-perf-cliffs/)
Most of the current issues hence come down to parsing.

This PR aims to address the string literal performance issues by isolating string parsing to a small, single-type tokenizer, which runs as much of its work as possible in a tail-recursive alias type.

## Set of changes

- Add tokenizer
- Update tests and parser to use tokens
- Update parser structure to use fewer type aliases overall and collapse some types
- Sacrifice exactness (generally, we now allow for some “empty” expressions, e.g. empty selections, arguments, var names, etc) to simplify checks