### PR TITLE
fix: Update default ID scalar type to be `string`

### DIFF
--- a/.changeset/two-rockets-hear.md
+++ b/.changeset/two-rockets-hear.md
@@ -2,4 +2,4 @@
 "gql.tada": minor
 ---
 
-Change the default `scalar` type of `ID` to be `string`, as specified in [the spec](https://spec.graphql.org/October2021/#sec-ID)
+Change the default scalar type of `ID` to be `string`, as [the GraphQL spec](https://spec.graphql.org/October2021/#sec-ID) recommends it to serialize to a string

--- a/.changeset/two-rockets-hear.md
+++ b/.changeset/two-rockets-hear.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": minor
+---
+
+Change the default `scalar` type of `ID` to be `string`, as specified in [the spec](https://spec.graphql.org/October2021/#sec-ID)

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -76,14 +76,14 @@ describe('graphql()', () => {
     );
 
     expectTypeOf<FragmentOf<typeof fragment>>().toEqualTypeOf<{
-      id: string | number;
+      id: string;
       text: string;
     }>();
 
     expectTypeOf<ResultOf<typeof query>>().toEqualTypeOf<{
       todos:
         | ({
-            id: string | number;
+            id: string;
             text: string;
           } | null)[]
         | null;
@@ -124,11 +124,11 @@ describe('graphql()', () => {
     expectTypeOf<FragmentOf<typeof fragment>>().toEqualTypeOf<
       | {
           __typename: 'BigTodo';
-          id: string | number;
+          id: string;
         }
       | {
           __typename: 'SmallTodo';
-          id: string | number;
+          id: string;
         }
     >();
 
@@ -136,12 +136,12 @@ describe('graphql()', () => {
       itodo:
         | {
             __typename: 'BigTodo';
-            id: string | number;
+            id: string;
             wallOfText: string | null;
           }
         | {
             __typename: 'SmallTodo';
-            id: string | number;
+            id: string;
             maxLength: number | null;
           };
     }>();
@@ -218,14 +218,14 @@ describe('graphql() with `disableMasking: true`', () => {
     );
 
     expectTypeOf<FragmentOf<typeof fragment>>().toEqualTypeOf<{
-      id: string | number;
+      id: string;
       text: string;
     }>();
 
     expectTypeOf<ResultOf<typeof query>>().toEqualTypeOf<{
       todos:
         | ({
-            id: string | number;
+            id: string;
             text: string;
           } | null)[]
         | null;

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -92,7 +92,7 @@ describe('declare setupSchema configuration', () => {
 
         expectTypeOf<typeof result>().toEqualTypeOf<{
           todos: ({
-            id: string | number;
+            id: string;
             complete: boolean | null;
             [$tada.fragmentRefs]: {
               TodoData: 'Todo';
@@ -103,7 +103,7 @@ describe('declare setupSchema configuration', () => {
         const todo = readFragment(todoFragment, result?.todos?.[0]);
 
         expectTypeOf<typeof todo>().toEqualTypeOf<{
-          id: string | number;
+          id: string;
           text: string;
         } | undefined | null>();
       `,
@@ -157,7 +157,7 @@ describe('initGraphQLTada configuration', () => {
 
         expectTypeOf<typeof result>().toEqualTypeOf<{
           todos: ({
-            id: string | number;
+            id: string;
             complete: boolean | null;
             [$tada.fragmentRefs]: {
               TodoData: 'Todo';
@@ -168,7 +168,7 @@ describe('initGraphQLTada configuration', () => {
         const todo = readFragment(todoFragment, result?.todos?.[0]);
 
         expectTypeOf<typeof todo>().toEqualTypeOf<{
-          id: string | number;
+          id: string;
           text: string;
         } | undefined | null>();
       `,
@@ -220,7 +220,7 @@ describe('initGraphQLTada configuration', () => {
 
         expectTypeOf<typeof result>().toEqualTypeOf<{
           todos: ({
-            id: string | number;
+            id: string;
             complete: boolean | null;
             text: string;
           } | null)[] | null;
@@ -229,7 +229,7 @@ describe('initGraphQLTada configuration', () => {
         const todo = readFragment(todoFragment, result?.todos?.[0]);
 
         expectTypeOf<typeof todo>().toEqualTypeOf<{
-          id: string | number;
+          id: string;
           text: string;
         } | undefined | null>();
       `,

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -371,7 +371,7 @@ export type simpleSchema = {
     ID: {
       kind: 'SCALAR';
       name: 'ID';
-      type: string | number;
+      type: string;
     };
 
     String: {

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -20,7 +20,7 @@ test('infers simple fields', () => {
   `>;
 
   type actual = getDocumentType<query, schema>;
-  type expected = { todos: Array<{ id: string | number } | null> | null };
+  type expected = { todos: Array<{ id: string } | null> | null };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();
 });
@@ -35,7 +35,7 @@ test('infers mutation fields', () => {
   `>;
 
   type actual = getDocumentType<mutation, schema>;
-  type expected = { toggleTodo: { id: string | number } | null };
+  type expected = { toggleTodo: { id: string } | null };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();
 });
@@ -70,7 +70,7 @@ test('infers adjacent inline fragments', () => {
   type actual = getDocumentType<query, schema>;
   type expected = {
     todos: Array<{
-      id: string | number;
+      id: string;
       text: string;
       complete: boolean | null;
     } | null> | null;
@@ -86,7 +86,7 @@ test('infers aliased fields', () => {
 
   type actual = getDocumentType<query, schema>;
   type expected = {
-    todos: Array<{ myIdIsGreat: string | number } | null> | null;
+    todos: Array<{ myIdIsGreat: string } | null> | null;
   };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();
@@ -105,7 +105,7 @@ test('infers optional properties for @skip/@include', () => {
   type actual = getDocumentType<query, schema>;
   type expected = {
     todos: Array<{
-      id?: string | number | undefined;
+      id?: string | undefined;
       __typename?: 'Todo';
     } | null> | null;
   };
@@ -127,7 +127,7 @@ test('infers nullable field types for @required/@optional', () => {
   type expected = {
     todos:
       | ({
-          id: string | number | null;
+          id: string | null;
           complete: boolean;
         } | null)[]
       | null;
@@ -154,7 +154,7 @@ test('infers optional fragment for @defer', () => {
   type expected = {
     todos: Array<
       | {
-          id: string | number;
+          id: string;
         }
       | {}
       | null
@@ -184,7 +184,7 @@ test('infers optional inline fragment for @defer', () => {
   type expected = {
     todos: Array<
       | {
-          id: string | number;
+          id: string;
         }
       | {}
       | null
@@ -201,7 +201,7 @@ test('infers enum values', () => {
 
   type actual = getDocumentType<query, schema>;
   type expected = {
-    todos: Array<{ id: string | number; test: 'value' | 'more' | null } | null> | null;
+    todos: Array<{ id: string; test: 'value' | 'more' | null } | null> | null;
   };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();
@@ -217,7 +217,7 @@ test('infers fragment spreads', () => {
   type expected = {
     todos: Array<{
       __typename: 'Todo';
-      id: string | number;
+      id: string;
       text: string;
       complete: boolean | null;
     } | null> | null;
@@ -271,7 +271,7 @@ test('infers inline fragments and fragment spreads', () => {
   type expected = {
     todos: Array<{
       __typename: 'Todo';
-      id: string | number;
+      id: string;
       text: string;
       complete: boolean | null;
     } | null> | null;
@@ -309,7 +309,7 @@ test('infers fragment spreads on unions', () => {
       | { message: string; __typename: 'NoTodosError' }
       | {
           __typename: 'Todo';
-          id: string | number;
+          id: string;
           text: string;
           complete: boolean | null;
         };
@@ -321,7 +321,7 @@ test('infers fragment spreads on unions', () => {
   if (data.latestTodo.__typename === 'NoTodosError') {
     data.latestTodo.message satisfies string;
   } else if (data.latestTodo.__typename === 'Todo') {
-    data.latestTodo.id satisfies string | number;
+    data.latestTodo.id satisfies string;
   }
 });
 
@@ -349,8 +349,8 @@ test('infers fragment spreads inside fragment spreads on interfaces', () => {
   type actual = getDocumentType<query, schema>;
   type expected = {
     itodo:
-      | { wallOfText: string | null; id: string | number; __typename: 'BigTodo' }
-      | { maxLength: number | null; id: string | number; __typename: 'SmallTodo' };
+      | { wallOfText: string | null; id: string; __typename: 'BigTodo' }
+      | { maxLength: number | null; id: string; __typename: 'SmallTodo' };
   };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();
@@ -365,7 +365,7 @@ test('infers mutations', () => {
 
   type actual = getDocumentType<query, schema>;
   type expected = {
-    toggleTodo: { id: string | number } | null;
+    toggleTodo: { id: string } | null;
   };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();
@@ -393,13 +393,13 @@ test('infers unions and interfaces correctly', () => {
     test:
       | {
           __typename: 'SmallTodo';
-          id: string | number;
+          id: string;
           text: string;
           maxLength: number | null;
         }
       | {
           __typename: 'BigTodo';
-          id: string | number;
+          id: string;
           wallOfText: string | null;
         }
       | null;
@@ -449,7 +449,7 @@ test('infers queries from GitHub introspection schema', () => {
 
   type expected = {
     repository: {
-      id: string | number;
+      id: string;
     } | null;
   };
 
@@ -470,7 +470,7 @@ test('creates a type for a given fragment', () => {
 
   type expected = {
     __typename: 'Todo';
-    id: string | number;
+    id: string;
     text: string;
     complete: boolean | null;
   };
@@ -492,7 +492,7 @@ test('creates a type for a given fragment with optional inline spread', () => {
   type expected =
     | {}
     | {
-        id: number | string;
+        id: string;
       };
 
   expectTypeOf<expected>().toEqualTypeOf<actual>();

--- a/src/__tests__/selection.test.ts
+++ b/src/__tests__/selection.test.ts
@@ -37,7 +37,7 @@ describe('simple introspection', () => {
 
         expectTypeOf<{
           todos: Array<{
-            id: string | number;
+            id: string;
             text: string;
             complete: boolean | null;
           } | null> | null;
@@ -91,12 +91,12 @@ describe('simple introspection', () => {
         expectTypeOf<{
           test: null | {
             __typename: 'SmallTodo';
-            id: string | number;
+            id: string;
             text: string;
             maxLength: number | null;
           } | {
             __typename: 'BigTodo';
-            id: string | number;
+            id: string;
             wallOfText: string | null;
           };
         }>().toEqualTypeOf<actual>();

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -14,7 +14,7 @@ describe('getVariablesType', () => {
     type doc = parseDocument<typeof query>;
     type variables = getVariablesType<doc, schema>;
 
-    expectTypeOf<variables>().toEqualTypeOf<{ id: string | number }>();
+    expectTypeOf<variables>().toEqualTypeOf<{ id: string }>();
   });
 
   it('works for input-objects', () => {
@@ -28,7 +28,7 @@ describe('getVariablesType', () => {
     type variables = getVariablesType<doc, schema>;
 
     expectTypeOf<variables>().toEqualTypeOf<{
-      id: string | number;
+      id: string;
       input: { title: string; complete?: boolean | null; description: string };
     }>();
   });
@@ -43,8 +43,8 @@ describe('getVariablesType', () => {
     type doc = parseDocument<typeof query>;
     type variables = getVariablesType<doc, schema>;
 
-    expectTypeOf<variables>().toEqualTypeOf<{ id?: string | number | undefined }>();
-    expectTypeOf<variables['id']>().toEqualTypeOf<string | number | undefined>();
+    expectTypeOf<variables>().toEqualTypeOf<{ id?: string | undefined }>();
+    expectTypeOf<variables['id']>().toEqualTypeOf<string | undefined>();
   });
 
   it('allows optionals for default values inside input-objects', () => {
@@ -74,8 +74,8 @@ describe('getVariablesType', () => {
     type doc = parseDocument<typeof query>;
     type variables = getVariablesType<doc, schema>;
 
-    expectTypeOf<variables>().toEqualTypeOf<{ id?: string | number | null | undefined }>();
-    expectTypeOf<variables['id']>().toEqualTypeOf<string | number | null | undefined>();
+    expectTypeOf<variables>().toEqualTypeOf<{ id?: string | null | undefined }>();
+    expectTypeOf<variables['id']>().toEqualTypeOf<string | null | undefined>();
   });
 });
 

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -110,7 +110,7 @@ interface IntrospectionInputValue {
 }
 
 interface DefaultScalars {
-  ID: number | string;
+  ID: string;
   Boolean: boolean;
   String: string;
   Float: number;


### PR DESCRIPTION
Resolves #145 

## Summary

In the spec it is outlined that `ID` should always serialize to `string` https://spec.graphql.org/October2021/#sec-ID
