### PR TITLE
feat(cli): cache typescript types

### DIFF
--- a/.changeset/gorgeous-avocados-push.md
+++ b/.changeset/gorgeous-avocados-push.md
@@ -1,0 +1,6 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Add `gql-tada turbo` which will calculate all the types from `graphql()` calls so subsequent
+clones, ... won't have to calculate all the types.

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -2,14 +2,18 @@ import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
   interface SetupCache {
-    '\r\n  fragment PokemonItem on Pokemon {\r\n    id\r\n    name\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
-      { [key: string]: any },
-      { [key: string]: any },
-      void
+    '\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n': import('/Users/phil/Development/gql.tada/dist/gql-tada').TadaDocumentNode<
+      { name: string; id: string },
+      {},
+      { fragment: 'PokemonItem'; on: 'Pokemon'; masked: true }
     >;
-    '\r\n  query Pokemons ($limit: Int = 10) {\r\n    pokemons(limit: $limit) {\r\n      id\r\n      ...PokemonItem\r\n    }\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
-      { [key: string]: any },
-      { [key: string]: any },
+    '\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n': import('/Users/phil/Development/gql.tada/dist/gql-tada').TadaDocumentNode<
+      {
+        pokemons:
+          | ({ [$tada.fragmentRefs]: { PokemonItem: 'Pokemon' }; id: string } | null)[]
+          | null;
+      },
+      { limit?: number | null | undefined },
       void
     >;
   }

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -1,0 +1,22 @@
+import * as gqlTada from 'gql.tada';
+
+declare module 'gql.tada' {
+  interface Cache {
+    properties: {
+      '\r\n  fragment PokemonItem on Pokemon {\r\n    id\r\n    name\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
+        { name: string; id: string },
+        {},
+        { fragment: 'PokemonItem'; on: 'Pokemon'; masked: true }
+      >;
+      '\r\n  query Pokemons ($limit: Int = 10) {\r\n    pokemons(limit: $limit) {\r\n      id\r\n      ...PokemonItem\r\n    }\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
+        {
+          pokemons:
+            | ({ [$tada.fragmentRefs]: { PokemonItem: 'Pokemon' }; id: string } | null)[]
+            | null;
+        },
+        { limit?: number | null | undefined },
+        void
+      >;
+    };
+  }
+}

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -3,9 +3,10 @@
 import type { TadaDocumentNode, $tada } from 'gql.tada';
 
 declare module 'gql.tada' {
-  interface setupCache {
-    
-"\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n": TadaDocumentNode<{ name: string; id: string; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>
-"\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n": TadaDocumentNode<{ pokemons: ({ [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; id: string; } | null)[] | null; }, { limit?: number | null | undefined; }, void>
+ interface setupCache {
+    "\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n":
+      TadaDocumentNode<{ name: string; id: string; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>;
+    "\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n":
+      TadaDocumentNode<{ pokemons: ({ [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; id: string; } | null)[] | null; }, { limit?: number | null | undefined; }, void>;
   }
 }

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -1,20 +1,11 @@
+/* eslint-disable */
+/* prettier-ignore */
 import type { TadaDocumentNode, $tada } from 'gql.tada';
 
 declare module 'gql.tada' {
   interface setupCache {
-    '\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n': TadaDocumentNode<
-      { name: string; id: string },
-      {},
-      { fragment: 'PokemonItem'; on: 'Pokemon'; masked: true }
-    >;
-    '\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n': TadaDocumentNode<
-      {
-        pokemons:
-          | ({ [$tada.fragmentRefs]: { PokemonItem: 'Pokemon' }; id: string } | null)[]
-          | null;
-      },
-      { limit?: number | null | undefined },
-      void
-    >;
+    
+"\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n": TadaDocumentNode<{ name: string; id: string; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>
+"\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n": TadaDocumentNode<{ pokemons: ({ [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; id: string; } | null)[] | null; }, { limit?: number | null | undefined; }, void>
   }
 }

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -1,13 +1,13 @@
-import * as gqlTada from 'gql.tada';
+import type { TadaDocumentNode, $tada } from 'gql.tada';
 
 declare module 'gql.tada' {
-  interface SetupCache {
-    '\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n': import('/Users/phil/Development/gql.tada/dist/gql-tada').TadaDocumentNode<
+  interface setupCache {
+    '\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n': TadaDocumentNode<
       { name: string; id: string },
       {},
       { fragment: 'PokemonItem'; on: 'Pokemon'; masked: true }
     >;
-    '\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n': import('/Users/phil/Development/gql.tada/dist/gql-tada').TadaDocumentNode<
+    '\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n': TadaDocumentNode<
       {
         pokemons:
           | ({ [$tada.fragmentRefs]: { PokemonItem: 'Pokemon' }; id: string } | null)[]

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -1,22 +1,16 @@
 import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
-  interface Cache {
-    properties: {
-      '\r\n  fragment PokemonItem on Pokemon {\r\n    id\r\n    name\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
-        { name: string; id: string },
-        {},
-        { fragment: 'PokemonItem'; on: 'Pokemon'; masked: true }
-      >;
-      '\r\n  query Pokemons ($limit: Int = 10) {\r\n    pokemons(limit: $limit) {\r\n      id\r\n      ...PokemonItem\r\n    }\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
-        {
-          pokemons:
-            | ({ [$tada.fragmentRefs]: { PokemonItem: 'Pokemon' }; id: string } | null)[]
-            | null;
-        },
-        { limit?: number | null | undefined },
-        void
-      >;
-    };
+  interface SetupCache {
+    '\r\n  fragment PokemonItem on Pokemon {\r\n    id\r\n    name\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
+      { [key: string]: any },
+      { [key: string]: any },
+      void
+    >;
+    '\r\n  query Pokemons ($limit: Int = 10) {\r\n    pokemons(limit: $limit) {\r\n      id\r\n      ...PokemonItem\r\n    }\r\n  }\r\n': import('E:/gql.tada/dist/gql-tada').TadaDocumentNode<
+      { [key: string]: any },
+      { [key: string]: any },
+      void
+    >;
   }
 }

--- a/packages/cli-utils/src/commands/cache.ts
+++ b/packages/cli-utils/src/commands/cache.ts
@@ -1,0 +1,71 @@
+import { Project, ts } from 'ts-morph';
+import path from 'node:path';
+
+import { getTsConfig } from '../tsconfig';
+import type { GraphQLSPConfig } from '../lsp';
+import { getGraphQLSPConfig } from '../lsp';
+import { createPluginInfo } from '../ts/project';
+
+export async function generateGraphQLCache() {
+  const tsConfig = await getTsConfig();
+  if (!tsConfig) {
+    return;
+  }
+
+  const config = getGraphQLSPConfig(tsConfig);
+  if (!config) {
+    return;
+  }
+
+  await getPersistedOperationsFromFiles(config);
+}
+
+async function getPersistedOperationsFromFiles(
+  config: GraphQLSPConfig
+): Promise<Record<string, string>> {
+  // TODO: leverage ts-morph tsconfig resolver
+  const projectName = path.resolve(process.cwd(), 'tsconfig.json');
+  const project = new Project({
+    tsConfigFilePath: projectName,
+  });
+
+  const pluginCreateInfo = createPluginInfo(project, config, projectName);
+
+  const sourceFiles = project.getSourceFiles();
+
+  return sourceFiles.reduce((acc, sourceFile) => {
+    const tadaCallExpressions = findAllCallExpressions(sourceFile.compilerNode, pluginCreateInfo);
+    return {
+      ...acc,
+      ...tadaCallExpressions.reduce((acc, callExpression) => {
+        const typeChecker = project.getTypeChecker().compilerObject;
+        const resolvedSignature = typeChecker.getResolvedSignature(callExpression);
+        if (!resolvedSignature) {
+          return acc;
+        }
+
+        const returnType = resolvedSignature.getReturnType();
+        acc[callExpression.getText()] = typeChecker.typeToString(returnType);
+        return acc;
+      }, {}),
+    };
+  }, {});
+}
+
+function findAllCallExpressions(
+  sourceFile: ts.SourceFile,
+  info: ts.server.PluginCreateInfo
+): Array<ts.CallExpression> {
+  const result: Array<ts.CallExpression> = [];
+  const templates = new Set([info.config.template, 'graphql', 'gql'].filter(Boolean));
+  function find(node: ts.Node) {
+    if (ts.isCallExpression(node) && templates.has(node.expression.getText())) {
+      result.push(node);
+      return;
+    } else {
+      ts.forEachChild(node, find);
+    }
+  }
+  find(sourceFile);
+  return result;
+}

--- a/packages/cli-utils/src/commands/cache.ts
+++ b/packages/cli-utils/src/commands/cache.ts
@@ -1,4 +1,4 @@
-import { Project, ts } from 'ts-morph';
+import { Project, TypeFormatFlags, ts } from 'ts-morph';
 import path from 'node:path';
 
 import { getTsConfig } from '../tsconfig';
@@ -45,12 +45,23 @@ async function getPersistedOperationsFromFiles(
         }
 
         const returnType = resolvedSignature.getReturnType();
-        acc[callExpression.getText()] = typeChecker.typeToString(returnType);
+        acc[callExpression.getText()] = typeChecker.typeToString(
+          returnType,
+          undefined,
+          BUILDER_FLAGS
+        );
         return acc;
       }, {}),
     };
   }, {});
 }
+
+const BUILDER_FLAGS =
+  TypeFormatFlags.NoTruncation |
+  TypeFormatFlags.NoTypeReduction |
+  TypeFormatFlags.InTypeAlias |
+  TypeFormatFlags.UseFullyQualifiedType |
+  TypeFormatFlags.GenerateNamesForShadowedTypeParams;
 
 function findAllCallExpressions(
   sourceFile: ts.SourceFile,

--- a/packages/cli-utils/src/commands/cache.ts
+++ b/packages/cli-utils/src/commands/cache.ts
@@ -27,10 +27,10 @@ export async function generateGraphQLCache() {
 }
 
 function createCache(cache: Record<string, string>): string {
-  return `import * as gqlTada from 'gql.tada';
+  return `import type { TadaDocumentNode, $tada } from 'gql.tada';
 
 declare module 'gql.tada' {
-  interface SetupCache {
+  interface setupCache {
     ${Object.keys(cache).reduce((acc, key) => {
       const value = cache[key];
       return `${acc}\n${JSON.stringify(key)}: ${value}`;
@@ -57,7 +57,7 @@ async function getGraphqlInvocationCache(config: GraphQLSPConfig): Promise<Recor
         const typeChecker = project.getTypeChecker().compilerObject;
         const type = typeChecker.getTypeAtLocation(callExpression);
         if (type.symbol.getEscapedName() !== 'TadaDocumentNode') {
-          return acc; // TODO: error?
+          return acc; // TODO: we could collect this and warn if all extracted types have some kind of error
         }
 
         const valueString = typeChecker.typeToString(type, callExpression, BUILDER_FLAGS);
@@ -74,7 +74,10 @@ const BUILDER_FLAGS: TypeFormatFlags =
   TypeFormatFlags.NoTypeReduction |
   TypeFormatFlags.InTypeAlias |
   TypeFormatFlags.UseFullyQualifiedType |
-  TypeFormatFlags.GenerateNamesForShadowedTypeParams;
+  TypeFormatFlags.GenerateNamesForShadowedTypeParams |
+  TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
+  TypeFormatFlags.AllowUniqueESSymbolType |
+  TypeFormatFlags.WriteTypeArgumentsOfSignature;
 
 function findAllCallExpressions(
   sourceFile: ts.SourceFile,

--- a/packages/cli-utils/src/commands/cache.ts
+++ b/packages/cli-utils/src/commands/cache.ts
@@ -45,7 +45,7 @@ async function getPersistedOperationsFromFiles(
         }
 
         const returnType = resolvedSignature.getReturnType();
-        acc[callExpression.getText()] = typeChecker.typeToString(
+        acc[callExpression.arguments[0].getText().slice(1, -1)] = typeChecker.typeToString(
           returnType,
           undefined,
           BUILDER_FLAGS

--- a/packages/cli-utils/src/commands/cache.ts
+++ b/packages/cli-utils/src/commands/cache.ts
@@ -31,11 +31,11 @@ function createCache(cache: Record<string, string>): string {
   return `import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
-  interface Cache {
-    properties: { ${Object.keys(cache).reduce((acc, key) => {
+  interface SetupCache {
+    ${Object.keys(cache).reduce((acc, key) => {
       const value = cache[key];
       return `${acc}\n${JSON.stringify(key)}: ${value}`;
-    }, '')} }
+    }, '')}
   }
 }\n`;
 }

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -14,6 +14,7 @@ import { executeTadaDoctor } from './commands/doctor';
 import { check } from './commands/check';
 import { initGqlTada } from './commands/init';
 import { generatePersisted } from './commands/generate-persisted';
+import { generateGraphQLCache } from './commands/cache';
 
 interface GenerateSchemaOptions {
   headers?: Record<string, string>;
@@ -105,6 +106,10 @@ async function main() {
     .action(async (folder) => {
       const target = path.resolve(process.cwd(), folder);
       await initGqlTada(target);
+    })
+    .command('cache')
+    .action(async () => {
+      await generateGraphQLCache();
     })
     .command('doctor')
     .describe('Finds common issues in your gql.tada setup.')

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -107,7 +107,7 @@ async function main() {
       const target = path.resolve(process.cwd(), folder);
       await initGqlTada(target);
     })
-    .command('cache')
+    .command('turbo')
     .action(async () => {
       await generateGraphQLCache();
     })

--- a/src/api.ts
+++ b/src/api.ts
@@ -85,9 +85,10 @@ interface setupSchema extends AbstractSetupSchema {
 }
 
 interface AbstractSetupCache {
-  [key: string]: TadaDocumentNode;
+  [key: string]: unknown;
 }
-interface SetupCache extends AbstractSetupCache {}
+
+interface setupCache extends AbstractSetupCache {}
 
 interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfig> {
   /** Function to create and compose GraphQL documents with result and variable types.
@@ -132,8 +133,8 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
   <const In extends string, const Fragments extends readonly FragmentShape[]>(
     input: In,
     fragments?: Fragments
-  ): SetupCache['In'] extends TadaDocumentNode
-    ? SetupCache['In']
+  ): setupCache[In] extends TadaDocumentNode
+    ? setupCache[In]
     : getDocumentNode<
         parseDocument<In>,
         Schema,
@@ -652,10 +653,11 @@ const graphql: GraphQLTadaAPI<
 export { parse, graphql, readFragment, maskFragments, unsafe_readResult, initGraphQLTada };
 
 export type {
-  SetupCache,
+  setupCache,
   setupSchema,
   parseDocument,
   AbstractSetupSchema,
+  AbstractSetupCache,
   GraphQLTadaAPI,
   TadaDocumentNode,
   TadaPersistedDocumentNode,

--- a/src/api.ts
+++ b/src/api.ts
@@ -84,6 +84,11 @@ interface setupSchema extends AbstractSetupSchema {
   /*empty*/
 }
 
+interface AbstractCache {
+  cache: Record<string, TadaDocumentNode>;
+}
+interface Cache extends AbstractCache {}
+
 interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfig> {
   /** Function to create and compose GraphQL documents with result and variable types.
    *

--- a/src/api.ts
+++ b/src/api.ts
@@ -84,10 +84,10 @@ interface setupSchema extends AbstractSetupSchema {
   /*empty*/
 }
 
-interface AbstractCache {
-  cache: Record<string, TadaDocumentNode>;
+interface AbstractSetupCache {
+  [key: string]: TadaDocumentNode;
 }
-interface Cache extends AbstractCache {}
+interface SetupCache extends AbstractSetupCache {}
 
 interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfig> {
   /** Function to create and compose GraphQL documents with result and variable types.
@@ -132,12 +132,14 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
   <const In extends string, const Fragments extends readonly FragmentShape[]>(
     input: In,
     fragments?: Fragments
-  ): getDocumentNode<
-    parseDocument<In>,
-    Schema,
-    getFragmentsOfDocuments<Fragments>,
-    Config['isMaskingDisabled']
-  >;
+  ): SetupCache['In'] extends TadaDocumentNode
+    ? SetupCache['In']
+    : getDocumentNode<
+        parseDocument<In>,
+        Schema,
+        getFragmentsOfDocuments<Fragments>,
+        Config['isMaskingDisabled']
+      >;
 
   /** Function to validate the type of a given scalar or enum value.
    *
@@ -650,6 +652,7 @@ const graphql: GraphQLTadaAPI<
 export { parse, graphql, readFragment, maskFragments, unsafe_readResult, initGraphQLTada };
 
 export type {
+  SetupCache,
   setupSchema,
   parseDocument,
   AbstractSetupSchema,

--- a/src/api.ts
+++ b/src/api.ts
@@ -133,7 +133,7 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
   <const In extends string, const Fragments extends readonly FragmentShape[]>(
     input: In,
     fragments?: Fragments
-  ): setupCache[In] extends TadaDocumentNode
+  ): setupCache[In] extends DocumentNodeLike
     ? setupCache[In]
     : getDocumentNode<
         parseDocument<In>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   maskFragments,
   unsafe_readResult,
   initGraphQLTada,
+  Cache,
 } from './api';
 
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,11 @@ export {
 } from './api';
 
 export type {
-  SetupCache,
+  setupCache,
   setupSchema,
   parseDocument,
   AbstractSetupSchema,
+  AbstractSetupCache,
   GraphQLTadaAPI,
   TadaDocumentNode,
   TadaPersistedDocumentNode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ export {
   maskFragments,
   unsafe_readResult,
   initGraphQLTada,
-  Cache,
 } from './api';
 
 export type {
+  SetupCache,
   setupSchema,
   parseDocument,
   AbstractSetupSchema,


### PR DESCRIPTION
Resolves #160 

## Summary

This compiles types Ahead Of Time so that we can have a cache and that during dev TypeScript has less to worry about, current output looks like:

```
{
  'graphql(`\r\n  fragment PokemonItem on Pokemon {\r\n    id\r\n    name\r\n  }\r\n`)': 'TadaDocumentNode<{ name: string; id: string; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>',
  'graphql(`\r\n  query Pokemons ($limit: Int = 10) {\r\n    pokemons(limit: $limit) {\r\n      id\r\n      ...PokemonItem\r\n    }\r\n  }\r\n`, [PokemonItemFragment])': 'TadaDocumentNode<{ pokemons: ({ [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; id: string; } | null)[] | null; 
}, { limit?: number | null | undefined; }, void>'
}
```
