### PR TITLE
fix: Allow `readFragment` to be called on already unmasked fragments

### DIFF
--- a/.changeset/silver-peaches-beam.md
+++ b/.changeset/silver-peaches-beam.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Allow `readFragment` to be called again on an already unmasked fragment.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -308,6 +308,21 @@ describe('readFragment', () => {
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 
+  it('should be callable on already unmasked fragments', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = readFragment({} as document, {} as FragmentOf<document>);
+    const result2 = readFragment({} as document, result);
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
+    expectTypeOf<typeof result2>().toEqualTypeOf<ResultOf<document>>();
+    expectTypeOf<typeof result2>().toEqualTypeOf<typeof result>();
+  });
+
   it('unmasks fragments with optional spreads', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {

--- a/src/api.ts
+++ b/src/api.ts
@@ -434,6 +434,22 @@ type fragmentOfTypeRec<Document extends makeDefinitionDecoration> =
 
 type resultOfTypeRec<Data> = readonly resultOfTypeRec<Data>[] | Data | undefined | null;
 
+function readFragment<
+  const Document extends makeDefinitionDecoration & DocumentDecoration<any, any>,
+  const Fragment extends fragmentOfTypeRec<Document>,
+>(
+  _document: Document,
+  fragment: Fragment
+): fragmentOfTypeRec<Document> extends Fragment
+  ? never
+  : mirrorFragmentTypeRec<Fragment, ResultOf<Document>>;
+
+// NOTE: Variant for already unmasked fragments
+function readFragment<
+  const Document extends makeDefinitionDecoration & DocumentDecoration<any, any>,
+  const Data extends resultOfTypeRec<ResultOf<Document>>,
+>(_document: Document, data: Data): Data;
+
 /** Unmasks a fragment mask for a given fragment document and data.
  *
  * @param _document - A GraphQL document of a fragment, created using {@link graphql}.
@@ -482,16 +498,8 @@ type resultOfTypeRec<Data> = readonly resultOfTypeRec<Data>[] | Data | undefined
  *
  * @see {@link readFragment} for how to read from fragment masks.
  */
-function readFragment<
-  const Document extends makeDefinitionDecoration & DocumentDecoration<any, any>,
-  const Fragment extends fragmentOfTypeRec<Document>,
->(
-  _document: Document,
-  fragment: Fragment
-): fragmentOfTypeRec<Document> extends Fragment
-  ? never
-  : mirrorFragmentTypeRec<Fragment, ResultOf<Document>> {
-  return fragment as any;
+function readFragment(_document: unknown, fragment: unknown) {
+  return fragment;
 }
 
 /** For testing, masks fragment data for given data and fragments.


### PR DESCRIPTION
Supersedes #121
cc @benjie

## Summary

This allows `readFragment` to be called on already unmasked fragments, which will most likely happen if we try to call `readFragment` on data that's already typed by (i.e. has already been unwrapped by) another `readFragment` call.

See #121 for more details

## Set of changes

- Add overload to `readFragment` that accepts already unwrapped data
