### PR TITLE
feat(cli): generate persisted operations json files

### DIFF
--- a/.changeset/healthy-shrimps-pretend.md
+++ b/.changeset/healthy-shrimps-pretend.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Implement `generate-persisted` as a way to go through all of the codebase and generate a persisted operations manifest

--- a/examples/example-pokemon-api/package.json
+++ b/examples/example-pokemon-api/package.json
@@ -13,7 +13,7 @@
     "urql": "^4.0.6"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.8.0",
+    "@0no-co/graphqlsp": "^1.9.1",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
     "@vitejs/plugin-react": "^4.2.1",

--- a/examples/example-pokemon-api/po.json
+++ b/examples/example-pokemon-api/po.json
@@ -1,0 +1,3 @@
+{
+  "sha256:fc073da8e9719deb51cdb258d7c35865708852c5ce9031a257588370d3cd42f3": "\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n\nfragment PokemonItem on Pokemon {\n  id\n  name\n}"
+}

--- a/examples/example-pokemon-api/src/components/PokemonList.tsx
+++ b/examples/example-pokemon-api/src/components/PokemonList.tsx
@@ -12,6 +12,8 @@ const PokemonsQuery = graphql(`
   }
 `, [PokemonItemFragment]);
 
+export const persisted = graphql.persisted<typeof PokemonsQuery>("sha256:fc073da8e9719deb51cdb258d7c35865708852c5ce9031a257588370d3cd42f3")
+
 const PokemonList = () => {
   const [result] = useQuery({ query: PokemonsQuery });
 

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@gql.tada/internal": "workspace:*",
-    "@0no-co/graphqlsp": "^1.8.0",
+    "@0no-co/graphqlsp": "^1.9.1",
     "ts-morph": "~22.0.0",
     "graphql": "^16.8.1"
   },

--- a/packages/cli-utils/src/commands/generate-persisted.ts
+++ b/packages/cli-utils/src/commands/generate-persisted.ts
@@ -1,0 +1,143 @@
+import { Project, ts } from 'ts-morph';
+import { print } from '@0no-co/graphql.web';
+import {
+  init,
+  findAllPersistedCallExpressions,
+  getDocumentReferenceFromTypeQuery,
+  unrollTadaFragments,
+} from '@0no-co/graphqlsp/api';
+import { load, resolveTypeScriptRootDir } from '@gql.tada/internal';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { getTsConfig } from '../tsconfig';
+import type { GraphQLSPConfig } from '../lsp';
+import { getGraphQLSPConfig } from '../lsp';
+
+export async function generatePersisted(target: string) {
+  const tsConfig = await getTsConfig();
+  if (!tsConfig) {
+    return;
+  }
+
+  const config = getGraphQLSPConfig(tsConfig);
+  if (!config) {
+    return;
+  }
+
+  const persistedOperations = await getPersistedOperationsFromFiles(config);
+
+  return fs.writeFile(target, JSON.stringify(persistedOperations, null, 2));
+}
+
+async function getPersistedOperationsFromFiles(
+  config: GraphQLSPConfig
+): Promise<Record<string, string>> {
+  // TODO: leverage ts-morph tsconfig resolver
+  const projectName = path.resolve(process.cwd(), 'tsconfig.json');
+  const rootPath = (await resolveTypeScriptRootDir(projectName)) || path.dirname(projectName);
+  const project = new Project({
+    tsConfigFilePath: projectName,
+  });
+
+  init({
+    typescript: ts as any,
+  });
+
+  const languageService = project.getLanguageService();
+  const pluginCreateInfo = {
+    config,
+    languageService: {
+      getReferencesAtPosition: (filename, position) => {
+        return languageService.compilerObject.getReferencesAtPosition(filename, position);
+      },
+      getDefinitionAtPosition: (filename, position) => {
+        return languageService.compilerObject.getDefinitionAtPosition(filename, position);
+      },
+      getProgram: () => {
+        const program = project.getProgram();
+        return {
+          ...program,
+          getTypeChecker: () => project.getTypeChecker(),
+          getSourceFile: (s) => {
+            const source = project.getSourceFile(s);
+            return source && source.compilerNode;
+          },
+        };
+      },
+      // This prevents us from exposing normal diagnostics
+      getSemanticDiagnostics: () => [],
+    } as any,
+    languageServiceHost: {} as any,
+    project: {
+      getProjectName: () => path.resolve(process.cwd(), 'tsconfig.json'),
+      projectService: {
+        logger: console,
+      },
+    } as any,
+    serverHost: {} as any,
+  };
+
+  const sourceFiles = project.getSourceFiles();
+  const loader = load({ origin: config.schema, rootPath });
+  let schema;
+  try {
+    const loaderResult = await loader.load();
+    schema = loaderResult && loaderResult.schema;
+    if (!schema) {
+      throw new Error(`Failed to load schema`);
+    }
+  } catch (error) {
+    throw new Error(`Failed to load schema: ${error}`);
+  }
+
+  return sourceFiles.reduce((acc, sourceFile) => {
+    const persistedCallExpressions = findAllPersistedCallExpressions(sourceFile.compilerNode);
+    return {
+      ...acc,
+      ...persistedCallExpressions.reduce((acc, callExpression) => {
+        const hash = callExpression.arguments[0].getText();
+        if (!callExpression.typeArguments) {
+          // TODO: do we log an error or not, this should be handled by check...
+          return acc;
+        }
+        const [typeQuery] = callExpression.typeArguments;
+        if (!ts.isTypeQueryNode(typeQuery)) {
+          // TODO: do we log an error or not, this should be handled by check...
+          return acc;
+        }
+
+        const { node: foundNode } = getDocumentReferenceFromTypeQuery(
+          typeQuery,
+          sourceFile.compilerNode.fileName,
+          pluginCreateInfo
+        );
+
+        if (!foundNode) {
+          // TODO: do we log an error or not, this should be handled by check...
+          return acc;
+        }
+
+        const initializer = foundNode.initializer;
+        if (
+          !initializer ||
+          !ts.isCallExpression(initializer) ||
+          !ts.isNoSubstitutionTemplateLiteral(initializer.arguments[0])
+        ) {
+          // TODO: do we log an error or not, this should be handled by check...
+          return acc;
+        }
+
+        const fragments = [];
+        const operation = initializer.arguments[0].getText().slice(1, -1);
+        if (initializer.arguments[1] && ts.isArrayLiteralExpression(initializer.arguments[1])) {
+          unrollTadaFragments(initializer.arguments[1], fragments, pluginCreateInfo);
+        }
+
+        const document = `${operation}\n${fragments.map((frag) => print(frag)).join('\n')}`;
+        acc[hash.slice(1, -1)] = document;
+        return acc;
+      }, {}),
+    };
+  }, {});
+}

--- a/packages/cli-utils/src/commands/generate-persisted.ts
+++ b/packages/cli-utils/src/commands/generate-persisted.ts
@@ -113,7 +113,7 @@ async function getPersistedOperationsFromFiles(
           unrollTadaFragments(initializer.arguments[1], fragments, pluginCreateInfo);
         }
 
-        const document = `${operation}\n${fragments.map((frag) => print(frag)).join('\n')}`;
+        const document = `${operation}\n\n${fragments.map((frag) => print(frag)).join('\n\n')}`;
         acc[hash.slice(1, -1)] = document;
         return acc;
       }, {}),

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -142,7 +142,7 @@ async function main() {
     })
     .command('generate-persisted <target>')
     .action(async (target) => {
-      await generatePersisted(target || './po.json');
+      await generatePersisted(target);
     })
     .command('generate-output')
     .option(

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -13,6 +13,7 @@ import { getTsConfig } from './tsconfig';
 import { executeTadaDoctor } from './commands/doctor';
 import { check } from './commands/check';
 import { initGqlTada } from './commands/init';
+import { generatePersisted } from './commands/generate-persisted';
 
 interface GenerateSchemaOptions {
   headers?: Record<string, string>;
@@ -138,6 +139,10 @@ async function main() {
         headers: Object.keys(parsedHeaders).length ? parsedHeaders : undefined,
         output: options.output,
       });
+    })
+    .command('generate-persisted <target>')
+    .action(async (target) => {
+      await generatePersisted(target || './po.json');
     })
     .command('generate-output')
     .option(

--- a/packages/cli-utils/src/ts/project.ts
+++ b/packages/cli-utils/src/ts/project.ts
@@ -1,0 +1,42 @@
+import type { Project } from 'ts-morph';
+import type { GraphQLSPConfig } from '../lsp';
+
+export const createPluginInfo = (
+  project: Project,
+  config: GraphQLSPConfig,
+  projectName: string
+): any => {
+  const languageService = project.getLanguageService();
+  return {
+    config,
+    languageService: {
+      getReferencesAtPosition: (filename, position) => {
+        return languageService.compilerObject.getReferencesAtPosition(filename, position);
+      },
+      getDefinitionAtPosition: (filename, position) => {
+        return languageService.compilerObject.getDefinitionAtPosition(filename, position);
+      },
+      getProgram: () => {
+        const program = project.getProgram();
+        return {
+          ...program,
+          getTypeChecker: () => project.getTypeChecker(),
+          getSourceFile: (s) => {
+            const source = project.getSourceFile(s);
+            return source && source.compilerNode;
+          },
+        };
+      },
+      // This prevents us from exposing normal diagnostics
+      getSemanticDiagnostics: () => [],
+    } as any,
+    languageServiceHost: {} as any,
+    project: {
+      getProjectName: () => projectName,
+      projectService: {
+        logger: console,
+      },
+    } as any,
+    serverHost: {} as any,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         version: 4.0.6(graphql@16.8.1)(react@18.2.0)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.8.0
-        version: 1.8.0(typescript@5.4.2)
+        specifier: ^1.9.1
+        version: 1.9.1(typescript@5.4.2)
       '@types/react':
         specifier: ^18.2.64
         version: 18.2.64
@@ -151,8 +151,8 @@ importers:
   packages/cli-utils:
     dependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.8.0
-        version: 1.8.0(typescript@5.4.2)
+        specifier: ^1.9.1
+        version: 1.9.1(typescript@5.4.2)
       '@gql.tada/internal':
         specifier: workspace:*
         version: link:../internal
@@ -289,8 +289,8 @@ packages:
     dependencies:
       graphql: 16.8.1
 
-  /@0no-co/graphqlsp@1.8.0(typescript@5.4.2):
-    resolution: {integrity: sha512-DVET7krt1doddpSDg97t41mZZru2P/CWv22JXG4N1oFo1A1KFVGdka/chnn4pmB7/FqRCRUJARGvZNwwb1EJjw==}
+  /@0no-co/graphqlsp@1.9.1(typescript@5.4.2):
+    resolution: {integrity: sha512-3mLLCNponLK84hVbBUZIXZhw1nvmWblRwFTJE7WCs312iqlCdLW+SZEt+HfhEgM03XhN0D0gQB/8KnZHKs9qwg==}
     peerDependencies:
       typescript: ^5.3.3
     dependencies:


### PR DESCRIPTION
## Summary

This adds a new command called `generate-persisted` which will go through all the files and generate a JSON file containing all your persisted operations. This can then be used to upload to GraphQL Yoga or some other server to limit the distinct amount of documents that can be sent to the GraphQL server.

Related to https://github.com/0no-co/GraphQLSP/pull/240
Implements part of #76 
