### PR TITLE
refactor: Accept pre-processed schemas as introspection inputs

### DIFF
--- a/.changeset/rotten-eagles-sort.md
+++ b/.changeset/rotten-eagles-sort.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Accept a pre-processed schema when setting up `gql.tada` for the `AbstractSetupSchema.introspection` option. This allows us to map an `IntrospectionQuery` ahead of time.

--- a/.changeset/rotten-eagles-sort.md
+++ b/.changeset/rotten-eagles-sort.md
@@ -1,5 +1,5 @@
 ---
-"gql.tada": patch
+"gql.tada": minor
 ---
 
 Accept a pre-processed schema when setting up `gql.tada` for the `AbstractSetupSchema.introspection` option. This allows us to map an `IntrospectionQuery` ahead of time.

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -368,29 +368,10 @@ export type simpleSchema = {
       };
     };
 
-    ID: {
-      kind: 'SCALAR';
-      name: 'ID';
-      type: string;
-    };
-
-    String: {
-      kind: 'SCALAR';
-      name: 'String';
-      type: string;
-    };
-
-    Boolean: {
-      kind: 'SCALAR';
-      name: 'Boolean';
-      type: boolean;
-    };
-
-    Int: {
-      kind: 'SCALAR';
-      name: 'Int';
-      type: number;
-    };
+    ID: unknown;
+    String: unknown;
+    Boolean: unknown;
+    Int: unknown;
 
     Author: {
       kind: 'OBJECT';

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -1,17 +1,16 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type { simpleIntrospection } from './fixtures/simpleIntrospection';
 import type { simpleSchema } from './fixtures/simpleSchema';
-import type { mapIntrospection } from '../introspection';
+import type { mapIntrospection, addIntrospectionScalars } from '../introspection';
 
 describe('mapIntrospection', () => {
   it('prepares sample schema', () => {
-    type expected = mapIntrospection<simpleIntrospection>;
+    type expected = addIntrospectionScalars<mapIntrospection<simpleIntrospection>>;
     expectTypeOf<expected>().toMatchTypeOf<simpleSchema>();
   });
 
   it('applies scalar types as appropriate', () => {
-    type expected = mapIntrospection<simpleIntrospection, { ID: 'ID' }>;
-
+    type expected = addIntrospectionScalars<mapIntrospection<simpleIntrospection>, { ID: 'ID' }>;
     type idScalar = expected['types']['ID']['type'];
     expectTypeOf<idScalar>().toEqualTypeOf<'ID'>();
   });

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -12,7 +12,7 @@ import type {
   makeDefinitionDecoration,
 } from '../namespace';
 
-type schema = simpleSchema;
+type schema = addIntrospectionScalars<simpleSchema>;
 
 test('infers simple fields', () => {
   type query = parseDocument</* GraphQL */ `

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -2,7 +2,7 @@ import { expectTypeOf, test } from 'vitest';
 
 import type { simpleSchema } from './fixtures/simpleSchema';
 import type { parseDocument } from '../parser';
-import type { mapIntrospection } from '../introspection';
+import type { mapIntrospection, addIntrospectionScalars } from '../introspection';
 import type { getDocumentType } from '../selection';
 
 import type {
@@ -435,7 +435,9 @@ test('infers __typename on union unambiguously', () => {
 });
 
 test('infers queries from GitHub introspection schema', () => {
-  type schema = mapIntrospection<import('./fixtures/githubIntrospection').githubIntrospection>;
+  type schema = addIntrospectionScalars<
+    mapIntrospection<import('./fixtures/githubIntrospection').githubIntrospection>
+  >;
 
   type repositories = parseDocument</* GraphQL */ `
     query ($org: String!, $repo: String!) {

--- a/src/__tests__/selection.test.ts
+++ b/src/__tests__/selection.test.ts
@@ -19,7 +19,7 @@ describe('simple introspection', () => {
         import { expectTypeOf } from 'expect-type';
         import { simpleIntrospection } from './simpleIntrospection';
         import { parseDocument } from './parser';
-        import { mapIntrospection } from './introspection';
+        import { mapIntrospection, addIntrospectionScalars } from './introspection';
         import { getDocumentType } from './selection';
 
         type query = parseDocument<\`
@@ -32,7 +32,7 @@ describe('simple introspection', () => {
           }
         \`>;
 
-        type schema = mapIntrospection<simpleIntrospection>;
+        type schema = addIntrospectionScalars<mapIntrospection<simpleIntrospection>>;
         type actual = getDocumentType<query, schema>;
 
         expectTypeOf<{
@@ -66,7 +66,7 @@ describe('simple introspection', () => {
         import { expectTypeOf } from 'expect-type';
         import { simpleIntrospection } from './simpleIntrospection';
         import { parseDocument } from './parser';
-        import { mapIntrospection } from './introspection';
+        import { mapIntrospection, addIntrospectionScalars } from './introspection';
         import { getDocumentType } from './selection';
 
         type query = parseDocument<\`
@@ -85,7 +85,7 @@ describe('simple introspection', () => {
           }
         \`>;
 
-        type schema = mapIntrospection<simpleIntrospection>;
+        type schema = addIntrospectionScalars<mapIntrospection<simpleIntrospection>>;
         type actual = getDocumentType<query, schema>;
 
         expectTypeOf<{

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -1,7 +1,10 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type { simpleSchema as schema } from './fixtures/simpleSchema';
+import type { simpleSchema } from './fixtures/simpleSchema';
+import type { addIntrospectionScalars } from '../introspection';
 import type { parseDocument } from '../parser';
 import type { getVariablesType, getScalarType } from '../variables';
+
+type schema = addIntrospectionScalars<simpleSchema>;
 
 describe('getVariablesType', () => {
   it('parses document-variables correctly', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,7 +4,7 @@ import { Kind, parse as _parse } from '@0no-co/graphql.web';
 import type {
   IntrospectionQuery,
   ScalarsLike,
-  IntrospectionLikeType,
+  SchemaLike,
   mapIntrospection,
   addIntrospectionScalars,
 } from './introspection';
@@ -83,7 +83,7 @@ interface setupSchema extends AbstractSetupSchema {
   /*empty*/
 }
 
-interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends AbstractConfig> {
+interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfig> {
   /** Function to create and compose GraphQL documents with result and variable types.
    *
    * @param input - A string of a GraphQL document.
@@ -300,7 +300,7 @@ function parse<const In extends stringLiteral<In>>(input: In): parseDocument<In>
 
 export type getDocumentNode<
   Document extends DocumentNodeLike,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any } = {},
   isMaskingDisabled = false,
 > = getDocumentType<Document, Introspection, Fragments> extends never

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@ import type { DocumentNode, DefinitionNode } from '@0no-co/graphql.web';
 import { Kind, parse as _parse } from '@0no-co/graphql.web';
 
 import type {
-  IntrospectionQuery,
+  IntrospectionLikeInput,
   ScalarsLike,
   SchemaLike,
   mapIntrospection,
@@ -36,7 +36,7 @@ import type { stringLiteral, obj, matchOr, writable, DocumentDecoration } from '
  * @param scalars - An object type with scalar names as keys and the corresponding scalar types as values.
  */
 interface AbstractSetupSchema {
-  introspection: IntrospectionQuery;
+  introspection: IntrospectionLikeInput;
   scalars?: ScalarsLike;
   disableMasking?: boolean;
 }
@@ -210,7 +210,7 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
 }
 
 type schemaOfSetup<Setup extends AbstractSetupSchema> = addIntrospectionScalars<
-  mapIntrospection<matchOr<IntrospectionQuery, Setup['introspection'], never>>,
+  mapIntrospection<matchOr<IntrospectionLikeInput, Setup['introspection'], never>>,
   matchOr<ScalarsLike, Setup['scalars'], {}>
 >;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ import type {
   ScalarsLike,
   IntrospectionLikeType,
   mapIntrospection,
+  addIntrospectionScalars,
 } from './introspection';
 
 import type {
@@ -208,8 +209,8 @@ interface GraphQLTadaAPI<Schema extends IntrospectionLikeType, Config extends Ab
     : never;
 }
 
-type schemaOfSetup<Setup extends AbstractSetupSchema> = mapIntrospection<
-  matchOr<IntrospectionQuery, Setup['introspection'], never>,
+type schemaOfSetup<Setup extends AbstractSetupSchema> = addIntrospectionScalars<
+  mapIntrospection<matchOr<IntrospectionQuery, Setup['introspection'], never>>,
   matchOr<ScalarsLike, Setup['scalars'], {}>
 >;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export type { DocumentDecoration } from './utils';
 
 // NOTE: This must be exported for `isolatedModules: true`
 export type { $tada } from './namespace';
+export type { mapIntrospection } from './introspection';

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -202,16 +202,18 @@ type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> =
   };
 }>;
 
-type mapIntrospection<Query extends IntrospectionQuery> = {
-  query: Query['__schema']['queryType']['name'];
-  mutation: Query['__schema']['mutationType'] extends { name: string }
-    ? Query['__schema']['mutationType']['name']
-    : never;
-  subscription: Query['__schema']['subscriptionType'] extends { name: string }
-    ? Query['__schema']['subscriptionType']['name']
-    : never;
-  types: mapIntrospectionTypes<Query>;
-};
+type mapIntrospection<Query extends IntrospectionLikeInput> = Query extends IntrospectionQuery
+  ? {
+      query: Query['__schema']['queryType']['name'];
+      mutation: Query['__schema']['mutationType'] extends { name: string }
+        ? Query['__schema']['mutationType']['name']
+        : never;
+      subscription: Query['__schema']['subscriptionType'] extends { name: string }
+        ? Query['__schema']['subscriptionType']['name']
+        : never;
+      types: mapIntrospectionTypes<Query>;
+    }
+  : Query;
 
 type addIntrospectionScalars<
   Schema extends SchemaLike,
@@ -222,6 +224,10 @@ type addIntrospectionScalars<
   subscription: Schema['subscription'];
   types: mapIntrospectionScalarTypes<Scalars> & Schema['types'];
 };
+
+/** Either a format of introspection data or an already preprocessed schema.
+ * @see {@link IntrospectionQuery} */
+export type IntrospectionLikeInput = SchemaLike | IntrospectionQuery;
 
 export type ScalarsLike = {
   [name: string]: any;

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -202,6 +202,7 @@ type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> =
   };
 }>;
 
+/** @internal */
 type mapIntrospection<Query extends IntrospectionLikeInput> = Query extends IntrospectionQuery
   ? {
       query: Query['__schema']['queryType']['name'];

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -214,7 +214,7 @@ type mapIntrospection<Query extends IntrospectionQuery> = {
 };
 
 type addIntrospectionScalars<
-  Schema extends IntrospectionLikeType,
+  Schema extends SchemaLike,
   Scalars extends ScalarsLike = DefaultScalars,
 > = {
   query: Schema['query'];
@@ -227,7 +227,7 @@ export type ScalarsLike = {
   [name: string]: any;
 };
 
-export type IntrospectionLikeType = {
+export type SchemaLike = {
   query: string;
   mutation?: any;
   subscription?: any;

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -182,15 +182,15 @@ type mapType<Type> = Type extends IntrospectionEnumType
             ? unknown
             : never;
 
-type mapIntrospectionTypes<Query extends IntrospectionQuery> = {
+type mapIntrospectionTypes<Query extends IntrospectionQuery> = obj<{
   [P in Query['__schema']['types'][number]['name']]: Query['__schema']['types'][number] extends infer Type
     ? Type extends { readonly name: P }
       ? mapType<Type>
       : never
     : never;
-};
+}>;
 
-type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> = {
+type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> = obj<{
   [P in keyof Scalars | keyof DefaultScalars]: {
     kind: 'SCALAR';
     name: P;
@@ -200,12 +200,9 @@ type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> =
         ? DefaultScalars[P]
         : 'wat';
   };
-};
+}>;
 
-type mapIntrospection<
-  Query extends IntrospectionQuery,
-  Scalars extends ScalarsLike = DefaultScalars,
-> = {
+type mapIntrospection<Query extends IntrospectionQuery> = {
   query: Query['__schema']['queryType']['name'];
   mutation: Query['__schema']['mutationType'] extends { name: string }
     ? Query['__schema']['mutationType']['name']
@@ -213,7 +210,17 @@ type mapIntrospection<
   subscription: Query['__schema']['subscriptionType'] extends { name: string }
     ? Query['__schema']['subscriptionType']['name']
     : never;
-  types: obj<mapIntrospectionTypes<Query> & mapIntrospectionScalarTypes<Scalars>>;
+  types: mapIntrospectionTypes<Query>;
+};
+
+type addIntrospectionScalars<
+  Schema extends IntrospectionLikeType,
+  Scalars extends ScalarsLike = DefaultScalars,
+> = {
+  query: Schema['query'];
+  mutation: Schema['mutation'];
+  subscription: Schema['subscription'];
+  types: mapIntrospectionScalarTypes<Scalars> & Schema['types'];
 };
 
 export type ScalarsLike = {
@@ -227,4 +234,4 @@ export type IntrospectionLikeType = {
   types: { [name: string]: any };
 };
 
-export type { mapIntrospectionTypes, mapIntrospection };
+export type { mapIntrospectionTypes, mapIntrospection, addIntrospectionScalars };

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -198,7 +198,7 @@ type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> =
       ? Scalars[P]
       : P extends keyof DefaultScalars
         ? DefaultScalars[P]
-        : 'wat';
+        : never;
   };
 }>;
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -4,7 +4,7 @@ import type { obj } from './utils';
 import type { DocumentNodeLike } from './parser';
 
 import type { $tada, makeUndefinedFragmentRef } from './namespace';
-import type { IntrospectionLikeType } from './introspection';
+import type { SchemaLike } from './introspection';
 
 type ObjectLikeType = {
   kind: 'OBJECT' | 'INTERFACE' | 'UNION';
@@ -15,7 +15,7 @@ type ObjectLikeType = {
 type unwrapTypeRec<
   Type,
   SelectionSet,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
   IsOptional,
 > = Type extends { readonly kind: 'NON_NULL'; readonly ofType: any }
@@ -76,7 +76,7 @@ type getFragmentSelection<
   Node,
   PossibleType extends string,
   Type extends ObjectLikeType,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
 > = Node extends { kind: Kind.INLINE_FRAGMENT; selectionSet: any }
   ? getPossibleTypeSelectionRec<
@@ -105,7 +105,7 @@ type getFragmentSelection<
 type getSpreadSubtype<
   Node,
   BaseType extends ObjectLikeType,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
 > = Node extends { kind: Kind.INLINE_FRAGMENT; typeCondition?: any }
   ? Node['typeCondition'] extends { kind: Kind.NAMED_TYPE; name: any }
@@ -124,7 +124,7 @@ type getTypenameOfType<Type> =
 type getSelection<
   Selections,
   Type extends ObjectLikeType,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
 > = Type extends { kind: 'UNION' | 'INTERFACE'; possibleTypes: any }
   ? {
@@ -150,7 +150,7 @@ type getPossibleTypeSelectionRec<
   Selections,
   PossibleType extends string,
   Type extends ObjectLikeType,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
   SelectionAcc,
 > = Selections extends [infer Node, ...infer Rest]
@@ -202,7 +202,7 @@ type getPossibleTypeSelectionRec<
 
 type getOperationSelectionType<
   Definition,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
 > = Definition extends {
   kind: Kind.OPERATION_DEFINITION;
@@ -217,7 +217,7 @@ type getOperationSelectionType<
 
 type getFragmentSelectionType<
   Definition,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any },
 > = Definition extends {
   kind: Kind.FRAGMENT_DEFINITION;
@@ -232,7 +232,7 @@ type getFragmentSelectionType<
 
 type getDocumentType<
   Document extends DocumentNodeLike,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   Fragments extends { [name: string]: any } = {},
 > = Document['definitions'] extends readonly [infer Definition, ...infer Rest]
   ? Definition extends { kind: Kind.OPERATION_DEFINITION }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,11 +1,11 @@
 import type { Kind } from '@0no-co/graphql.web';
-import type { IntrospectionLikeType } from './introspection';
+import type { SchemaLike } from './introspection';
 import type { DocumentNodeLike } from './parser';
 import type { obj } from './utils';
 
 type getInputObjectTypeRec<
   InputFields,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   InputObject = {},
 > = InputFields extends [infer InputField, ...infer Rest]
   ? getInputObjectTypeRec<
@@ -26,11 +26,10 @@ type getInputObjectTypeRec<
     >
   : InputObject;
 
-type unwrapTypeRec<
-  TypeRef,
-  Introspection extends IntrospectionLikeType,
-  IsOptional,
-> = TypeRef extends { kind: 'NON_NULL'; ofType: any }
+type unwrapTypeRec<TypeRef, Introspection extends SchemaLike, IsOptional> = TypeRef extends {
+  kind: 'NON_NULL';
+  ofType: any;
+}
   ? unwrapTypeRec<TypeRef['ofType'], Introspection, false>
   : TypeRef extends { kind: 'LIST'; ofType: any }
     ? IsOptional extends false
@@ -42,11 +41,10 @@ type unwrapTypeRec<
         : null | _getScalarType<TypeRef['name'], Introspection>
       : unknown;
 
-type unwrapTypeRefRec<
-  Type,
-  Introspection extends IntrospectionLikeType,
-  IsOptional,
-> = Type extends { kind: Kind.NON_NULL_TYPE; type: any }
+type unwrapTypeRefRec<Type, Introspection extends SchemaLike, IsOptional> = Type extends {
+  kind: Kind.NON_NULL_TYPE;
+  type: any;
+}
   ? unwrapTypeRefRec<Type['type'], Introspection, false>
   : Type extends { kind: Kind.LIST_TYPE; type: any }
     ? IsOptional extends false
@@ -60,7 +58,7 @@ type unwrapTypeRefRec<
 
 type _getVariablesRec<
   Variables,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   VariablesObject = {},
 > = Variables extends [infer Variable, ...infer Rest]
   ? _getVariablesRec<
@@ -89,7 +87,7 @@ type _getVariablesRec<
 
 type getVariablesType<
   Document extends DocumentNodeLike,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
 > = Document['definitions'][0] extends {
   kind: Kind.OPERATION_DEFINITION;
   variableDefinitions: any;
@@ -99,7 +97,7 @@ type getVariablesType<
 
 type _getScalarType<
   TypeName,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
 > = TypeName extends keyof Introspection['types']
   ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
     ? Introspection['types'][TypeName]['type']
@@ -110,7 +108,7 @@ type _getScalarType<
 
 type getScalarType<
   TypeName,
-  Introspection extends IntrospectionLikeType,
+  Introspection extends SchemaLike,
   OrType = never,
 > = TypeName extends keyof Introspection['types']
   ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }


### PR DESCRIPTION
## Summary

This allows the API to accept a pre-processed “`gql.tada` schema” to be accepted as the `introspection` option (i.e. on `AbstractSetupSchema` / `setupSchema`). Effectively, this means that `mapIntrospection` is used on demand, and only when the input hasn't already been run through `mapIntrospection` before.

This also required us to then split introspection mapping into two steps — one for the general remapping, and one for scalars.

## Set of changes

- Split `mapIntrospection` into non-scalar and scalar-adding steps
- Accept pre-processed schema as `introspection` option
