### PR TITLE
fix: Fix tokenizer hitting tail-recursion limit

### DIFF
--- a/.changeset/eight-yaks-provide.md
+++ b/.changeset/eight-yaks-provide.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Fix tokenizer hitting tail recursion limit by recursing on each ignored token.

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -34,6 +34,12 @@ type letter =
   | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
   | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
 
+type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
+  ? skipIgnored<In>
+  : In extends `${ignored}${infer In}`
+    ? skipIgnored<In>
+    : In;
+
 type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
 
 type skipFloat<In> = In extends `${'.'}${infer In}`
@@ -96,7 +102,7 @@ type tokenizeRec<State> =
     : State extends _state<infer In, infer Out>
     ? tokenizeRec<
         In extends `#${string}\n${infer In}` ? _state<In, Out>
-          : In extends `${ignored}${infer In}` ? _state<In, Out>
+          : In extends `${ignored}${infer In}` ? _state<skipIgnored<In>, Out>
           : In extends `...${infer In}` ? _state<In, [...Out, Token.Spread]>
           : In extends `!${infer In}` ? _state<In, [...Out, Token.Exclam]>
           : In extends `=${infer In}` ? _state<In, [...Out, Token.Equal]>


### PR DESCRIPTION
## Summary

TypeScript also has a tail recursion limit and the changes in #111, while being very effective at reduing parsing overhead times, caused us to now hit the limit of 1,000 when too many ignored tokens were being tokenized.

This PR addresses this by splitting the recursion of ignored tokens back out, reducing the iteration count of tokens for each chain of ignored tokens back to `1`.

That does mean that we still have a limit of 1,000 tokens, including chains of ignored tokens, but from preliminary testing it looks like this is quite reasonable and hard to hit in an app with composed fragments.
I actually like that this may cause us to have a hard limit on which queries are reasonably parsed with `gql.tada`, and when hitting this limit, there's a high chance of a fragment boundary being missed.

## Set of changes

- Readd `skipIgnored` type alias to tokenizer
- Restore old structure of `takeSelectionRec` type
  - Note: This is unrelated, but while it looked like it was better, it actually wasn't
