### PR TITLE
Don't lose fragmentRefs when unwrapping fragment

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -410,7 +410,7 @@ export type mirrorFragmentTypeRec<Fragment, Data> = Fragment extends (infer Valu
       ? null
       : Fragment extends undefined
         ? undefined
-        : Data;
+        : Data & Fragment;
 
 type fragmentRefsOfFragmentsRec<
   Fragments extends readonly any[],


### PR DESCRIPTION
Assuming I have:

```ts
const raw: FragmentOf<typeof SomeFrag> = ...;
const frag = readFragment(SomeFrag, raw);
```

I would expect to be able to use `frag` in places that expect to receive `FragmentOf<typeof SomeFrag>`:

```ts
const rawAgain: FragmentOf<typeof SomeFrag> = frag;
```

However, currently this causes a TypeScript error stating it's incompatible.

The current code seems to lose `fragmentRefs` when you call `readFragment()`, preventing passing the read fragment to an argument/prop expecting `FragmentOf<typeof SomeFrag>`. This PR restores the behaviour I would expect.

I made these changes directly in GitHub after using patch-package to ensure the change worked for my one use-case locally. I'm not sure if this is the right way to solve the issue or if this is a deliberate behaviour; guidance welcome
