### PR TITLE
fix: Change `fragmentRefs` output to use typename string literal rather than `$tada.ref`

### DIFF
--- a/.changeset/chilly-cats-smell.md
+++ b/.changeset/chilly-cats-smell.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Replace redundant `$tada.ref` value on `$tada.fragmentRefs` definitions for masked fragments with typename string literal. The record for fragment masks is already namespaced, so there wasn't a need to use a symbol value here, and this further increases readability and usefulness.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -45,7 +45,7 @@ describe('graphql()', () => {
 
     expectTypeOf<FragmentOf<typeof fragment>>().toEqualTypeOf<{
       [$tada.fragmentRefs]: {
-        Fields: $tada.ref;
+        Fields: 'Todo';
       };
     }>();
 
@@ -53,7 +53,7 @@ describe('graphql()', () => {
       todos:
         | ({
             [$tada.fragmentRefs]: {
-              Fields: $tada.ref;
+              Fields: 'Todo';
             };
           } | null)[]
         | null;

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -95,7 +95,7 @@ describe('declare setupSchema configuration', () => {
             id: string | number;
             complete: boolean | null;
             [$tada.fragmentRefs]: {
-              TodoData: $tada.ref;
+              TodoData: 'Todo';
             };
           } | null)[] | null;
         }>();
@@ -160,7 +160,7 @@ describe('initGraphQLTada configuration', () => {
             id: string | number;
             complete: boolean | null;
             [$tada.fragmentRefs]: {
-              TodoData: $tada.ref;
+              TodoData: 'Todo';
             };
           } | null)[] | null;
         }>();

--- a/src/__tests__/namespace.test-d.ts
+++ b/src/__tests__/namespace.test-d.ts
@@ -65,7 +65,7 @@ describe('getFragmentsOfDocumentsRec', () => {
       };
       [$tada.ref]: {
         [$tada.fragmentRefs]: {
-          TodoFragment: $tada.ref;
+          TodoFragment: 'Todo';
         };
       };
     };

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -94,12 +94,12 @@ type makeFragmentRef<Document> = Document extends { [$tada.definition]?: infer D
         ? Result
         : {
             [$tada.fragmentRefs]: {
-              [Name in Definition['fragment']]: $tada.ref;
+              [Name in Definition['fragment']]: Definition['on'];
             };
           }
       : {
           [$tada.fragmentRefs]: {
-            [Name in Definition['fragment']]: $tada.ref;
+            [Name in Definition['fragment']]: Definition['on'];
           };
         }
     : never


### PR DESCRIPTION
Resolves #110

## Summary

This replaces the `$tada.ref` value on the `$tada.fragmentRefs` record for masked fragments with a string literal of the typename of the given fragment, further increasing readability and further decreasing the chance of fragment name conflicts.

Using the symbol as a value flag was redundant, since the entire object is already a value on a symbol property (`$tada.fragmentRefs`) and this change will further increase readability of output types.

It also happens to fix #110, since Remix's `JsonifyObject` does not filter keys but only values.

## Set of changes

- Replace `$tada.ref` value with fragment typename
