### PR TITLE
fix: Remove `stringLiteral` utility type

### DIFF
--- a/.changeset/real-dogs-swim.md
+++ b/.changeset/real-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Remove `stringLiteral` generic constraint, causing errors depending on TypeScript version

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,7 +20,7 @@ import type {
 import type { getDocumentType } from './selection';
 import type { parseDocument, DocumentNodeLike } from './parser';
 import type { getVariablesType, getScalarType } from './variables';
-import type { stringLiteral, obj, matchOr, writable, DocumentDecoration } from './utils';
+import type { obj, matchOr, writable, DocumentDecoration } from './utils';
 
 /** Abstract configuration type input for your schema and scalars.
  *
@@ -123,10 +123,7 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
    *
    * @see {@link readFragment} for how to read from fragment masks.
    */
-  <
-    const In extends stringLiteral<In>,
-    const Fragments extends readonly [...makeDefinitionDecoration[]],
-  >(
+  <const In extends string, const Fragments extends readonly [...makeDefinitionDecoration[]]>(
     input: In,
     fragments?: Fragments
   ): getDocumentNode<
@@ -163,14 +160,14 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
    * ```
    */
   scalar<
-    const Name extends stringLiteral<Name>,
+    const Name extends string,
     const Value extends getScalarType<Name, Schema, null | undefined>,
   >(
     name: Name,
     value: Value
   ): Value;
 
-  scalar<const Name extends stringLiteral<Name>>(
+  scalar<const Name extends string>(
     name: Name,
     value?: getScalarType<Name, Schema>
   ): getScalarType<Name, Schema>;
@@ -294,7 +291,7 @@ function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
  * GraphQL’s `parse` function. However, its return type will be the exact
  * structure of the AST parsed in types.
  */
-function parse<const In extends stringLiteral<In>>(input: In): parseDocument<In> {
+function parse<const In extends string>(input: In): parseDocument<In> {
   return _parse(input) as any;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,3 @@
-/** Constraints a given string to a string literal. */
-export type stringLiteral<T extends string> = string extends T ? never : string;
-
 /** Returns `T` if it matches `Constraint` without being equal to it. Failing this evaluates to `Fallback` otherwise. */
 export type matchOr<Constraint, T, Fallback> = Constraint extends T
   ? Fallback


### PR DESCRIPTION
This was causing an error, depending on the `typescript` version that's installed and used, due to the circular definition of the string literal generics.