### PR TITLE
fix: Fix tokenizer not handling floats with repeated decimal digits

### DIFF
--- a/.changeset/proud-cats-enjoy.md
+++ b/.changeset/proud-cats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Fix tokenizer not handling repeated digits for floats.

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -22,8 +22,8 @@ describe('tokenize', () => {
   });
 
   it('tokenizes integers', () => {
-    type actual = tokenize<'-1 1'>;
-    type expected = [Token.Integer, Token.Integer];
+    type actual = tokenize<'-1 1 123'>;
+    type expected = [Token.Integer, Token.Integer, Token.Integer];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 
@@ -31,6 +31,10 @@ describe('tokenize', () => {
     type actual = tokenize<'1.0 1e2 1.0E-2'>;
     type expected = [Token.Float, Token.Float, Token.Float];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
+
+    type actual2 = tokenize<'1.00 1e22 1.00E-20'>;
+    type expected2 = [Token.Float, Token.Float, Token.Float];
+    expectTypeOf<actual2>().toEqualTypeOf<expected2>();
   });
 
   it('tokenizes strings', () => {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -43,12 +43,10 @@ type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
 type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
 
 type skipFloat<In> = In extends `${'.'}${infer In}`
-  ? In extends `${digit}${infer In}`
-    ? In extends `${'e' | 'E'}${infer In}`
-      ? skipDigits<In extends `${'+' | '-'}${infer In}` ? In : In>
-      : In
-    : void
-  : In extends `${'e' | 'E'}${infer In}`
+  ? skipDigits<In> extends `${'e' | 'E'}${infer In}`
+    ? skipDigits<In extends `${'+' | '-'}${infer In}` ? In : In>
+    : skipDigits<In>
+  : skipDigits<In> extends `${'e' | 'E'}${infer In}`
     ? skipDigits<In extends `${'+' | '-'}${infer In}` ? In : In>
     : void;
 


### PR DESCRIPTION
Resolves #139

## Summary

Instead of handling repeated digits, the tokenizer was only handling a single decimal digit for floats.

## Set of changes

- Update tests
- Add missing `skipDigits` cases to `skipFloat`
