### PR TITLE
feat(cli): doctor command

### DIFF
--- a/.changeset/nasty-masks-count.md
+++ b/.changeset/nasty-masks-count.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Add `doctor` command to diagnose common issues with the LSP and gql.tada

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@gql.tada/internal": "workspace:*",
-    "graphql": "^16.8.1"
+    "graphql": "^16.8.1",
+    "semiver": "^1.1.0"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -44,13 +44,13 @@
     "json5": "^2.2.3",
     "rollup": "^4.9.4",
     "sade": "^1.8.1",
+    "semiver": "^1.1.0",
     "type-fest": "^4.10.2",
     "typescript": "^5.3.3"
   },
   "dependencies": {
     "@gql.tada/internal": "workspace:*",
-    "graphql": "^16.8.1",
-    "semiver": "^1.1.0"
+    "graphql": "^16.8.1"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/cli-utils/src/commands/doctor.ts
+++ b/packages/cli-utils/src/commands/doctor.ts
@@ -4,9 +4,9 @@ import { parse } from 'json5';
 import semiver from 'semiver';
 import type { TsConfigJson } from 'type-fest';
 import { resolveTypeScriptRootDir } from '@gql.tada/internal';
-
-import { getGraphQLSPConfig } from './lsp';
 import { existsSync } from 'node:fs';
+
+import { getGraphQLSPConfig } from '../lsp';
 
 const MINIMUM_VERSIONS = {
   typescript: '4.1.0',
@@ -49,7 +49,7 @@ export async function executeTadaDoctor() {
     return;
   }
 
-  const gqlspVersion = deps.find((x) => x[0] === '@0no-co/graphqlsp');
+  const gqlspVersion = deps.find((x) => x[0] === "'@0no-co/graphqlsp'");
   if (!gqlspVersion) {
     console.error('Failed to find a "@0no-co/graphqlsp" installation, try installing one.');
     return;
@@ -60,7 +60,7 @@ export async function executeTadaDoctor() {
     return;
   }
 
-  const gqlTadaVersion = deps.find((x) => x[0] === 'gql.tada');
+  const gqlTadaVersion = deps.find((x) => x[0] === "'gql.tada'");
   if (!gqlTadaVersion) {
     console.error('Failed to find a "gql.tada" installation, try installing one.');
     return;

--- a/packages/cli-utils/src/doctor.ts
+++ b/packages/cli-utils/src/doctor.ts
@@ -32,10 +32,12 @@ export async function executeTadaDoctor() {
     return;
   }
 
-  const typeScriptVersion = Object.entries({
+  const deps = Object.entries({
     ...packageJsonContents.dependencies,
     ...packageJsonContents.devDependencies,
-  }).find((x) => x[0] === 'typescript');
+  });
+
+  const typeScriptVersion = deps.find((x) => x[0] === 'typescript');
   if (!typeScriptVersion) {
     console.error('Failed to find a "typescript" installation, try installing one.');
     return;
@@ -47,10 +49,7 @@ export async function executeTadaDoctor() {
     return;
   }
 
-  const gqlspVersion = Object.entries({
-    ...packageJsonContents.dependencies,
-    ...packageJsonContents.devDependencies,
-  }).find((x) => x[0] === '@0no-co/graphqlsp');
+  const gqlspVersion = deps.find((x) => x[0] === '@0no-co/graphqlsp');
   if (!gqlspVersion) {
     console.error('Failed to find a "@0no-co/graphqlsp" installation, try installing one.');
     return;
@@ -61,10 +60,7 @@ export async function executeTadaDoctor() {
     return;
   }
 
-  const gqlTadaVersion = Object.entries({
-    ...packageJsonContents.dependencies,
-    ...packageJsonContents.devDependencies,
-  }).find((x) => x[0] === 'gql.tada');
+  const gqlTadaVersion = deps.find((x) => x[0] === 'gql.tada');
   if (!gqlTadaVersion) {
     console.error('Failed to find a "gql.tada" installation, try installing one.');
     return;
@@ -76,7 +72,6 @@ export async function executeTadaDoctor() {
   }
 
   const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
-
   const root = (await resolveTypeScriptRootDir(tsconfigpath)) || cwd;
 
   let tsconfigContents: string;

--- a/packages/cli-utils/src/doctor.ts
+++ b/packages/cli-utils/src/doctor.ts
@@ -8,6 +8,12 @@ import { resolveTypeScriptRootDir } from '@gql.tada/internal';
 import { getGraphQLSPConfig } from './lsp';
 import { existsSync } from 'node:fs';
 
+const MINIMUM_VERSIONS = {
+  typescript: '4.1.0',
+  tada: '1.0.0',
+  lsp: '1.0.0',
+};
+
 export async function executeTadaDoctor() {
   // Check TypeScript version
   const cwd = process.cwd();
@@ -31,11 +37,13 @@ export async function executeTadaDoctor() {
     ...packageJsonContents.devDependencies,
   }).find((x) => x[0] === 'typescript');
   if (!typeScriptVersion) {
-    console.error('Failed to find a typescript installation, try installing one.');
+    console.error('Failed to find a "typescript" installation, try installing one.');
     return;
-  } else if (semiver(typeScriptVersion[1], '4.1.0') === -1) {
+  } else if (semiver(typeScriptVersion[1], MINIMUM_VERSIONS.typescript) === -1) {
     // TypeScript version lower than v4.1 which is when they introduced template lits
-    console.error('Found an outdated TypeScript version, gql.tada requires at least 4.1.0.');
+    console.error(
+      `Found an outdated "TypeScript" version, gql.tada requires at least ${MINIMUM_VERSIONS.typescript}.`
+    );
     return;
   }
 
@@ -46,10 +54,9 @@ export async function executeTadaDoctor() {
   if (!gqlspVersion) {
     console.error('Failed to find a "@0no-co/graphqlsp" installation, try installing one.');
     return;
-  } else if (semiver(gqlspVersion[1], '1.0.0') === -1) {
-    // TypeScript version lower than v4.1 which is when they introduced template lits
+  } else if (semiver(gqlspVersion[1], MINIMUM_VERSIONS.lsp) === -1) {
     console.error(
-      'Found an outdated "@0no-co/graphqlsp" version, gql.tada requires at least 1.0.0.'
+      `Found an outdated "@0no-co/graphqlsp" version, gql.tada requires at least ${MINIMUM_VERSIONS.lsp}.`
     );
     return;
   }
@@ -62,8 +69,9 @@ export async function executeTadaDoctor() {
     console.error('Failed to find a "gql.tada" installation, try installing one.');
     return;
   } else if (semiver(gqlTadaVersion[1], '1.0.0') === -1) {
-    // TypeScript version lower than v4.1 which is when they introduced template lits
-    console.error('Found an outdated "gql.tada" version, gql.tada requires at least 1.0.0.');
+    console.error(
+      `Found an outdated "gql.tada" version, gql.tada requires at least ${MINIMUM_VERSIONS.tada}.`
+    );
     return;
   }
 

--- a/packages/cli-utils/src/doctor.ts
+++ b/packages/cli-utils/src/doctor.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parse } from 'json5';
+import semiver from 'semiver';
+import type { TsConfigJson } from 'type-fest';
+import { resolveTypeScriptRootDir } from '@gql.tada/internal';
+
+import { getGraphQLSPConfig } from './lsp';
+import { existsSync } from 'node:fs';
+
+export async function executeTadaDoctor() {
+  // Check TypeScript version
+  const cwd = process.cwd();
+  const packageJsonPath = path.resolve(cwd, 'package.json');
+  let packageJsonContents: {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+  };
+  try {
+    const file = path.resolve(packageJsonPath);
+    packageJsonContents = JSON.parse(await fs.readFile(file, 'utf-8'));
+  } catch (error) {
+    console.error(
+      'Failed to read package.json in current working directory, try running the doctor command in your workspace folder.'
+    );
+    return;
+  }
+
+  const typeScriptVersion = Object.entries({
+    ...packageJsonContents.dependencies,
+    ...packageJsonContents.devDependencies,
+  }).find((x) => x[0] === 'typescript');
+  if (!typeScriptVersion) {
+    console.error('Failed to find a typescript installation, try installing one.');
+    return;
+  } else if (semiver(typeScriptVersion[1], '4.1.0') === -1) {
+    // TypeScript version lower than v4.1 which is when they introduced template lits
+    console.error('Found an outdated TypeScript version, gql.tada requires at least 4.1.0.');
+    return;
+  }
+
+  const gqlspVersion = Object.entries({
+    ...packageJsonContents.dependencies,
+    ...packageJsonContents.devDependencies,
+  }).find((x) => x[0] === '@0no-co/graphqlsp');
+  if (!gqlspVersion) {
+    console.error('Failed to find a "@0no-co/graphqlsp" installation, try installing one.');
+    return;
+  } else if (semiver(gqlspVersion[1], '1.0.0') === -1) {
+    // TypeScript version lower than v4.1 which is when they introduced template lits
+    console.error(
+      'Found an outdated "@0no-co/graphqlsp" version, gql.tada requires at least 1.0.0.'
+    );
+    return;
+  }
+
+  const gqlTadaVersion = Object.entries({
+    ...packageJsonContents.dependencies,
+    ...packageJsonContents.devDependencies,
+  }).find((x) => x[0] === 'gql.tada');
+  if (!gqlTadaVersion) {
+    console.error('Failed to find a "gql.tada" installation, try installing one.');
+    return;
+  } else if (semiver(gqlTadaVersion[1], '1.0.0') === -1) {
+    // TypeScript version lower than v4.1 which is when they introduced template lits
+    console.error('Found an outdated "gql.tada" version, gql.tada requires at least 1.0.0.');
+    return;
+  }
+
+  const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
+
+  const root = (await resolveTypeScriptRootDir(tsconfigpath)) || cwd;
+
+  let tsconfigContents: string;
+  try {
+    const file = path.resolve(root, 'tsconfig.json');
+    tsconfigContents = await fs.readFile(file, 'utf-8');
+  } catch (error) {
+    console.error(
+      'Failed to read tsconfig.json in current working directory, try adding a "tsconfig.json".'
+    );
+    return;
+  }
+
+  let tsConfig: TsConfigJson;
+  try {
+    tsConfig = parse(tsconfigContents) as TsConfigJson;
+  } catch (err) {
+    console.error('Unable to parse tsconfig.json in current working directory.', err);
+    return;
+  }
+
+  // Check GraphQLSP version, later on we can check if a ts version is > 5.5.0 to use gql.tada/lsp instead of
+  // the LSP package.
+  const config = getGraphQLSPConfig(tsConfig);
+  if (!config) {
+    console.error(`Missing a "@0no-co/graphqlsp" plugin in your tsconfig.`);
+    return;
+  }
+
+  // TODO: this is optional I guess with the CLI being there and all
+  if (!config.tadaOutputLocation) {
+    console.error(`Missing a "tadaOutputLocation" setting in your GraphQLSP configuration.`);
+    return;
+  }
+
+  if (!config.schema) {
+    console.error(`Missing a "schema" setting in your GraphQLSP configuration.`);
+    return;
+  } else {
+    const isFile =
+      typeof config.schema === 'string' &&
+      (config.schema.endsWith('.json') || config.schema.endsWith('.graphql'));
+    if (isFile) {
+      const resolvedFile = path.resolve(root, config.schema as string);
+      if (!existsSync(resolvedFile)) {
+        console.error(`The schema setting does not point at an existing file "${resolvedFile}"`);
+        return;
+      }
+    } else {
+      try {
+        typeof config.schema === 'string' ? new URL(config.schema) : new URL(config.schema.url);
+      } catch (e) {
+        console.error(
+          `The schema setting does not point at a valid URL "${JSON.stringify(config.schema)}"`
+        );
+        return;
+      }
+    }
+  }
+}

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -3,14 +3,13 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { parse } from 'json5';
 import { printSchema } from 'graphql';
-import semiver from 'semiver';
 import type { GraphQLSchema } from 'graphql';
 import type { TsConfigJson } from 'type-fest';
 import { resolveTypeScriptRootDir, load } from '@gql.tada/internal';
 
 import { getGraphQLSPConfig } from './lsp';
 import { ensureTadaIntrospection } from './tada';
-import { existsSync } from 'node:fs';
+import { executeTadaDoctor } from './doctor';
 
 interface GenerateSchemaOptions {
   headers?: Record<string, string>;
@@ -118,127 +117,7 @@ async function main() {
     .command('doctor')
     .describe('Finds common issues in your gql.tada setup.')
     .action(async () => {
-      // Check TypeScript version
-      const cwd = process.cwd();
-      const packageJsonPath = path.resolve(cwd, 'package.json');
-      let packageJsonContents: {
-        dependencies: Record<string, string>;
-        devDependencies: Record<string, string>;
-      };
-      try {
-        const file = path.resolve(packageJsonPath);
-        packageJsonContents = JSON.parse(await fs.readFile(file, 'utf-8'));
-      } catch (error) {
-        console.error(
-          'Failed to read package.json in current working directory, try running the doctor command in your workspace folder.'
-        );
-        return;
-      }
-
-      const typeScriptVersion = Object.entries({
-        ...packageJsonContents.dependencies,
-        ...packageJsonContents.devDependencies,
-      }).find((x) => x[0] === 'typescript');
-      if (!typeScriptVersion) {
-        console.error('Failed to find a typescript installation, try installing one.');
-        return;
-      } else if (semiver(typeScriptVersion[1], '4.1.0') === -1) {
-        // TypeScript version lower than v4.1 which is when they introduced template lits
-        console.error('Found an outdated TypeScript version, gql.tada requires at least 4.1.0.');
-        return;
-      }
-
-      const gqlspVersion = Object.entries({
-        ...packageJsonContents.dependencies,
-        ...packageJsonContents.devDependencies,
-      }).find((x) => x[0] === '@0no-co/graphqlsp');
-      if (!gqlspVersion) {
-        console.error('Failed to find a "@0no-co/graphqlsp" installation, try installing one.');
-        return;
-      } else if (semiver(gqlspVersion[1], '1.0.0') === -1) {
-        // TypeScript version lower than v4.1 which is when they introduced template lits
-        console.error(
-          'Found an outdated "@0no-co/graphqlsp" version, gql.tada requires at least 1.0.0.'
-        );
-        return;
-      }
-
-      const gqlTadaVersion = Object.entries({
-        ...packageJsonContents.dependencies,
-        ...packageJsonContents.devDependencies,
-      }).find((x) => x[0] === 'gql.tada');
-      if (!gqlTadaVersion) {
-        console.error('Failed to find a "gql.tada" installation, try installing one.');
-        return;
-      } else if (semiver(gqlTadaVersion[1], '1.0.0') === -1) {
-        // TypeScript version lower than v4.1 which is when they introduced template lits
-        console.error('Found an outdated "gql.tada" version, gql.tada requires at least 1.0.0.');
-        return;
-      }
-
-      const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
-
-      const root = (await resolveTypeScriptRootDir(tsconfigpath)) || cwd;
-
-      let tsconfigContents: string;
-      try {
-        const file = path.resolve(root, 'tsconfig.json');
-        tsconfigContents = await fs.readFile(file, 'utf-8');
-      } catch (error) {
-        console.error(
-          'Failed to read tsconfig.json in current working directory, try adding a "tsconfig.json".'
-        );
-        return;
-      }
-
-      let tsConfig: TsConfigJson;
-      try {
-        tsConfig = parse(tsconfigContents) as TsConfigJson;
-      } catch (err) {
-        console.error('Unable to parse tsconfig.json in current working directory.', err);
-        return;
-      }
-
-      // Check GraphQLSP version, later on we can check if a ts version is > 5.5.0 to use gql.tada/lsp instead of
-      // the LSP package.
-      const config = getGraphQLSPConfig(tsConfig);
-      if (!config) {
-        console.error(`Missing a "@0no-co/graphqlsp" plugin in your tsconfig.`);
-        return;
-      }
-
-      // TODO: this is optional I guess with the CLI being there and all
-      if (!config.tadaOutputLocation) {
-        console.error(`Missing a "tadaOutputLocation" setting in your GraphQLSP configuration.`);
-        return;
-      }
-
-      if (!config.schema) {
-        console.error(`Missing a "schema" setting in your GraphQLSP configuration.`);
-        return;
-      } else {
-        const isFile =
-          typeof config.schema === 'string' &&
-          (config.schema.endsWith('.json') || config.schema.endsWith('.graphql'));
-        if (isFile) {
-          const resolvedFile = path.resolve(root, config.schema as string);
-          if (!existsSync(resolvedFile)) {
-            console.error(
-              `The schema setting does not point at an existing file "${resolvedFile}"`
-            );
-            return;
-          }
-        } else {
-          try {
-            typeof config.schema === 'string' ? new URL(config.schema) : new URL(config.schema.url);
-          } catch (e) {
-            console.error(
-              `The schema setting does not point at a valid URL "${JSON.stringify(config.schema)}"`
-            );
-            return;
-          }
-        }
-      }
+      return executeTadaDoctor();
     })
     .command('generate-schema <target>')
     .describe(

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -148,6 +148,34 @@ async function main() {
         return;
       }
 
+      const gqlspVersion = Object.entries({
+        ...packageJsonContents.dependencies,
+        ...packageJsonContents.devDependencies,
+      }).find((x) => x[0] === '@0no-co/graphqlsp');
+      if (!gqlspVersion) {
+        console.error('Failed to find a "@0no-co/graphqlsp" installation, try installing one.');
+        return;
+      } else if (semiver(gqlspVersion[1], '1.0.0') === -1) {
+        // TypeScript version lower than v4.1 which is when they introduced template lits
+        console.error(
+          'Found an outdated "@0no-co/graphqlsp" version, gql.tada requires at least 1.0.0.'
+        );
+        return;
+      }
+
+      const gqlTadaVersion = Object.entries({
+        ...packageJsonContents.dependencies,
+        ...packageJsonContents.devDependencies,
+      }).find((x) => x[0] === 'gql.tada');
+      if (!gqlTadaVersion) {
+        console.error('Failed to find a "gql.tada" installation, try installing one.');
+        return;
+      } else if (semiver(gqlTadaVersion[1], '1.0.0') === -1) {
+        // TypeScript version lower than v4.1 which is when they introduced template lits
+        console.error('Found an outdated "gql.tada" version, gql.tada requires at least 1.0.0.');
+        return;
+      }
+
       const tsconfigpath = path.resolve(cwd, 'tsconfig.json');
 
       const root = (await resolveTypeScriptRootDir(tsconfigpath)) || cwd;

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -9,7 +9,7 @@ import { resolveTypeScriptRootDir, load } from '@gql.tada/internal';
 
 import { getGraphQLSPConfig } from './lsp';
 import { ensureTadaIntrospection } from './tada';
-import { executeTadaDoctor } from './doctor';
+import { executeTadaDoctor } from './commands/doctor';
 
 interface GenerateSchemaOptions {
   headers?: Record<string, string>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,9 +156,6 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
-      semiver:
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^20.11.0
@@ -172,6 +169,9 @@ importers:
       sade:
         specifier: ^1.8.1
         version: 1.8.1
+      semiver:
+        specifier: ^1.1.0
+        version: 1.1.0
       type-fest:
         specifier: ^4.10.2
         version: 4.10.2
@@ -2357,7 +2357,7 @@ packages:
   /@vue/language-core@1.8.27(typescript@5.4.3):
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
     peerDependencies:
-      typescript: '*'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5376,7 +5376,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
+      typescript: ^5.3.3
     dependencies:
       magic-string: 0.30.5
       rollup: 4.9.4
@@ -5484,7 +5484,7 @@ packages:
   /semiver@1.1.0:
     resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
     engines: {node: '>=6'}
-    dev: false
+    dev: true
 
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -5926,7 +5926,7 @@ packages:
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: ^5.3.3
     dependencies:
       typescript: 5.3.3
     dev: true
@@ -5958,7 +5958,7 @@ packages:
   /twoslash-vue@0.1.2(typescript@5.4.3):
     resolution: {integrity: sha512-LCD3VTw0+gKVMXou/nP8OAtpajGAoKuzFx9oyGteBkeMRgDj2DO95WDBHy/o+ihkckYZ0lUbvIFFjzmDy7zHag==}
     peerDependencies:
-      typescript: '*'
+      typescript: ^5.3.3
     dependencies:
       '@vue/language-core': 1.8.27(typescript@5.4.3)
       twoslash: 0.1.2(typescript@5.4.3)
@@ -5970,7 +5970,7 @@ packages:
   /twoslash@0.1.2(typescript@5.4.3):
     resolution: {integrity: sha512-q0jnapnD3b0umNGCJCRlo6Em1oSFl2OBPwsXqhLzijtEzuORrGVrJffG7E1k1KPHFlwBSRX2q6yYA61etn5hSg==}
     peerDependencies:
-      typescript: '*'
+      typescript: ^5.3.3
     dependencies:
       '@typescript/vfs': 1.5.0
       typescript: 5.4.3
@@ -6401,7 +6401,7 @@ packages:
   /vue@3.4.21(typescript@5.4.3):
     resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
     peerDependencies:
-      typescript: '*'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
+      semiver:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^20.11.0
@@ -2354,7 +2357,7 @@ packages:
   /@vue/language-core@1.8.27(typescript@5.4.3):
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5373,7 +5376,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^5.3.3
+      typescript: ^4.5 || ^5.0
     dependencies:
       magic-string: 0.30.5
       rollup: 4.9.4
@@ -5477,6 +5480,11 @@ packages:
   /search-insights@2.13.0:
     resolution: {integrity: sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==}
     dev: true
+
+  /semiver@1.1.0:
+    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
+    engines: {node: '>=6'}
+    dev: false
 
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -5918,7 +5926,7 @@ packages:
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
     dev: true
@@ -5950,7 +5958,7 @@ packages:
   /twoslash-vue@0.1.2(typescript@5.4.3):
     resolution: {integrity: sha512-LCD3VTw0+gKVMXou/nP8OAtpajGAoKuzFx9oyGteBkeMRgDj2DO95WDBHy/o+ihkckYZ0lUbvIFFjzmDy7zHag==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     dependencies:
       '@vue/language-core': 1.8.27(typescript@5.4.3)
       twoslash: 0.1.2(typescript@5.4.3)
@@ -5962,7 +5970,7 @@ packages:
   /twoslash@0.1.2(typescript@5.4.3):
     resolution: {integrity: sha512-q0jnapnD3b0umNGCJCRlo6Em1oSFl2OBPwsXqhLzijtEzuORrGVrJffG7E1k1KPHFlwBSRX2q6yYA61etn5hSg==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     dependencies:
       '@typescript/vfs': 1.5.0
       typescript: 5.4.3
@@ -6393,7 +6401,7 @@ packages:
   /vue@3.4.21(typescript@5.4.3):
     resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true


### PR DESCRIPTION
## Summary

Addresses part of https://github.com/0no-co/gql.tada/issues/76

This adds `gql.tada doctor` which does the following

- Check whether we have a `package.json`
- Check whether we have a `typescript` dependency > 4.1.0 (when string literal parsing got introduced)
- Check whether `gql.tada` is intalled
- Check whether `@0no-co/graphqlsp` is installed
- Check whether we have a `tsconfig`
- Check whether GraphQLSP is in the tsconfig
- Check whether the `schema` setting is valid
- Check whether the `tadaOutputLocation` is present