### PR TITLE
feat: Allow enums to be remapped like scalars

### DIFF
--- a/.changeset/fair-otters-lie.md
+++ b/.changeset/fair-otters-lie.md
@@ -1,0 +1,6 @@
+---
+"gql.tada": minor
+"@gql.tada/internal": patch
+---
+
+Allow GraphQL enum types to be remapped with the `scalars` configuration option.

--- a/packages/internal/src/introspection/preprocess.ts
+++ b/packages/internal/src/introspection/preprocess.ts
@@ -57,7 +57,7 @@ const printFields = (fields: readonly IntrospectionField[]) => {
 export const printIntrospectionType = (type: IntrospectionType) => {
   if (type.kind === 'ENUM') {
     const values = printNamedTypes(type.enumValues);
-    return `{ name: ${printName(type.name)}; type: ${values}; }`;
+    return `{ name: ${printName(type.name)}; enumValues: ${values}; }`;
   } else if (type.kind === 'INPUT_OBJECT') {
     const fields = printInputFields(type.inputFields);
     return `{ kind: 'INPUT_OBJECT'; name: ${printName(type.name)}; inputFields: ${fields}; }`;

--- a/packages/internal/src/introspection/preprocess.ts
+++ b/packages/internal/src/introspection/preprocess.ts
@@ -57,7 +57,7 @@ const printFields = (fields: readonly IntrospectionField[]) => {
 export const printIntrospectionType = (type: IntrospectionType) => {
   if (type.kind === 'ENUM') {
     const values = printNamedTypes(type.enumValues);
-    return `{ kind: 'ENUM'; name: ${printName(type.name)}; type: ${values}; }`;
+    return `{ name: ${printName(type.name)}; type: ${values}; }`;
   } else if (type.kind === 'INPUT_OBJECT') {
     const fields = printInputFields(type.inputFields);
     return `{ kind: 'INPUT_OBJECT'; name: ${printName(type.name)}; inputFields: ${fields}; }`;
@@ -73,10 +73,8 @@ export const printIntrospectionType = (type: IntrospectionType) => {
     const name = printName(type.name);
     const possibleTypes = printNamedTypes(type.possibleTypes);
     return `{ kind: 'UNION'; name: ${name}; fields: {}; possibleTypes: ${possibleTypes}; }`;
-  } else if (type.kind === 'SCALAR') {
-    return 'unknown';
   } else {
-    return 'never';
+    return 'unknown';
   }
 };
 

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -149,11 +149,17 @@ describe('graphql()', () => {
 });
 
 describe('graphql() with custom scalars', () => {
+  enum TestEnum {
+    value = 'value',
+    test = 'test',
+  }
+
   const graphql = initGraphQLTada<{
     introspection: simpleIntrospection;
     scalars: {
       ID: [string];
       String: { value: string };
+      test: TestEnum;
     };
   }>();
 
@@ -162,6 +168,7 @@ describe('graphql() with custom scalars', () => {
       fragment Fields on Todo @_unmask {
         id
         text
+        test
       }
     `);
 
@@ -179,6 +186,7 @@ describe('graphql() with custom scalars', () => {
     expectTypeOf<FragmentOf<typeof fragment>>().toEqualTypeOf<{
       id: [string];
       text: { value: string };
+      test: TestEnum | null;
     }>();
 
     expectTypeOf<ResultOf<typeof query>>().toEqualTypeOf<{
@@ -186,6 +194,7 @@ describe('graphql() with custom scalars', () => {
         | ({
             id: [string];
             text: { value: string };
+            test: TestEnum | null;
           } | null)[]
         | null;
     }>();

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -65,7 +65,7 @@ export type simpleSchema = {
 
     test: {
       name: 'test';
-      type: 'value' | 'more';
+      enumValues: 'value' | 'more';
     };
 
     SmallTodo: {

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -64,7 +64,6 @@ export type simpleSchema = {
     };
 
     test: {
-      kind: 'ENUM';
       name: 'test';
       type: 'value' | 'more';
     };

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -14,4 +14,10 @@ describe('mapIntrospection', () => {
     type idScalar = expected['types']['ID']['type'];
     expectTypeOf<idScalar>().toEqualTypeOf<'ID'>();
   });
+
+  it('still uses default scalars when applying custom scalars', () => {
+    type expected = addIntrospectionScalars<mapIntrospection<simpleIntrospection>, { ID: 'ID' }>;
+    type intScalar = expected['types']['Int']['type'];
+    expectTypeOf<intScalar>().toEqualTypeOf<number>();
+  });
 });

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -20,4 +20,17 @@ describe('mapIntrospection', () => {
     type intScalar = expected['types']['Int']['type'];
     expectTypeOf<intScalar>().toEqualTypeOf<number>();
   });
+
+  it('allows enums to be remapped', () => {
+    enum TestEnum {
+      test = 'test',
+      value = 'value',
+    }
+    type expected = addIntrospectionScalars<
+      mapIntrospection<simpleIntrospection>,
+      { test: TestEnum }
+    >;
+    type testEnum = expected['types']['test']['type'];
+    expectTypeOf<testEnum>().toEqualTypeOf<TestEnum>();
+  });
 });

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -31,12 +31,6 @@ interface IntrospectionSchema {
   readonly types: readonly any[];
 }
 
-interface IntrospectionScalarType {
-  readonly kind: 'SCALAR';
-  readonly name: string;
-  readonly specifiedByURL?: string | null;
-}
-
 export interface IntrospectionObjectType {
   readonly kind: 'OBJECT';
   readonly name: string;
@@ -49,33 +43,27 @@ export interface IntrospectionObjectType {
 interface IntrospectionInterfaceType {
   readonly kind: 'INTERFACE';
   readonly name: string;
-  // Usually this would be `IntrospectionField`.
-  // However, to save TypeScript some work, instead, we constraint it to `any` here.
-  readonly fields: readonly any[];
-  readonly possibleTypes: readonly IntrospectionNamedTypeRef[];
-  // The `interfaces` field isn't used. It's omitted here
+  readonly fields: readonly any[] /*readonly IntrospectionField[]*/;
+  readonly possibleTypes: readonly any[] /*readonly IntrospectionNamedTypeRef[]*/;
+  // NOTE: The `interfaces` field isn't used. It's omitted here
 }
 
 interface IntrospectionUnionType {
   readonly kind: 'UNION';
   readonly name: string;
-  readonly possibleTypes: readonly IntrospectionNamedTypeRef[];
-}
-
-interface IntrospectionEnumValue {
-  readonly name: string;
+  readonly possibleTypes: readonly any[] /*readonly IntrospectionNamedTypeRef[]*/;
 }
 
 interface IntrospectionEnumType {
   readonly kind: 'ENUM';
   readonly name: string;
-  readonly enumValues: readonly IntrospectionEnumValue[];
+  readonly enumValues: readonly any[] /*readonly IntrospectionEnumValue[]*/;
 }
 
 interface IntrospectionInputObjectType {
   readonly kind: 'INPUT_OBJECT';
   readonly name: string;
-  readonly inputFields: readonly IntrospectionInputValue[];
+  readonly inputFields: readonly any[] /*readonly IntrospectionInputValue[]*/;
 }
 
 export interface IntrospectionListTypeRef {
@@ -101,12 +89,6 @@ export interface IntrospectionField {
   readonly name: string;
   readonly type: IntrospectionTypeRef;
   // The `args` field isn't used. It's omitted here
-}
-
-interface IntrospectionInputValue {
-  readonly name: string;
-  readonly type: IntrospectionTypeRef;
-  readonly defaultValue?: string | null;
 }
 
 interface DefaultScalars {

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -178,9 +178,7 @@ type mapType<Type> = Type extends IntrospectionEnumType
         ? mapUnion<Type>
         : Type extends IntrospectionInputObjectType
           ? mapInputObject<Type>
-          : Type extends IntrospectionScalarType
-            ? unknown
-            : never;
+          : unknown;
 
 /** @internal */
 type mapIntrospectionTypes<Query extends IntrospectionQuery> = obj<{

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -118,7 +118,6 @@ interface DefaultScalars {
 }
 
 type mapEnum<T extends IntrospectionEnumType> = {
-  kind: 'ENUM';
   name: T['name'];
   type: T['enumValues'][number]['name'];
 };
@@ -195,7 +194,6 @@ type mapIntrospectionTypes<Query extends IntrospectionQuery> = obj<{
 /** @internal */
 type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> = obj<{
   [P in keyof Scalars | keyof DefaultScalars]: {
-    kind: 'SCALAR';
     name: P;
     type: P extends keyof Scalars
       ? Scalars[P]

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -92,11 +92,11 @@ export interface IntrospectionField {
 }
 
 interface DefaultScalars {
-  ID: string;
-  Boolean: boolean;
-  String: string;
-  Float: number;
-  Int: number;
+  readonly ID: string;
+  readonly Boolean: boolean;
+  readonly String: string;
+  readonly Float: number;
+  readonly Int: number;
 }
 
 type mapEnum<T extends IntrospectionEnumType> = {
@@ -212,7 +212,7 @@ type addIntrospectionScalars<
 export type IntrospectionLikeInput = SchemaLike | IntrospectionQuery;
 
 export type ScalarsLike = {
-  [name: string]: any;
+  readonly [name: string]: any;
 };
 
 export type SchemaLike = {

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -101,7 +101,7 @@ interface DefaultScalars {
 
 type mapEnum<T extends IntrospectionEnumType> = {
   name: T['name'];
-  type: T['enumValues'][number]['name'];
+  enumValues: T['enumValues'][number]['name'];
 };
 
 type mapField<T> = T extends IntrospectionField

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -47,9 +47,13 @@ type unwrapTypeRec<
                 Fragments
               >
           : unknown
-        : IsOptional extends false
-          ? Introspection['types'][Type['name']]['type']
-          : null | Introspection['types'][Type['name']]['type']
+        : Introspection['types'][Type['name']] extends { type: any }
+          ? IsOptional extends false
+            ? Introspection['types'][Type['name']]['type']
+            : Introspection['types'][Type['name']]['type'] | null
+          : IsOptional extends false
+            ? Introspection['types'][Type['name']]['enumValues']
+            : Introspection['types'][Type['name']]['enumValues'] | null
       : unknown;
 
 type getTypeDirective<Node> = Node extends { directives: any[] }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -98,7 +98,7 @@ type _getScalarType<
     ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
     : Introspection['types'][TypeName] extends { type: any }
       ? Introspection['types'][TypeName]['type']
-      : never
+      : Introspection['types'][TypeName]['enumValues']
   : unknown;
 
 type getScalarType<
@@ -110,7 +110,9 @@ type getScalarType<
     ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection> | OrType
     : Introspection['types'][TypeName] extends { type: any }
       ? Introspection['types'][TypeName]['type'] | OrType
-      : never
+      : Introspection['types'][TypeName] extends { enumValues: any }
+        ? Introspection['types'][TypeName]['enumValues'] | OrType
+        : never
   : never;
 
 export type { getVariablesType, getScalarType };

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -96,7 +96,7 @@ type _getScalarType<
 > = TypeName extends keyof Introspection['types']
   ? Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
     ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
-    : Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+    : Introspection['types'][TypeName] extends { type: any }
       ? Introspection['types'][TypeName]['type']
       : never
   : unknown;
@@ -108,7 +108,7 @@ type getScalarType<
 > = TypeName extends keyof Introspection['types']
   ? Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
     ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection> | OrType
-    : Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+    : Introspection['types'][TypeName] extends { type: any }
       ? Introspection['types'][TypeName]['type'] | OrType
       : never
   : never;

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -83,17 +83,12 @@ type _getVariablesRec<
         : {}) &
         VariablesObject
     >
-  : VariablesObject;
+  : obj<VariablesObject>;
 
 type getVariablesType<
   Document extends DocumentNodeLike,
   Introspection extends SchemaLike,
-> = Document['definitions'][0] extends {
-  kind: Kind.OPERATION_DEFINITION;
-  variableDefinitions: any;
-}
-  ? obj<_getVariablesRec<Document['definitions'][0]['variableDefinitions'], Introspection>>
-  : {};
+> = _getVariablesRec<Document['definitions'][0]['variableDefinitions'], Introspection>;
 
 type _getScalarType<
   TypeName,

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -94,10 +94,10 @@ type _getScalarType<
   TypeName,
   Introspection extends SchemaLike,
 > = TypeName extends keyof Introspection['types']
-  ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
-    ? Introspection['types'][TypeName]['type']
-    : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
-      ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
+  ? Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
+    ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
+    : Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+      ? Introspection['types'][TypeName]['type']
       : never
   : unknown;
 
@@ -106,12 +106,10 @@ type getScalarType<
   Introspection extends SchemaLike,
   OrType = never,
 > = TypeName extends keyof Introspection['types']
-  ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
-    ? Introspection['types'][TypeName]['type'] | OrType
-    : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
-      ?
-          | getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
-          | OrType
+  ? Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
+    ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection> | OrType
+    : Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
+      ? Introspection['types'][TypeName]['type'] | OrType
       : never
   : never;
 

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -24,7 +24,7 @@ type getInputObjectTypeRec<
         : {}) &
         InputObject
     >
-  : InputObject;
+  : obj<InputObject>;
 
 type unwrapTypeRec<TypeRef, Introspection extends SchemaLike, IsOptional> = TypeRef extends {
   kind: 'NON_NULL';
@@ -102,7 +102,7 @@ type _getScalarType<
   ? Introspection['types'][TypeName] extends { kind: 'SCALAR' | 'ENUM'; type: any }
     ? Introspection['types'][TypeName]['type']
     : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
-      ? obj<getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>>
+      ? getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
       : never
   : unknown;
 
@@ -115,9 +115,7 @@ type getScalarType<
     ? Introspection['types'][TypeName]['type'] | OrType
     : Introspection['types'][TypeName] extends { kind: 'INPUT_OBJECT'; inputFields: any }
       ?
-          | obj<
-              getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
-            >
+          | getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
           | OrType
       : never
   : never;

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -501,9 +501,11 @@ declare module 'gql.tada' {
 This is used either via [`setupSchema`](#setupschema) or [`initGraphQLTada()`](#initgraphqltada) to set
 up your schema and scalars. Your configuration objects must match the shape of this type.
 
-The `scalars` option is optional and can be used to set up more scalars, apart
-from the default ones (like: Int, Float, String, Boolean).
+The `scalars` option is optional and can be used to set up custom scalar and enum types.
 It must be an object map of scalar names to their desired TypeScript types.
+When a scalar or enum is missing in your custom `scalars` object, a fallback will be
+used for the built-in scalars (`Int`, `Float`, `String`, `Boolean`, and `ID`) and for
+enums, the `enumValues` defined by the schema will be used.
 
 The `disableMasking` flag may be set to `true` instead of using `@_unmask` on individual fragments
 and allows fragment masking to be disabled globally.


### PR DESCRIPTION
Resolves #180

## Summary

This allows enums to be remapped like scalars. Specifically, if a user has a more qualified type for enums, they should be allowed to completely remap it.

Because `Omit<Schema['types'], keyof Scalars>` is potentially expensive for TypeScript to traverse, this PR avoids this pattern and instead refactors the code that resolves the types for enums. Specifically, `mapEnum` now outputs its type onto the `enumValues` property rather than `type`.

This PR also removes some redundant checks throughout the touched code path.

In practice, the following is now possible:

```ts
enum TestEnum {
  value = 'VALUE',
  test = 'TEST',
}

const graphql = initGraphQLTada<{
  introspection: someIntrospection;
  scalars: {
    // enum Test { VALUE, TEST }
    Test: TestEnum;
  };
}>();
```

In the future, we could add an additional check to `graphql.scalar` that checks the remapped type against the `enumValues` type to make sure they're compatible.

## Set of changes

- Refactor `getInputObjectTypeRec` and `_getVariablesRec` in `variables.ts` to move `obj<>` squashing
- Remove `SCALAR` and `ENUM` markers from processed schema outputs
- Remove redundant `unknown | never` output from processed schema outputs
- Slim down introspection generics once again
- Allow `scalars` to be an object of `readonly` properties
- **Output enum type onto `enumValues` and modify `variables.ts` and `selection.ts` to check `type` then `enumValues`**
