### PR TITLE
feat(cli): export cli actions as node apis

### DIFF
--- a/.changeset/fresh-pillows-argue.md
+++ b/.changeset/fresh-pillows-argue.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': minor
+---
+
+Abstract core logic for `generate-schema` and `generate-output` CLI commands into importable Node.js API's

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -12,6 +12,140 @@ import type { GraphQLSPConfig } from './lsp';
 import { hasGraphQLSP } from './lsp';
 import { ensureTadaIntrospection } from './tada';
 
+interface GenerateSchemaOptions {
+  headers?: Record<string, string>;
+  output?: string;
+  cwd?: string;
+}
+
+export async function generateSchema(
+  target: string,
+  { headers, output, cwd = process.cwd() }: GenerateSchemaOptions
+) {
+  let url: URL | undefined;
+
+  try {
+    url = new URL(target);
+  } catch (e) {}
+
+  let introspection: IntrospectionQuery;
+  if (url) {
+    const response = await fetch(url!.toString(), {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: getIntrospectionQuery({
+          descriptions: true,
+          schemaDescription: false,
+          inputValueDeprecation: false,
+          directiveIsRepeatable: false,
+          specifiedByUrl: false,
+        }),
+      }),
+    });
+
+    if (response.ok) {
+      const text = await response.text();
+
+      try {
+        const result = JSON.parse(text);
+        if (result.data) {
+          introspection = (result as { data: IntrospectionQuery }).data;
+        } else {
+          console.error(`Got invalid response ${JSON.stringify(result)}`);
+          return;
+        }
+      } catch (e) {
+        console.error(`Got invalid JSON ${text}`);
+        return;
+      }
+    } else {
+      console.error(`Got invalid response ${await response.text()}`);
+      return;
+    }
+  } else {
+    const path = resolve(cwd, target);
+    const fileContents = await fs.readFile(path, 'utf-8');
+
+    try {
+      introspection = JSON.parse(fileContents);
+    } catch (e) {
+      console.error(`Got invalid JSON ${fileContents}`);
+      return;
+    }
+  }
+
+  const schema = buildClientSchema(introspection!);
+
+  let destination = output;
+  if (!destination) {
+    const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
+    const hasTsConfig = existsSync(tsconfigpath);
+    if (!hasTsConfig) {
+      console.error(`Could not find a tsconfig in the working-directory.`);
+      return;
+    }
+
+    const tsconfigContents = await fs.readFile(tsconfigpath, 'utf-8');
+    let tsConfig: TsConfigJson;
+    try {
+      tsConfig = parse(tsconfigContents) as TsConfigJson;
+    } catch (err) {
+      console.error(err);
+      return;
+    }
+
+    if (!hasGraphQLSP(tsConfig)) {
+      console.error(`Could not find a "@0no-co/graphqlsp" plugin in your tsconfig.`);
+      return;
+    }
+
+    const foundPlugin = tsConfig.compilerOptions!.plugins!.find(
+      (plugin) => plugin.name === '@0no-co/graphqlsp'
+    ) as GraphQLSPConfig;
+
+    destination = foundPlugin.schema;
+
+    if (!foundPlugin.schema.endsWith('.graphql')) {
+      console.error(`Found "${foundPlugin.schema}" which is not a path to a GraphQL Schema.`);
+      return;
+    }
+  }
+
+  await fs.writeFile(resolve(cwd, destination), printSchema(schema), 'utf-8');
+}
+
+export async function generateTadaTypes(cwd: string = process.cwd()) {
+  const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
+  const hasTsConfig = existsSync(tsconfigpath);
+  if (!hasTsConfig) {
+    console.error('Missing tsconfig.json');
+    return;
+  }
+
+  const tsconfigContents = await fs.readFile(tsconfigpath, 'utf-8');
+  let tsConfig: TsConfigJson;
+  try {
+    tsConfig = parse(tsconfigContents) as TsConfigJson;
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+
+  if (!hasGraphQLSP(tsConfig)) {
+    return;
+  }
+
+  const foundPlugin = tsConfig.compilerOptions!.plugins!.find(
+    (plugin) => plugin.name === '@0no-co/graphqlsp'
+  ) as GraphQLSPConfig;
+
+  await ensureTadaIntrospection(foundPlugin.schema, foundPlugin.tadaOutputLocation!, cwd);
+}
+
 const prog = sade('gql.tada');
 
 prog.version(process.env.npm_package_version || '0.0.0');
@@ -30,147 +164,28 @@ async function main() {
     .example("generate-schema https://example.com --header 'Authorization: Bearer token'")
     .example('generate-schema ./introspection.json')
     .action(async (target, options) => {
-      const cwd = process.cwd();
-      let url: URL | undefined;
+      const parsedHeaders = {};
 
-      try {
-        url = new URL(target);
-      } catch (e) {}
-
-      let introspection: IntrospectionQuery;
-      if (url) {
-        const headers = (Array.isArray(options.header) ? options.header : [options.header]).reduce(
-          (acc, item) => {
-            if (!item) return acc;
-
-            const parts = item.split(':');
-            return {
-              ...acc,
-              [parts[0]]: parts[1],
-            };
-          },
-          {}
-        );
-        const response = await fetch(url!.toString(), {
-          method: 'POST',
-          headers: {
-            ...headers,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            query: getIntrospectionQuery({
-              descriptions: true,
-              schemaDescription: false,
-              inputValueDeprecation: false,
-              directiveIsRepeatable: false,
-              specifiedByUrl: false,
-            }),
-          }),
+      if (typeof options.header === 'string') {
+        const [key, value] = options.header.split(':').map((part) => part.trim());
+        parsedHeaders[key] = value;
+      } else if (Array.isArray(options.header)) {
+        options.header.forEach((header) => {
+          const [key, value] = header.split(':').map((part) => part.trim());
+          parsedHeaders[key] = value;
         });
-
-        if (response.ok) {
-          const text = await response.text();
-
-          try {
-            const result = JSON.parse(text);
-            if (result.data) {
-              introspection = (result as { data: IntrospectionQuery }).data;
-            } else {
-              console.error(`Got invalid response ${JSON.stringify(result)}`);
-              return;
-            }
-          } catch (e) {
-            console.error(`Got invalid JSON ${text}`);
-            return;
-          }
-        } else {
-          console.error(`Got invalid response ${await response.text()}`);
-          return;
-        }
-      } else {
-        const path = resolve(cwd, target);
-        const fileContents = await fs.readFile(path, 'utf-8');
-
-        try {
-          introspection = JSON.parse(fileContents);
-        } catch (e) {
-          console.error(`Got invalid JSON ${fileContents}`);
-          return;
-        }
       }
 
-      const schema = buildClientSchema(introspection!);
-
-      let destination = options.output;
-      if (!destination) {
-        const cwd = process.cwd();
-        const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
-        const hasTsConfig = existsSync(tsconfigpath);
-        if (!hasTsConfig) {
-          console.error(`Could not find a tsconfig in the working-directory.`);
-          return;
-        }
-
-        const tsconfigContents = await fs.readFile(tsconfigpath, 'utf-8');
-        let tsConfig: TsConfigJson;
-        try {
-          tsConfig = parse(tsconfigContents) as TsConfigJson;
-        } catch (err) {
-          console.error(err);
-          return;
-        }
-
-        if (!hasGraphQLSP(tsConfig)) {
-          console.error(`Could not find a "@0no-co/graphqlsp" plugin in your tsconfig.`);
-          return;
-        }
-
-        const foundPlugin = tsConfig.compilerOptions!.plugins!.find(
-          (plugin) => plugin.name === '@0no-co/graphqlsp'
-        ) as GraphQLSPConfig;
-
-        destination = foundPlugin.schema;
-
-        if (!foundPlugin.schema.endsWith('.graphql')) {
-          console.error(`Found "${foundPlugin.schema}" which is not a path to a GraphQL Schema.`);
-          return;
-        }
-      }
-
-      await fs.writeFile(resolve(cwd, destination), printSchema(schema), 'utf-8');
+      generateSchema(target, {
+        headers: parsedHeaders,
+        output: options.output,
+      });
     })
     .command('generate-output')
     .describe(
       'Generate the gql.tada types file, this will look for your "tsconfig.json" and use the "@0no-co/graphqlsp" configuration to generate the file.'
     )
-    .action(async () => {
-      const cwd = process.cwd();
-      const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
-      const hasTsConfig = existsSync(tsconfigpath);
-      if (!hasTsConfig) {
-        console.error('Missing tsconfig.json');
-        return;
-      }
-
-      const tsconfigContents = await fs.readFile(tsconfigpath, 'utf-8');
-      let tsConfig: TsConfigJson;
-      try {
-        tsConfig = parse(tsconfigContents) as TsConfigJson;
-      } catch (err) {
-        console.error(err);
-        return;
-      }
-
-      if (!hasGraphQLSP(tsConfig)) {
-        return;
-      }
-
-      const foundPlugin = tsConfig.compilerOptions!.plugins!.find(
-        (plugin) => plugin.name === '@0no-co/graphqlsp'
-      ) as GraphQLSPConfig;
-
-      await ensureTadaIntrospection(foundPlugin.schema, foundPlugin.tadaOutputLocation!);
-    });
+    .action(() => generateTadaTypes());
   prog.parse(process.argv);
 }
 

--- a/packages/cli-utils/src/tada.ts
+++ b/packages/cli-utils/src/tada.ts
@@ -31,10 +31,9 @@ export { readFragment as useFragment } from 'gql.tada';
  */
 export async function ensureTadaIntrospection(
   schemaLocation: SchemaOrigin | string,
-  outputLocation: string
+  outputLocation: string,
+  base: string = process.cwd()
 ) {
-  const base = process.cwd();
-
   const writeTada = async () => {
     try {
       const schema = await loadSchema(base, schemaLocation);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 import cli from '@gql.tada/cli-utils';
-cli();
+(cli as any).default();


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Resolves #134

Abstract core logic for `generate-schema` and `generate-output` CLI commands into importable Node.js APIs.

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

The diff is large, but the code is largely the same, mostly just moved around:

- All of the logic in `generateSchema` is unchanged, with the exception of header parsing being pulled out of the function and now headers are passed in as a `Record<string,string>`. Additionally, `cwd` is now an optional parameter (helpful when this methods are called from a directory outside of the directory containing your project's `tsconfig.json` file, e.g., `npm create some-project`).
- `generateTadaTypes` is almost entirely unchanged, `cwd` is now an optional parameter.
