### PR TITLE
chore(cli): Enable pre-processing by default

### DIFF
--- a/.changeset/kind-geckos-appear.md
+++ b/.changeset/kind-geckos-appear.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Enable pre-processed introspection output by default (since it only applies to `d.ts` outputs)

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -191,14 +191,15 @@ async function main() {
     })
     .command('generate-output')
     .option(
-      '--preprocess',
-      'Enables pre-processing, converting the introspection data to a more efficient schema structure ahead of time'
+      '--disable-preprocessing',
+      'Disables pre-processing, which is an internal introspection format generated ahead of time'
     )
     .describe(
       'Generate the gql.tada types file, this will look for your "tsconfig.json" and use the "@0no-co/graphqlsp" configuration to generate the file.'
     )
     .action((options) => {
-      const shouldPreprocess = !!options.preprocess && options.preprocess !== 'false';
+      const shouldPreprocess =
+        !options['disable-preprocessing'] && options['disable-preprocessing'] !== 'false';
       return generateTadaTypes(shouldPreprocess);
     });
   prog.parse(process.argv);


### PR DESCRIPTION
## Set of changes

- `$ gql.tada generate-output` now accepts a `--disable-preprocessing` flag
- Preprocessing is enabled by default
