### PR TITLE
feat(internal/cli): Implement schema loaders for URL/SDL inputs

### DIFF
--- a/.changeset/beige-tools-eat.md
+++ b/.changeset/beige-tools-eat.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Add `loadFromSDL` and `loadFromURL` schema loader utilities.

--- a/.changeset/swift-dolphins-join.md
+++ b/.changeset/swift-dolphins-join.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Update CLI with new schema loaders

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -71,15 +71,19 @@ export async function generateSchema(
 
 export async function generateTadaTypes(shouldPreprocess = false, cwd: string = process.cwd()) {
   const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
-  const hasTsConfig = existsSync(tsconfigpath);
-  if (!hasTsConfig) {
-    console.error('Missing tsconfig.json');
-    return;
-  }
 
   // TODO: Remove redundant read and move tsconfig.json handling to internal package
   const root = (await resolveTypeScriptRootDir(tsconfigpath)) || cwd;
-  const tsconfigContents = await fs.readFile(path.resolve(root, 'tsconfig.json'), 'utf-8');
+
+  let tsconfigContents: string;
+  try {
+    const file = path.resolve(root, 'tsconfig.json');
+    tsconfigContents = await fs.readFile(file, 'utf-8');
+  } catch (error) {
+    console.error('Failed to read tsconfig.json in current working directory.', error);
+    return;
+  }
+
   let tsConfig: TsConfigJson;
   try {
     tsConfig = parse(tsconfigContents) as TsConfigJson;

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -66,6 +66,7 @@ export async function generateSchema(
     }
   }
 
+  // TODO: Should the output be relative to the relevant `tsconfig.json` file?
   await fs.writeFile(path.resolve(cwd, destination), printSchema(schema), 'utf-8');
 }
 

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -137,7 +137,7 @@ async function main() {
       }
 
       return generateSchema(target, {
-        headers: parsedHeaders,
+        headers: Object.keys(parsedHeaders).length ? parsedHeaders : undefined,
         output: options.output,
       });
     })

--- a/packages/cli-utils/src/lsp.ts
+++ b/packages/cli-utils/src/lsp.ts
@@ -1,41 +1,48 @@
 import type { TsConfigJson } from 'type-fest';
 
+export type SchemaOrigin =
+  | string
+  | {
+      url: string;
+      headers: HeadersInit;
+    };
+
 export type GraphQLSPConfig = {
   name: string;
-  schema: string;
-  tadaOutputLocation?: string;
+  schema: SchemaOrigin;
+  tadaOutputLocation: string;
 };
 
-export function hasGraphQLSP(tsconfig: TsConfigJson): boolean {
-  if (!tsconfig.compilerOptions) {
+export function getGraphQLSPConfig(tsconfig: TsConfigJson): GraphQLSPConfig | null {
+  if (tsconfig.compilerOptions) {
+    if (tsconfig.compilerOptions.plugins) {
+      const foundPlugin = tsconfig.compilerOptions.plugins.find(
+        (plugin) => plugin.name === '@0no-co/graphqlsp' || plugin.name === 'gql.tada/lsp'
+      ) as GraphQLSPConfig | undefined;
+      if (!foundPlugin) {
+        console.error('Missing @0no-co/graphqlsp plugin in tsconfig.json.');
+        return null;
+      }
+
+      if (!foundPlugin.schema) {
+        console.warn('Missing schema property in @0no-co/graphqlsp plugin in tsconfig.json.');
+        return null;
+      }
+
+      if (!foundPlugin.tadaOutputLocation) {
+        console.warn(
+          'Missing tadaOutputLocation property in @0no-co/graphqlsp plugin in tsconfig.json.'
+        );
+        return null;
+      }
+
+      return foundPlugin;
+    } else {
+      console.warn('Missing plugins array in tsconfig.json.');
+      return null;
+    }
+  } else {
     console.warn('Missing compilerOptions object in tsconfig.json.');
-    return false;
+    return null;
   }
-
-  if (!tsconfig.compilerOptions.plugins) {
-    console.warn('Missing plugins array in tsconfig.json.');
-    return false;
-  }
-
-  const foundPlugin = tsconfig.compilerOptions.plugins.find(
-    (plugin) => plugin.name === '@0no-co/graphqlsp' || plugin.name === 'gql.tada/lsp'
-  ) as GraphQLSPConfig | undefined;
-  if (!foundPlugin) {
-    console.warn('Missing @0no-co/graphqlsp plugin in tsconfig.json.');
-    return false;
-  }
-
-  if (!foundPlugin.schema) {
-    console.warn('Missing schema property in @0no-co/graphqlsp plugin in tsconfig.json.');
-    return false;
-  }
-
-  if (!foundPlugin.tadaOutputLocation) {
-    console.warn(
-      'Missing tadaOutputLocation property in @0no-co/graphqlsp plugin in tsconfig.json.'
-    );
-    return false;
-  }
-
-  return true;
 }

--- a/packages/cli-utils/src/tada.ts
+++ b/packages/cli-utils/src/tada.ts
@@ -10,6 +10,8 @@ import {
   loadFromURL,
 } from '@gql.tada/internal';
 
+import type { SchemaOrigin } from './lsp';
+
 /**
  * This function mimics the behavior of the LSP, this so we can ensure
  * that gql.tada will work in any environment. The JetBrains IDE's do not
@@ -50,13 +52,6 @@ export async function ensureTadaIntrospection(
     console.error('Something went wrong while writing the introspection file', error);
   }
 }
-
-export type SchemaOrigin =
-  | string
-  | {
-      url: string;
-      headers: HeadersInit;
-    };
 
 const getURLConfig = (origin: SchemaOrigin) => {
   if (typeof origin === 'string') {

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -41,8 +41,10 @@
     "prepublishOnly": "run-s clean build"
   },
   "devDependencies": {
-    "@urql/introspection": "^1.0.3",
     "@types/node": "^20.11.0",
+    "@urql/core": "^4.3.0",
+    "@urql/exchange-retry": "^1.2.1",
+    "@urql/introspection": "^1.0.3",
     "json5": "^2.2.3",
     "rollup": "^4.9.4",
     "sade": "^1.8.1",
@@ -50,6 +52,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@0no-co/graphql.web": "^1.0.4",
     "graphql": "^16.8.1"
   },
   "peerDependencies": {

--- a/packages/internal/src/index.ts
+++ b/packages/internal/src/index.ts
@@ -1,4 +1,5 @@
 export * from './vfs';
+export * from './loaders';
 
 export {
   minifyIntrospection,

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -1,0 +1,3 @@
+export type { SchemaLoader } from './types';
+export { loadFromSDL } from './sdl';
+export { loadFromURL } from './url';

--- a/packages/internal/src/loaders/query.ts
+++ b/packages/internal/src/loaders/query.ts
@@ -37,7 +37,7 @@ export const toSupportedFeatures = (data: IntrospectSupportQueryData): Supported
 let _introspectionQuery: DocumentNode | undefined;
 let _previousSupport: SupportedFeatures | undefined;
 /** Builds an introspection query as AST */
-export const makeIntrospectionQuery = (support: SupportedFeatures) => {
+export const makeIntrospectionQuery = (support: SupportedFeatures): DocumentNode => {
   if (_introspectionQuery && _previousSupport === support) {
     return _introspectionQuery;
   } else {

--- a/packages/internal/src/loaders/query.ts
+++ b/packages/internal/src/loaders/query.ts
@@ -1,0 +1,506 @@
+import { Kind, OperationTypeNode } from '@0no-co/graphql.web';
+
+import type {
+  SelectionSetNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+  FieldNode,
+  DocumentNode,
+} from '@0no-co/graphql.web';
+
+/** Support matrix to be used in the {@link makeIntrospectionQuery} builder */
+export interface SupportedFeatures {
+  directiveIsRepeatable: boolean;
+  specifiedByURL: boolean;
+  inputValueDeprecation: boolean;
+}
+
+/** Data from a {@link makeIntrospectSupportQuery} result */
+export interface IntrospectSupportQueryData {
+  directive: { fields: { name: string }[] | null } | null;
+  type: { fields: { name: string }[] | null } | null;
+  inputValue: { fields: { name: string }[] | null } | null;
+}
+
+const _hasField = (
+  data: IntrospectSupportQueryData[keyof IntrospectSupportQueryData],
+  fieldName: string
+): boolean => !!data && !!data.fields && data.fields.some((field) => field.name === fieldName);
+
+/** Evaluates data from a {@link makeIntrospectSupportQuery} result to {@link SupportedFeatures} */
+export const toSupportedFeatures = (data: IntrospectSupportQueryData): SupportedFeatures => ({
+  directiveIsRepeatable: _hasField(data.directive, 'isRepeatable'),
+  specifiedByURL: _hasField(data.type, 'specifiedByURL'),
+  inputValueDeprecation: _hasField(data.inputValue, 'isDeprecated'),
+});
+
+let _introspectionQuery: DocumentNode | undefined;
+let _previousSupport: SupportedFeatures | undefined;
+/** Builds an introspection query as AST */
+export const makeIntrospectionQuery = (support: SupportedFeatures) => {
+  if (_introspectionQuery && _previousSupport === support) {
+    return _introspectionQuery;
+  } else {
+    return (_introspectionQuery = _makeIntrospectionQuery((_previousSupport = support)));
+  }
+};
+
+const _makeIntrospectionQuery = (support: SupportedFeatures): DocumentNode => ({
+  kind: Kind.DOCUMENT,
+  definitions: [
+    {
+      kind: Kind.OPERATION_DEFINITION,
+      name: { kind: Kind.NAME, value: 'IntrospectionQuery' },
+      operation: OperationTypeNode.QUERY,
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: '__schema' },
+            selectionSet: _makeSchemaSelection(support),
+          },
+        ],
+      },
+    } satisfies OperationDefinitionNode,
+
+    _makeSchemaFullTypeFragment(support),
+    _makeSchemaInputValueFragment(support),
+    _makeTypeRefFragment(),
+  ],
+});
+
+/** Builds a support matrix query resulting in {@link IntrospectSupportQueryData} results */
+export const makeIntrospectSupportQuery = (): DocumentNode => ({
+  kind: Kind.DOCUMENT,
+  definitions: [
+    {
+      kind: Kind.OPERATION_DEFINITION,
+      name: { kind: Kind.NAME, value: 'IntrospectSupportQuery' },
+      operation: OperationTypeNode.QUERY,
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'directive' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__Directive' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection(),
+          },
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'type' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__Type' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection(),
+          },
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'inputValue' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__InputValue' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection(),
+          },
+        ],
+      },
+    } satisfies OperationDefinitionNode,
+  ],
+});
+
+const _makeFieldNamesSelection = (): SelectionSetNode => ({
+  kind: Kind.SELECTION_SET,
+  selections: [
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'fields' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+const _makeSchemaSelection = (support: SupportedFeatures): SelectionSetNode => ({
+  kind: Kind.SELECTION_SET,
+  selections: [
+    // queryType { name }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'queryType' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+    // mutationType { name }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'mutationType' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+    // subscriptionType { name }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'mutationType' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+    // types { ...FullType }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'types' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FRAGMENT_SPREAD,
+            name: { kind: Kind.NAME, value: 'FullType' },
+          },
+        ],
+      },
+    },
+    // directives { name description locations args }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'directives' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'description' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'locations' },
+          },
+          _makeSchemaArgsField(support),
+          ...(support.directiveIsRepeatable
+            ? ([
+                {
+                  kind: Kind.FIELD,
+                  name: { kind: Kind.NAME, value: 'isRepeatable' },
+                },
+              ] as const)
+            : []),
+        ],
+      },
+    },
+  ],
+});
+
+const _makeSchemaFullTypeFragment = (support: SupportedFeatures): FragmentDefinitionNode => ({
+  kind: Kind.FRAGMENT_DEFINITION,
+  name: { kind: Kind.NAME, value: 'FullType' },
+  typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: '__Type' } },
+  selectionSet: {
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'kind' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'name' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'description' },
+      },
+      ...(support.specifiedByURL
+        ? ([
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'specifiedByURL' },
+            },
+          ] as const)
+        : []),
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'fields' },
+        arguments: [
+          {
+            kind: Kind.ARGUMENT,
+            name: { kind: Kind.NAME, value: 'includeDeprecated' },
+            value: { kind: Kind.BOOLEAN, value: true },
+          },
+        ],
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'name' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'description' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'isDeprecated' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'deprecationReason' },
+            },
+            _makeSchemaArgsField(support),
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'type' },
+              selectionSet: {
+                kind: Kind.SELECTION_SET,
+                selections: [
+                  {
+                    kind: Kind.FRAGMENT_SPREAD,
+                    name: { kind: Kind.NAME, value: 'TypeRef' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'interfaces' },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'TypeRef' },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'possibleTypes' },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'TypeRef' },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'inputFields' },
+        arguments: support.inputValueDeprecation
+          ? [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'includeDeprecated' },
+                value: { kind: Kind.BOOLEAN, value: true },
+              },
+            ]
+          : [],
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'InputValue' },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'enumValues' },
+        arguments: [
+          {
+            kind: Kind.ARGUMENT,
+            name: { kind: Kind.NAME, value: 'includeDeprecated' },
+            value: { kind: Kind.BOOLEAN, value: true },
+          },
+        ],
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+
+          selections: [
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'name' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'description' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'isDeprecated' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'deprecationReason' },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+const _makeSchemaArgsField = (support: SupportedFeatures): FieldNode => ({
+  kind: Kind.FIELD,
+  name: { kind: Kind.NAME, value: 'args' },
+  arguments: support.inputValueDeprecation
+    ? [
+        {
+          kind: Kind.ARGUMENT,
+          name: { kind: Kind.NAME, value: 'includeDeprecated' },
+          value: { kind: Kind.BOOLEAN, value: true },
+        },
+      ]
+    : [],
+  selectionSet: {
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FRAGMENT_SPREAD,
+        name: { kind: Kind.NAME, value: 'InputValue' },
+      },
+    ],
+  },
+});
+
+const _makeSchemaInputValueFragment = (support: SupportedFeatures): FragmentDefinitionNode => ({
+  kind: Kind.FRAGMENT_DEFINITION,
+  name: { kind: Kind.NAME, value: 'InputValue' },
+  typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: '__InputValue' } },
+  selectionSet: {
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'name' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'description' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'defaultValue' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'type' },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'TypeRef' },
+            },
+          ],
+        },
+      },
+      ...(support.inputValueDeprecation
+        ? ([
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'isDeprecated' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'deprecationReason' },
+            },
+          ] as const)
+        : []),
+    ],
+  },
+});
+
+const _makeTypeRefFragment = (): FragmentDefinitionNode => ({
+  kind: Kind.FRAGMENT_DEFINITION,
+  name: { kind: Kind.NAME, value: 'TypeRef' },
+  typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: '__Type' } },
+  selectionSet: _makeTypeRefSelection(0),
+});
+
+const _makeTypeRefSelection = (depth: number): SelectionSetNode => ({
+  kind: Kind.SELECTION_SET,
+  selections:
+    depth < 9
+      ? [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'kind' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'ofType' },
+            selectionSet: _makeTypeRefSelection(depth + 1),
+          },
+        ]
+      : [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'kind' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+});

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -1,0 +1,98 @@
+import type { IntrospectionQuery, GraphQLSchema } from 'graphql';
+import { buildSchema, buildClientSchema, executeSync } from 'graphql';
+import { CombinedError } from '@urql/core';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { SupportedFeatures } from './query';
+import { makeIntrospectionQuery } from './query';
+
+import type { SchemaLoader } from './types';
+
+interface LoadFromSDLConfig {
+  assumeValid?: boolean;
+  file: string;
+}
+
+const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
+  directiveIsRepeatable: true,
+  specifiedByURL: true,
+  inputValueDeprecation: true,
+};
+
+export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
+  const subscriptions = new Set<() => void>();
+
+  let controller: AbortController | null = null;
+  let introspection: IntrospectionQuery | null = null;
+  let schema: GraphQLSchema | null = null;
+
+  const watch = async () => {
+    controller = new AbortController();
+    const watcher = fs.watch(config.file, {
+      persistent: false,
+      signal: controller.signal,
+    });
+
+    try {
+      for await (const event of watcher) {
+        if (event.eventType === 'rename' || !subscriptions.size) break;
+        for (const subscriber of subscriptions) subscriber();
+      }
+    } catch (error: any) {
+      if (error.name === 'AbortError') {
+        return;
+      } else {
+        throw error;
+      }
+    } finally {
+      controller = null;
+    }
+  };
+
+  const introspect = async () => {
+    const ext = path.extname(config.file);
+    const data = await fs.readFile(config.file, { encoding: 'utf8' });
+    if (ext === '.json') {
+      introspection = JSON.parse(data) || null;
+      schema =
+        introspection && buildClientSchema(introspection, { assumeValid: !!config.assumeValid });
+      return introspection;
+    } else {
+      schema = buildSchema(data, { assumeValidSDL: !!config.assumeValid });
+      const query = makeIntrospectionQuery(ALL_SUPPORTED_FEATURES);
+      const result = executeSync({ schema, document: query });
+      if (result.errors) {
+        throw new CombinedError({ graphQLErrors: result.errors as any[] });
+      } else if (result.data) {
+        return (introspection = (result.data as any) || null);
+      } else {
+        return (introspection = null);
+      }
+    }
+  };
+
+  return {
+    async loadIntrospection() {
+      return introspect();
+    },
+    async loadSchema() {
+      if (schema) {
+        return schema;
+      } else {
+        await this.loadIntrospection();
+        return schema;
+      }
+    },
+    notifyOnUpdate(onUpdate) {
+      if (!subscriptions.size) watch();
+      subscriptions.add(onUpdate);
+      return () => {
+        subscriptions.delete(onUpdate);
+        if (!subscriptions.size && controller) {
+          controller.abort();
+        }
+      };
+    },
+  };
+}

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -1,0 +1,7 @@
+import type { IntrospectionQuery, GraphQLSchema } from 'graphql';
+
+export interface SchemaLoader {
+  loadIntrospection(): Promise<IntrospectionQuery | null>;
+  loadSchema(): Promise<GraphQLSchema | null>;
+  notifyOnUpdate(onUpdate: () => void): () => void;
+}

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -1,0 +1,128 @@
+import type { IntrospectionQuery, GraphQLSchema } from 'graphql';
+import { buildClientSchema } from 'graphql';
+import { Client, fetchExchange } from '@urql/core';
+import { retryExchange } from '@urql/exchange-retry';
+
+import type { SupportedFeatures, IntrospectSupportQueryData } from './query';
+
+import { makeIntrospectionQuery, makeIntrospectSupportQuery, toSupportedFeatures } from './query';
+
+import type { SchemaLoader } from './types';
+
+interface LoadFromURLConfig {
+  url: URL | string;
+  headers?: HeadersInit;
+  interval?: number;
+}
+
+const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
+  directiveIsRepeatable: true,
+  specifiedByURL: true,
+  inputValueDeprecation: true,
+};
+
+const NO_SUPPORTED_FEATURES: SupportedFeatures = {
+  directiveIsRepeatable: false,
+  specifiedByURL: false,
+  inputValueDeprecation: false,
+};
+
+export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
+  const interval = config.interval || 60_000;
+  const subscriptions = new Set<() => void>();
+
+  let timeoutID: NodeJS.Timeout | null = null;
+  let supportedFeatures: SupportedFeatures | null = null;
+  let introspection: IntrospectionQuery | null = null;
+  let schema: GraphQLSchema | null = null;
+
+  const client = new Client({
+    url: `${config.url}`,
+    fetchOptions: { headers: config.headers },
+    exchanges: [retryExchange({ initialDelayMs: 200, maxDelayMs: 1_500 }), fetchExchange],
+  });
+
+  const scheduleUpdate = () => {
+    if (subscriptions.size && !timeoutID) {
+      timeoutID = setTimeout(() => {
+        for (const subscriber of subscriptions) subscriber();
+        timeoutID = null;
+      }, interval);
+    }
+  };
+
+  const introspect = async (support: SupportedFeatures): Promise<IntrospectionQuery | null> => {
+    const query = makeIntrospectionQuery(support);
+    const result = await client.query<IntrospectionQuery>(query, {});
+
+    try {
+      if (result.error && result.error.graphQLErrors.length > 0) {
+        schema = null;
+        return (introspection = null);
+      } else if (result.error) {
+        schema = null;
+        throw result.error;
+      } else {
+        schema = null;
+        return (introspection = result.data || null);
+      }
+    } finally {
+      scheduleUpdate();
+    }
+  };
+
+  return {
+    async loadIntrospection() {
+      if (!supportedFeatures) {
+        const query = makeIntrospectSupportQuery();
+        const result = await client.query<IntrospectSupportQueryData>(query, {});
+        if (result.error && result.error.graphQLErrors.length > 0) {
+          // If we failed to determine support, we try to activate all introspection features
+          introspection = await introspect(ALL_SUPPORTED_FEATURES);
+          if (introspection) {
+            // If we succeed, we can return the introspection and enable all introspection features
+            supportedFeatures = ALL_SUPPORTED_FEATURES;
+            return introspection;
+          } else {
+            // Otherwise, we assume no extra introspection features are supported,
+            // since all introspection spec additions were made in a single spec revision
+            supportedFeatures = NO_SUPPORTED_FEATURES;
+          }
+        } else if (result.data && !result.error) {
+          // Succeeding the support query, we get the supported features
+          supportedFeatures = toSupportedFeatures(result.data);
+        } else if (result.error) {
+          // On misc. error, we rethrow and reset supported features
+          supportedFeatures = null;
+          throw result.error;
+        } else {
+          // Otherwise we assume no features are supported
+          supportedFeatures = NO_SUPPORTED_FEATURES;
+        }
+      }
+
+      return introspect(supportedFeatures);
+    },
+
+    async loadSchema() {
+      if (schema) {
+        return schema;
+      } else {
+        const introspection = await this.loadIntrospection();
+        schema = introspection && buildClientSchema(introspection, { assumeValid: true });
+        return schema;
+      }
+    },
+
+    notifyOnUpdate(onUpdate) {
+      subscriptions.add(onUpdate);
+      return () => {
+        subscriptions.delete(onUpdate);
+        if (!subscriptions.size && timeoutID) {
+          clearTimeout(timeoutID);
+          timeoutID = null;
+        }
+      };
+    },
+  };
+}

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 import JSON5 from 'json5';
+import fs from 'node:fs/promises';
 import type { TsConfigJson } from 'type-fest';
 
-export const resolveTypeScriptRootDir = (
-  readFile: (path: string) => string | undefined,
+export const resolveTypeScriptRootDir = async (
   tsconfigPath: string
-): string | undefined => {
-  const tsconfigContents = readFile(tsconfigPath);
-  const parsed = JSON5.parse<TsConfigJson>(tsconfigContents!);
+): Promise<string | undefined> => {
+  const tsconfigContents = await fs.readFile(tsconfigPath, { encoding: 'utf8' });
+  const parsed = JSON5.parse<TsConfigJson>(tsconfigContents);
 
   if (
     parsed.compilerOptions &&
@@ -22,12 +22,12 @@ export const resolveTypeScriptRootDir = (
       const resolved = require.resolve(p, {
         paths: [path.dirname(tsconfigPath)],
       });
-      return resolveTypeScriptRootDir(readFile, resolved);
+      return resolveTypeScriptRootDir(resolved);
     });
   } else if (parsed.extends) {
     const resolved = require.resolve(parsed.extends, {
       paths: [path.dirname(tsconfigPath)],
     });
-    return resolveTypeScriptRootDir(readFile, resolved);
+    return resolveTypeScriptRootDir(resolved);
   }
 };

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -3,6 +3,7 @@ import JSON5 from 'json5';
 import fs from 'node:fs/promises';
 import type { TsConfigJson } from 'type-fest';
 
+// TODO: Replace config loading with typescript package's native config loading
 export const resolveTypeScriptRootDir = async (
   tsconfigPath: string
 ): Promise<string | undefined> => {
@@ -19,6 +20,8 @@ export const resolveTypeScriptRootDir = async (
     return path.dirname(tsconfigPath);
   } else if (Array.isArray(parsed.extends)) {
     return parsed.extends.find((p) => {
+      // TODO: This doesn't account for *.json being omitted
+      // See: https://www.typescriptlang.org/tsconfig#extends
       const resolved = require.resolve(p, {
         paths: [path.dirname(tsconfigPath)],
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
 
   packages/internal:
     dependencies:
+      '@0no-co/graphql.web':
+        specifier: ^1.0.4
+        version: 1.0.4(graphql@16.8.1)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -185,6 +188,12 @@ importers:
       '@types/node':
         specifier: ^20.11.0
         version: 20.11.0
+      '@urql/core':
+        specifier: ^4.3.0
+        version: 4.3.0(graphql@16.8.1)
+      '@urql/exchange-retry':
+        specifier: ^1.2.1
+        version: 1.2.1(graphql@16.8.1)
       '@urql/introspection':
         specifier: ^1.0.3
         version: 1.0.3(graphql@16.8.1)
@@ -264,7 +273,6 @@ packages:
         optional: true
     dependencies:
       graphql: 16.8.1
-    dev: false
 
   /@0no-co/graphqlsp@1.5.0:
     resolution: {integrity: sha512-NGMUwzj7m6DfIqudZxfTfUEmzKR2n9xphPssCKqkGsMEKe9qIzrNqLpXXwzXTWrGBS5FBELW+TXGUyTa0v1LAw==}
@@ -2133,7 +2141,15 @@ packages:
       wonka: 6.3.4
     transitivePeerDependencies:
       - graphql
-    dev: false
+
+  /@urql/exchange-retry@1.2.1(graphql@16.8.1):
+    resolution: {integrity: sha512-+BP73EJA0zJpGbdU1V6l2v8hb2m7/9dMHnF85ZjkaG6INkq4O7Tu9+jfC2wYxt2cajRxgxOoAL3iEJ5Xeerzyg==}
+    dependencies:
+      '@urql/core': 4.3.0(graphql@16.8.1)
+      wonka: 6.3.4
+    transitivePeerDependencies:
+      - graphql
+    dev: true
 
   /@urql/introspection@1.0.3(graphql@16.8.1):
     resolution: {integrity: sha512-5zgnfUDV10c3qudqYvfZ/rOtWVB2QvqanmoDMttqpt+TCCPkSUZdb2qcLCEB6DL7ph8mQRTZhXI29J57nTnqKg==}
@@ -6404,7 +6420,6 @@ packages:
 
   /wonka@6.3.4:
     resolution: {integrity: sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==}
-    dev: false
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}


### PR DESCRIPTION
Resolve #142
Related to #76

## Summary

This implements reusable loaders for GraphQL schemas from URLs and SDL/JSON files. It unifies the current logic that was used in the CLI and is placed in `@gql.tada/internal` so it's reusable for GraphQLSP.

The new `loadFromURL` loader also checks for schema support and enables the optional introspection features as needed.

## Set of changes

- **Remaining TODOs for current code are annotated** (mostly around `tsconfig` handling)
- Implement `loadFromSDL` and `loadFromURL` with watchers
- Replace current CLI logic with loaders
- Clean up `tsconfig` resolving logic
