### PR TITLE
fix: Allow `readFragment()` to accept fragment document as a generic

### DIFF
--- a/.changeset/wise-flowers-study.md
+++ b/.changeset/wise-flowers-study.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Allow `readFragment()` to accept the document as a generic rather than a (runtime value) argument. This replaces the complex mapping type for input arguments, and hence drops the (undocumented) support for nested arrays being passed to it.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -9,13 +9,7 @@ import type { obj } from '../utils';
 
 import { readFragment, maskFragments, unsafe_readResult, initGraphQLTada } from '../api';
 
-import type {
-  ResultOf,
-  VariablesOf,
-  FragmentOf,
-  mirrorFragmentTypeRec,
-  getDocumentNode,
-} from '../api';
+import type { ResultOf, VariablesOf, FragmentOf, mirrorTypeRec, getDocumentNode } from '../api';
 
 type schema = simpleSchema;
 type value = { __value: true };
@@ -241,30 +235,28 @@ describe('graphql.scalar()', () => {
   });
 });
 
-describe('mirrorFragmentTypeRec', () => {
+describe('mirrorTypeRec', () => {
   it('mirrors null and undefined', () => {
-    expectTypeOf<mirrorFragmentTypeRec<value, data>>().toEqualTypeOf<data>();
-    expectTypeOf<mirrorFragmentTypeRec<value | null, data>>().toEqualTypeOf<data | null>();
-    expectTypeOf<mirrorFragmentTypeRec<value | undefined, data>>().toEqualTypeOf<
-      data | undefined
-    >();
-    expectTypeOf<mirrorFragmentTypeRec<value | null | undefined, data>>().toEqualTypeOf<
+    expectTypeOf<mirrorTypeRec<value, data>>().toEqualTypeOf<data>();
+    expectTypeOf<mirrorTypeRec<value | null, data>>().toEqualTypeOf<data | null>();
+    expectTypeOf<mirrorTypeRec<value | undefined, data>>().toEqualTypeOf<data | undefined>();
+    expectTypeOf<mirrorTypeRec<value | null | undefined, data>>().toEqualTypeOf<
       data | null | undefined
     >();
   });
 
   it('mirrors nested arrays', () => {
-    expectTypeOf<mirrorFragmentTypeRec<value[], data>>().toEqualTypeOf<data[]>();
-    expectTypeOf<mirrorFragmentTypeRec<value[] | null, data>>().toEqualTypeOf<data[] | null>();
-    expectTypeOf<mirrorFragmentTypeRec<(value | null)[] | null, data>>().toEqualTypeOf<
+    expectTypeOf<mirrorTypeRec<value[], data>>().toEqualTypeOf<data[]>();
+    expectTypeOf<mirrorTypeRec<value[] | null, data>>().toEqualTypeOf<data[] | null>();
+    expectTypeOf<mirrorTypeRec<(value | null)[] | null, data>>().toEqualTypeOf<
       (data | null)[] | null
     >();
-    expectTypeOf<mirrorFragmentTypeRec<readonly value[], data>>().toEqualTypeOf<readonly data[]>();
+    expectTypeOf<mirrorTypeRec<readonly value[], data>>().toEqualTypeOf<readonly data[]>();
   });
 
   it('mirrors complex types', () => {
     type complex = { a: true } | { b: true };
-    type actual = mirrorFragmentTypeRec<value, complex>;
+    type actual = mirrorTypeRec<value, complex>;
     expectTypeOf<actual>().toEqualTypeOf<complex>();
   });
 });
@@ -283,7 +275,7 @@ describe('readFragment', () => {
     expectTypeOf<typeof result>().toBeNever();
   });
 
-  it('should not unmask empty objects', () => {
+  it('should not accept empty objects', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {
         id
@@ -292,8 +284,7 @@ describe('readFragment', () => {
 
     type document = getDocumentNode<fragment, schema>;
     // @ts-expect-error
-    const result = readFragment({} as document, {});
-    expectTypeOf<typeof result>().toBeNever();
+    const _result = readFragment({} as document, {});
   });
 
   it('unmasks regular fragments', () => {

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -271,6 +271,18 @@ describe('readFragment', () => {
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 
+  it('unmasks regular fragments passed as generics', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    const result = readFragment<document>({} as FragmentOf<document>);
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
+  });
+
   it('should be callable on already unmasked fragments', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -9,11 +9,9 @@ import type { obj } from '../utils';
 
 import { readFragment, maskFragments, unsafe_readResult, initGraphQLTada } from '../api';
 
-import type { ResultOf, VariablesOf, FragmentOf, mirrorTypeRec, getDocumentNode } from '../api';
+import type { ResultOf, VariablesOf, FragmentOf, getDocumentNode } from '../api';
 
 type schema = simpleSchema;
-type value = { __value: true };
-type data = { __data: true };
 
 describe('graphql()', () => {
   const graphql = initGraphQLTada<{ introspection: simpleIntrospection }>();
@@ -232,32 +230,6 @@ describe('graphql.scalar()', () => {
   it('should reject invalid names of types', () => {
     // @ts-expect-error
     const actual = graphql.scalar('what', null);
-  });
-});
-
-describe('mirrorTypeRec', () => {
-  it('mirrors null and undefined', () => {
-    expectTypeOf<mirrorTypeRec<value, data>>().toEqualTypeOf<data>();
-    expectTypeOf<mirrorTypeRec<value | null, data>>().toEqualTypeOf<data | null>();
-    expectTypeOf<mirrorTypeRec<value | undefined, data>>().toEqualTypeOf<data | undefined>();
-    expectTypeOf<mirrorTypeRec<value | null | undefined, data>>().toEqualTypeOf<
-      data | null | undefined
-    >();
-  });
-
-  it('mirrors nested arrays', () => {
-    expectTypeOf<mirrorTypeRec<value[], data>>().toEqualTypeOf<data[]>();
-    expectTypeOf<mirrorTypeRec<value[] | null, data>>().toEqualTypeOf<data[] | null>();
-    expectTypeOf<mirrorTypeRec<(value | null)[] | null, data>>().toEqualTypeOf<
-      (data | null)[] | null
-    >();
-    expectTypeOf<mirrorTypeRec<readonly value[], data>>().toEqualTypeOf<readonly data[]>();
-  });
-
-  it('mirrors complex types', () => {
-    type complex = { a: true } | { b: true };
-    type actual = mirrorTypeRec<value, complex>;
-    expectTypeOf<actual>().toEqualTypeOf<complex>();
   });
 });
 

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -374,7 +374,7 @@ describe('readFragment', () => {
 });
 
 describe('maskFragments', () => {
-  it('should not mask empty objects', () => {
+  it('should not accept empty objects', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {
         id
@@ -383,8 +383,7 @@ describe('maskFragments', () => {
 
     type document = getDocumentNode<fragment, schema>;
     // @ts-expect-error
-    const result = maskFragments([{} as document], {});
-    expectTypeOf<typeof result>().toBeNever();
+    const _result = maskFragments([{} as document], {});
   });
 
   it('masks fragments', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -479,6 +479,30 @@ export type mirrorTypeRec<From, To> = From extends (infer Value)[]
  * @see {@link readFragment} for how to read from fragment masks.
  */
 function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: resultOrFragmentOf<Document>
+): ResultOf<Document>;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: resultOrFragmentOf<Document> | null
+): ResultOf<Document> | null;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: resultOrFragmentOf<Document> | undefined
+): ResultOf<Document> | undefined;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: resultOrFragmentOf<Document> | null | undefined
+): ResultOf<Document> | null | undefined;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: readonly resultOrFragmentOf<Document>[]
+): readonly ResultOf<Document>[];
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: readonly (resultOrFragmentOf<Document> | null)[]
+): readonly (ResultOf<Document> | null)[];
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: readonly (resultOrFragmentOf<Document> | undefined)[]
+): readonly (ResultOf<Document> | undefined)[];
+function readFragment<const Document extends makeDefinitionDecoration>(
+  fragment: readonly (resultOrFragmentOf<Document> | null | undefined)[]
+): readonly (ResultOf<Document> | null | undefined)[];
+function readFragment<const Document extends makeDefinitionDecoration>(
   _document: Document,
   fragment: resultOrFragmentOf<Document>
 ): ResultOf<Document>;
@@ -510,8 +534,8 @@ function readFragment<const Document extends makeDefinitionDecoration>(
   _document: Document,
   fragment: readonly (resultOrFragmentOf<Document> | null | undefined)[]
 ): readonly (ResultOf<Document> | null | undefined)[];
-function readFragment(_document: unknown, fragment: unknown) {
-  return fragment;
+function readFragment(...args: [unknown] | [unknown, unknown]) {
+  return args.length === 2 ? args[1] : args[0];
 }
 
 /** For testing, masks fragment data for given data and fragments.

--- a/src/api.ts
+++ b/src/api.ts
@@ -430,40 +430,6 @@ export type mirrorTypeRec<From, To> = From extends (infer Value)[]
         ? undefined
         : To;
 
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: resultOrFragmentOf<Document>
-): ResultOf<Document>;
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: resultOrFragmentOf<Document> | null
-): ResultOf<Document> | null;
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: resultOrFragmentOf<Document> | undefined
-): ResultOf<Document> | undefined;
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: resultOrFragmentOf<Document> | null | undefined
-): ResultOf<Document> | null | undefined;
-
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: readonly resultOrFragmentOf<Document>[]
-): readonly ResultOf<Document>[];
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: readonly (resultOrFragmentOf<Document> | null)[]
-): readonly (ResultOf<Document> | null)[];
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: readonly (resultOrFragmentOf<Document> | undefined)[]
-): readonly (ResultOf<Document> | undefined)[];
-function readFragment<const Document extends makeDefinitionDecoration>(
-  _document: Document,
-  fragment: readonly (resultOrFragmentOf<Document> | null | undefined)[]
-): readonly (ResultOf<Document> | null | undefined)[];
-
 /** Unmasks a fragment mask for a given fragment document and data.
  *
  * @param _document - A GraphQL document of a fragment, created using {@link graphql}.
@@ -512,43 +478,41 @@ function readFragment<const Document extends makeDefinitionDecoration>(
  *
  * @see {@link readFragment} for how to read from fragment masks.
  */
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: resultOrFragmentOf<Document>
+): ResultOf<Document>;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: resultOrFragmentOf<Document> | null
+): ResultOf<Document> | null;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: resultOrFragmentOf<Document> | undefined
+): ResultOf<Document> | undefined;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: resultOrFragmentOf<Document> | null | undefined
+): ResultOf<Document> | null | undefined;
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: readonly resultOrFragmentOf<Document>[]
+): readonly ResultOf<Document>[];
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: readonly (resultOrFragmentOf<Document> | null)[]
+): readonly (ResultOf<Document> | null)[];
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: readonly (resultOrFragmentOf<Document> | undefined)[]
+): readonly (ResultOf<Document> | undefined)[];
+function readFragment<const Document extends makeDefinitionDecoration>(
+  _document: Document,
+  fragment: readonly (resultOrFragmentOf<Document> | null | undefined)[]
+): readonly (ResultOf<Document> | null | undefined)[];
 function readFragment(_document: unknown, fragment: unknown) {
   return fragment;
 }
-
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments>
-): fragmentRefsOfFragmentsRec<Fragments>;
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments> | null
-): fragmentRefsOfFragmentsRec<Fragments> | null;
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments> | undefined
-): fragmentRefsOfFragmentsRec<Fragments> | undefined;
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments> | null | undefined
-): fragmentRefsOfFragmentsRec<Fragments> | null | undefined;
-
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: readonly resultOfFragmentsRec<Fragments>[]
-): readonly fragmentRefsOfFragmentsRec<Fragments>[];
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: readonly (resultOfFragmentsRec<Fragments> | null)[]
-): readonly (fragmentRefsOfFragmentsRec<Fragments> | null)[];
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: readonly (resultOfFragmentsRec<Fragments> | undefined)[]
-): readonly (fragmentRefsOfFragmentsRec<Fragments> | undefined)[];
-function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
-  _fragments: Fragments,
-  fragment: readonly (resultOfFragmentsRec<Fragments> | null | undefined)[]
-): readonly (fragmentRefsOfFragmentsRec<Fragments> | null | undefined)[];
 
 /** For testing, masks fragment data for given data and fragments.
  *
@@ -579,6 +543,38 @@ function maskFragments<const Fragments extends readonly [...makeDefinitionDecora
  *
  * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
  */
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments>
+): fragmentRefsOfFragmentsRec<Fragments>;
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments> | null
+): fragmentRefsOfFragmentsRec<Fragments> | null;
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments> | undefined
+): fragmentRefsOfFragmentsRec<Fragments> | undefined;
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments> | null | undefined
+): fragmentRefsOfFragmentsRec<Fragments> | null | undefined;
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: readonly resultOfFragmentsRec<Fragments>[]
+): readonly fragmentRefsOfFragmentsRec<Fragments>[];
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: readonly (resultOfFragmentsRec<Fragments> | null)[]
+): readonly (fragmentRefsOfFragmentsRec<Fragments> | null)[];
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: readonly (resultOfFragmentsRec<Fragments> | undefined)[]
+): readonly (fragmentRefsOfFragmentsRec<Fragments> | undefined)[];
+function maskFragments<const Fragments extends readonly [...makeDefinitionDecoration[]]>(
+  _fragments: Fragments,
+  fragment: readonly (resultOfFragmentsRec<Fragments> | null | undefined)[]
+): readonly (fragmentRefsOfFragmentsRec<Fragments> | null | undefined)[];
 function maskFragments(_fragments: unknown, data: unknown) {
   return data;
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -420,16 +420,6 @@ type fragmentRefsOfFragmentsRec<
   ? fragmentRefsOfFragmentsRec<Rest, makeFragmentRef<Fragment> & FragmentRefs>
   : obj<FragmentRefs>;
 
-export type mirrorTypeRec<From, To> = From extends (infer Value)[]
-  ? mirrorTypeRec<Value, To>[]
-  : From extends readonly (infer Value)[]
-    ? readonly mirrorTypeRec<Value, To>[]
-    : From extends null
-      ? null
-      : From extends undefined
-        ? undefined
-        : To;
-
 /** Unmasks a fragment mask for a given fragment document and data.
  *
  * @param _document - A GraphQL document of a fragment, created using {@link graphql}.

--- a/website/src/content/docs/reference/gql-tada-api.mdx
+++ b/website/src/content/docs/reference/gql-tada-api.mdx
@@ -85,7 +85,7 @@ type Media = ReturnType<typeof graphql.scalar<'Media'>>;
 
 | | Description |
 | ----------- | ----------- |
-| `_document` argument | A GraphQL document of a fragment, created using [`graphql()`](#graphql). |
+| `_document` optional argument | A GraphQL document of a fragment, created using [`graphql()`](#graphql). |
 | `fragment` argument | A mask of the fragment, which can be wrapped in arrays, or nullable. |
 | returns | The unmasked data of the fragment. | 
 
@@ -95,10 +95,21 @@ fragment. This encourages isolation and is known as “fragment masking.”
 
 This means that you must use `readFragment()` to unmask these fragment masks
 and get to the data. This encourages isolation and only using the data you define
-a part of your codebase to require.
+a part of your codebase to require:
+
+```ts
+const unmaskedData = readFragment(Fragment, maskedData);
+```
 
 When passing `fragment` masks to `readFragment()`, you may also pass nullable, optional data, or data
 wrapped in arrays to `readFragment()` and the result type will be unwrapped and inferred accordingly.
+
+Instead of passing the fragment document as the first argument, you may also pass it as a generic,
+since it's not used as a runtime value anyway:
+
+```ts
+const unmaskedData = readFragment<typeof Fragment>(maskedData);
+```
 
 [Read more about fragment masking on the “Writing GraphQL” page.](../../get-started/writing-graphql/#fragment-masking)
 


### PR DESCRIPTION
> [!NOTE]  
> It's debatable whether this is a feature or a fix, but since it's a relatively safe addition that complements #98 (for #77) and that we can safely roll back if needed, I'd like to try shipping this as a patch to evaluate this quickly.

## Summary

This allows the document in `readFragment` to be passed as a generic, removing the need to keep fragments around as a runtime value.

```ts
// previous:
const unmaskedData = readFragment(document, maskedData);
// new:
const unmaskedData = readFragment<typeof document>(maskedData);
```

Replacing `readFragment`'s complex type argument and data generic with an overload is long and wordy, but potentially makes it simpler for TypeScript to evaluate and prevents us having to maintain `mirrorTypeRec`.

In case this is needed, we can add its definition back to the overload, but this wouldn't be compatible with being able to pass just one generic for the document.

## Set of changes

- Replace `maskFragments` and `readFragment` definitions with overloads
- Allow `readFragment` to only accept one argument
