### PR TITLE
fix(internal): Improve loader by adding a merged loader and incorporating `SchemaOrigin` parsing

### DIFF
--- a/.changeset/twelve-tips-rush.md
+++ b/.changeset/twelve-tips-rush.md
@@ -1,0 +1,6 @@
+---
+"@gql.tada/cli-utils": patch
+"@gql.tada/internal": patch
+---
+
+Update internal loader to merge them into one and incorporate `SchemaOrigin` parsing

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -6,10 +6,10 @@ import { printSchema } from 'graphql';
 
 import type { GraphQLSchema } from 'graphql';
 import type { TsConfigJson } from 'type-fest';
-import { resolveTypeScriptRootDir } from '@gql.tada/internal';
+import { resolveTypeScriptRootDir, load } from '@gql.tada/internal';
 
 import { getGraphQLSPConfig } from './lsp';
-import { ensureTadaIntrospection, makeLoader } from './tada';
+import { ensureTadaIntrospection } from './tada';
 
 interface GenerateSchemaOptions {
   headers?: Record<string, string>;
@@ -21,7 +21,8 @@ export async function generateSchema(
   target: string,
   { headers, output, cwd = process.cwd() }: GenerateSchemaOptions
 ) {
-  const loader = makeLoader(cwd, headers ? { url: target, headers } : target);
+  const origin = headers ? { url: target, headers } : target;
+  const loader = load({ origin, rootPath: cwd });
 
   let schema: GraphQLSchema | null;
   try {

--- a/packages/cli-utils/src/lsp.ts
+++ b/packages/cli-utils/src/lsp.ts
@@ -1,11 +1,5 @@
 import type { TsConfigJson } from 'type-fest';
-
-export type SchemaOrigin =
-  | string
-  | {
-      url: string;
-      headers: HeadersInit;
-    };
+import type { SchemaOrigin } from '@gql.tada/internal';
 
 export type GraphQLSPConfig = {
   name: string;

--- a/packages/cli-utils/src/tada.ts
+++ b/packages/cli-utils/src/tada.ts
@@ -4,13 +4,11 @@ import type { IntrospectionQuery } from 'graphql';
 import type { SchemaLoader } from '@gql.tada/internal';
 
 import {
+  type SchemaOrigin,
   minifyIntrospection,
   outputIntrospectionFile,
-  loadFromSDL,
-  loadFromURL,
+  load,
 } from '@gql.tada/internal';
-
-import type { SchemaOrigin } from './lsp';
 
 /**
  * This function mimics the behavior of the LSP, this so we can ensure
@@ -20,12 +18,12 @@ import type { SchemaOrigin } from './lsp';
  * this function.
  */
 export async function ensureTadaIntrospection(
-  schemaLocation: SchemaOrigin,
+  origin: SchemaOrigin,
   outputLocation: string,
   base: string = process.cwd(),
   shouldPreprocess = true
 ) {
-  const loader = makeLoader(base, schemaLocation);
+  const loader = load({ origin, rootPath: base });
 
   let introspection: IntrospectionQuery | null;
   try {
@@ -52,27 +50,6 @@ export async function ensureTadaIntrospection(
     console.error('Something went wrong while writing the introspection file', error);
   }
 }
-
-const getURLConfig = (origin: SchemaOrigin) => {
-  if (typeof origin === 'string') {
-    try {
-      return { url: new URL(origin) };
-    } catch (_error) {
-      return null;
-    }
-  } else if (typeof origin.url === 'string') {
-    try {
-      return {
-        url: new URL(origin.url),
-        headers: origin.headers,
-      };
-    } catch (error) {
-      throw new Error(`Input URL "${origin.url}" is invalid`);
-    }
-  } else {
-    return null;
-  }
-};
 
 export function makeLoader(root: string, origin: SchemaOrigin): SchemaLoader {
   const urlOrigin = getURLConfig(origin);

--- a/packages/cli-utils/src/tada.ts
+++ b/packages/cli-utils/src/tada.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { IntrospectionQuery } from 'graphql';
-import type { SchemaLoader } from '@gql.tada/internal';
 
 import {
   type SchemaOrigin,
@@ -48,17 +47,5 @@ export async function ensureTadaIntrospection(
     await fs.writeFile(resolvedOutputLocation, contents);
   } catch (error) {
     console.error('Something went wrong while writing the introspection file', error);
-  }
-}
-
-export function makeLoader(root: string, origin: SchemaOrigin): SchemaLoader {
-  const urlOrigin = getURLConfig(origin);
-  if (urlOrigin) {
-    return loadFromURL(urlOrigin);
-  } else if (typeof origin === 'string') {
-    const file = path.resolve(root, origin);
-    return loadFromSDL({ file, assumeValid: true });
-  } else {
-    throw new Error(`Configuration contains an invalid "schema" option`);
   }
 }

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -1,3 +1,41 @@
-export type { SchemaLoader } from './types';
-export { loadFromSDL } from './sdl';
-export { loadFromURL } from './url';
+export type * from './types';
+
+import path from 'node:path';
+import type { SchemaLoader, SchemaOrigin } from './types';
+import { loadFromSDL } from './sdl';
+import { loadFromURL } from './url';
+
+export { loadFromSDL, loadFromURL };
+
+const getURLConfig = (origin: SchemaOrigin | null) => {
+  try {
+    return (
+      origin && {
+        url: new URL(typeof origin === 'object' ? origin.url : origin),
+        headers: typeof origin === 'object' ? origin.headers : undefined,
+      }
+    );
+  } catch (_error) {
+    throw new Error(`Configuration contains an invalid "schema" option`);
+  }
+};
+
+export interface LoadConfig {
+  origin: SchemaOrigin;
+  rootPath?: string;
+  fetchInterval?: number;
+  assumeValid?: boolean;
+}
+
+export function load(config: LoadConfig): SchemaLoader {
+  const urlOrigin = getURLConfig(origin);
+  if (urlOrigin) {
+    return loadFromURL({ ...urlOrigin, interval: config.fetchInterval });
+  } else if (typeof origin === 'string') {
+    const file = config.rootPath ? path.resolve(config.rootPath, origin) : origin;
+    const assumeValid = config.assumeValid != null ? config.assumeValid : true;
+    return loadFromSDL({ file, assumeValid });
+  } else {
+    throw new Error(`Configuration contains an invalid "schema" option`);
+  }
+}

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -30,7 +30,10 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
     const ext = path.extname(config.file);
     const data = await fs.readFile(config.file, { encoding: 'utf8' });
     if (ext === '.json') {
-      const introspection: IntrospectionQuery | null = JSON.parse(data) || null;
+      let introspection: IntrospectionQuery | null = null;
+      try {
+        introspection = JSON.parse(data);
+      } catch (_error) {}
       return (
         introspection && {
           introspection,

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -67,11 +67,15 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
   };
 
   return {
-    async loadIntrospection() {
-      return introspect();
+    async loadIntrospection(reload?: boolean) {
+      if (!reload && introspection) {
+        return introspection;
+      } else {
+        return introspect();
+      }
     },
-    async loadSchema() {
-      if (schema) {
+    async loadSchema(reload?: boolean) {
+      if (!reload && schema) {
         return schema;
       } else {
         await this.loadIntrospection();

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -30,21 +30,15 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
   const watch = async () => {
     controller = new AbortController();
     const watcher = fs.watch(config.file, {
-      persistent: false,
       signal: controller.signal,
+      persistent: false,
     });
-
     try {
-      for await (const event of watcher) {
-        if (event.eventType === 'rename' || !subscriptions.size) break;
+      for await (const _event of watcher) {
         for (const subscriber of subscriptions) subscriber();
       }
     } catch (error: any) {
-      if (error.name === 'AbortError') {
-        return;
-      } else {
-        throw error;
-      }
+      if (error.name !== 'AbortError') throw error;
     } finally {
       controller = null;
     }

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -16,3 +16,10 @@ export interface SchemaLoader {
   /** @internal */
   loadSchema(): Promise<GraphQLSchema | null>;
 }
+
+export type SchemaOrigin =
+  | string
+  | {
+      url: string;
+      headers?: HeadersInit;
+    };

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -1,7 +1,18 @@
 import type { IntrospectionQuery, GraphQLSchema } from 'graphql';
 
+export interface SchemaLoaderResult {
+  introspection: IntrospectionQuery;
+  schema: GraphQLSchema;
+}
+
+export type OnSchemaUpdate = (result: SchemaLoaderResult) => void;
+
 export interface SchemaLoader {
-  loadIntrospection(reload?: boolean): Promise<IntrospectionQuery | null>;
-  loadSchema(reload?: boolean): Promise<GraphQLSchema | null>;
-  notifyOnUpdate(onUpdate: () => void): () => void;
+  load(reload?: boolean): Promise<SchemaLoaderResult | null>;
+  notifyOnUpdate(onUpdate: OnSchemaUpdate): () => void;
+
+  /** @internal */
+  loadIntrospection(): Promise<IntrospectionQuery | null>;
+  /** @internal */
+  loadSchema(): Promise<GraphQLSchema | null>;
 }

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -1,7 +1,7 @@
 import type { IntrospectionQuery, GraphQLSchema } from 'graphql';
 
 export interface SchemaLoader {
-  loadIntrospection(): Promise<IntrospectionQuery | null>;
-  loadSchema(): Promise<GraphQLSchema | null>;
+  loadIntrospection(reload?: boolean): Promise<IntrospectionQuery | null>;
+  loadSchema(reload?: boolean): Promise<GraphQLSchema | null>;
   notifyOnUpdate(onUpdate: () => void): () => void;
 }

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -72,7 +72,11 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
   };
 
   return {
-    async loadIntrospection() {
+    async loadIntrospection(reload?: boolean) {
+      if (!reload && introspection) {
+        return introspection;
+      }
+
       if (!supportedFeatures) {
         const query = makeIntrospectSupportQuery();
         const result = await client.query<IntrospectSupportQueryData>(query, {});
@@ -104,8 +108,8 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
       return introspect(supportedFeatures);
     },
 
-    async loadSchema() {
-      if (schema) {
+    async loadSchema(reload?: boolean) {
+      if (!reload && schema) {
         return schema;
       } else {
         const introspection = await this.loadIntrospection();


### PR DESCRIPTION
## Summary

This merges the `SchemaOrigin` type into `@gql.tada/internal` and merges both loaders into one. It also changes the loader interface to automatically reload schemas & introspections on updates and to add a single method to load both the schema and the introspection.

The latter methods are now marked as internal and won't reload the internal data.

## Set of changes

- Add `.load()` to loaders`
- Mark old loading methods as internal
- Reload schema/introspection data when watcher notifies
- Add merged `load()` function that accepts `SchemaOrigin`