### PR TITLE
fix(cli): generate-schema handle single header

### DIFF
--- a/.changeset/tender-suits-melt.md
+++ b/.changeset/tender-suits-melt.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix generate-schema not forwarding single header

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -39,8 +39,10 @@ async function main() {
 
       let introspection: IntrospectionQuery;
       if (url) {
-        const headers = (Array.isArray(options.header) ? options.header : []).reduce(
+        const headers = (Array.isArray(options.header) ? options.header : [options.header]).reduce(
           (acc, item) => {
+            if (!item) return acc;
+
             const parts = item.split(':');
             return {
               ...acc,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
This PR resolves an issue where `generate-schema` is not correctly handling single headers passed through `options.header`. It would only work correctly if multiple headers were provided. When a single header was passed, it would be ignored and not forwarded to the fetch call.

## Set of changes
`@gql.tada/cli-utils` ?