### PR TITLE
chore(internal): Improve consistency of preprocess output

### DIFF
--- a/.changeset/pretty-falcons-leave.md
+++ b/.changeset/pretty-falcons-leave.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Replace `minifyIntrospectionQuery` utility with a version that sorts fields and types by name.

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -44,7 +44,6 @@
     "@types/node": "^20.11.0",
     "@urql/core": "^4.3.0",
     "@urql/exchange-retry": "^1.2.1",
-    "@urql/introspection": "^1.0.3",
     "json5": "^2.2.3",
     "graphql": "^16.8.1",
     "rollup": "^4.9.4",

--- a/packages/internal/src/introspection/index.ts
+++ b/packages/internal/src/introspection/index.ts
@@ -1,3 +1,3 @@
-export { minifyIntrospectionQuery } from './minify';
+export { minifyIntrospectionQuery as minifyIntrospection } from './minify';
 export { preprocessIntrospection } from './preprocess';
 export * from './output';

--- a/packages/internal/src/introspection/index.ts
+++ b/packages/internal/src/introspection/index.ts
@@ -1,2 +1,3 @@
+export { minifyIntrospectionQuery } from './minify';
 export { preprocessIntrospection } from './preprocess';
 export * from './output';

--- a/packages/internal/src/introspection/minify.ts
+++ b/packages/internal/src/introspection/minify.ts
@@ -89,14 +89,14 @@ function minifyIntrospectionType(type: IntrospectionType): IntrospectionType {
       return {
         kind: 'ENUM',
         name: type.name,
-        enumValues: type.enumValues.map(mapEnumValue).sort(nameCompare),
+        enumValues: type.enumValues.map(mapEnumValue),
       };
 
     case 'INPUT_OBJECT': {
       return {
         kind: 'INPUT_OBJECT',
         name: type.name,
-        inputFields: type.inputFields.map(mapInputField).sort(nameCompare),
+        inputFields: type.inputFields.map(mapInputField),
       };
     }
 

--- a/packages/internal/src/introspection/minify.ts
+++ b/packages/internal/src/introspection/minify.ts
@@ -1,0 +1,209 @@
+import type {
+  IntrospectionQuery,
+  IntrospectionType,
+  IntrospectionTypeRef,
+  IntrospectionNamedTypeRef,
+  IntrospectionOutputTypeRef,
+  IntrospectionInputTypeRef,
+  IntrospectionInputValue,
+  IntrospectionEnumValue,
+  IntrospectionField,
+} from 'graphql';
+
+function nameCompare(objA: { name: string }, objB: { name: string }) {
+  return objA.name < objB.name ? -1 : objA.name > objB.name ? 1 : 0;
+}
+
+function mapTypeRef<const T extends IntrospectionTypeRef>(fromType: T): T;
+function mapTypeRef(fromType: IntrospectionTypeRef): IntrospectionTypeRef;
+function mapTypeRef(fromType: IntrospectionOutputTypeRef): IntrospectionOutputTypeRef;
+function mapTypeRef(fromType: IntrospectionInputTypeRef): IntrospectionInputTypeRef;
+
+function mapTypeRef(fromType: IntrospectionTypeRef): IntrospectionTypeRef {
+  switch (fromType.kind) {
+    case 'NON_NULL':
+      return {
+        kind: fromType.kind,
+        ofType: mapTypeRef(fromType.ofType),
+      };
+    case 'LIST':
+      return {
+        kind: fromType.kind,
+        ofType: mapTypeRef(fromType.ofType),
+      };
+    case 'ENUM':
+    case 'INPUT_OBJECT':
+    case 'SCALAR':
+    case 'OBJECT':
+    case 'INTERFACE':
+    case 'UNION':
+      return {
+        kind: fromType.kind,
+        name: fromType.name,
+      };
+  }
+}
+
+function mapEnumValue(value: IntrospectionEnumValue): IntrospectionEnumValue {
+  return {
+    name: value.name,
+    isDeprecated: !!value.isDeprecated,
+    deprecationReason: undefined,
+  };
+}
+
+function mapInputField(value: IntrospectionInputValue): IntrospectionInputValue {
+  return {
+    name: value.name,
+    type: mapTypeRef(value.type),
+    defaultValue: value.defaultValue || undefined,
+  };
+}
+
+function mapField(field: IntrospectionField): IntrospectionField {
+  return {
+    name: field.name,
+    type: mapTypeRef(field.type),
+    args: field.args ? field.args.map(mapInputField).sort(nameCompare) : [],
+    isDeprecated: !!field.isDeprecated,
+    deprecationReason: undefined,
+  };
+}
+
+function mapPossibleType<T extends IntrospectionNamedTypeRef>(ref: T): T {
+  return {
+    kind: ref.kind,
+    name: ref.name,
+  } as T;
+}
+
+function minifyIntrospectionType(type: IntrospectionType): IntrospectionType {
+  switch (type.kind) {
+    case 'SCALAR':
+      return {
+        kind: 'SCALAR',
+        name: type.name,
+      };
+
+    case 'ENUM':
+      return {
+        kind: 'ENUM',
+        name: type.name,
+        enumValues: type.enumValues.map(mapEnumValue).sort(nameCompare),
+      };
+
+    case 'INPUT_OBJECT': {
+      return {
+        kind: 'INPUT_OBJECT',
+        name: type.name,
+        inputFields: type.inputFields.map(mapInputField).sort(nameCompare),
+      };
+    }
+
+    case 'OBJECT':
+      return {
+        kind: 'OBJECT',
+        name: type.name,
+        fields: type.fields ? type.fields.map(mapField).sort(nameCompare) : [],
+        interfaces: type.interfaces ? type.interfaces.map(mapPossibleType).sort(nameCompare) : [],
+      };
+
+    case 'INTERFACE':
+      return {
+        kind: 'INTERFACE',
+        name: type.name,
+        fields: type.fields ? type.fields.map(mapField).sort(nameCompare) : [],
+        interfaces: type.interfaces ? type.interfaces.map(mapPossibleType).sort(nameCompare) : [],
+        possibleTypes: type.possibleTypes
+          ? type.possibleTypes.map(mapPossibleType).sort(nameCompare)
+          : [],
+      };
+
+    case 'UNION':
+      return {
+        kind: 'UNION',
+        name: type.name,
+        possibleTypes: type.possibleTypes
+          ? type.possibleTypes.map(mapPossibleType).sort(nameCompare)
+          : [],
+      };
+  }
+}
+
+/** Minifies an {@link IntrospectionQuery} for use with Graphcache or the `populateExchange`.
+ *
+ * @param schema - An {@link IntrospectionQuery} object to be minified.
+ * @param opts - An optional {@link MinifySchemaOptions} configuration object.
+ * @returns the minified {@link IntrospectionQuery} object.
+ *
+ * @remarks
+ * `minifyIntrospectionQuery` reduces the size of an {@link IntrospectionQuery} by
+ * removing data and information that a client-side consumer, like Graphcache or the
+ * `populateExchange`, may not require.
+ *
+ * At the very least, it will remove system types, descriptions, depreactions,
+ * and source locations. Unless disabled via the options passed, it will also
+ * by default remove all scalars, enums, inputs, and directives.
+ *
+ * @throws
+ * If `schema` receives an object that isn’t an {@link IntrospectionQuery}, a
+ * {@link TypeError} will be thrown.
+ */
+export const minifyIntrospectionQuery = (schema: IntrospectionQuery): IntrospectionQuery => {
+  if (!schema || !('__schema' in schema)) {
+    throw new TypeError('Expected to receive an IntrospectionQuery.');
+  }
+
+  const {
+    __schema: { queryType, mutationType, subscriptionType, types },
+  } = schema;
+
+  const minifiedTypes = types
+    .filter((type) => {
+      switch (type.name) {
+        case '__Directive':
+        case '__DirectiveLocation':
+        case '__EnumValue':
+        case '__InputValue':
+        case '__Field':
+        case '__Type':
+        case '__TypeKind':
+        case '__Schema':
+          return false;
+        default:
+          return (
+            type.kind === 'SCALAR' ||
+            type.kind === 'ENUM' ||
+            type.kind === 'INPUT_OBJECT' ||
+            type.kind === 'OBJECT' ||
+            type.kind === 'INTERFACE' ||
+            type.kind === 'UNION'
+          );
+      }
+    })
+    .map(minifyIntrospectionType)
+    .sort(nameCompare);
+
+  return {
+    __schema: {
+      queryType: {
+        kind: queryType.kind,
+        name: queryType.name,
+      },
+      mutationType: mutationType
+        ? {
+            kind: mutationType.kind,
+            name: mutationType.name,
+          }
+        : null,
+      subscriptionType: subscriptionType
+        ? {
+            kind: subscriptionType.kind,
+            name: subscriptionType.name,
+          }
+        : null,
+      types: minifiedTypes,
+      directives: [],
+    },
+  };
+};

--- a/packages/internal/src/introspection/output.ts
+++ b/packages/internal/src/introspection/output.ts
@@ -1,5 +1,4 @@
 import type { IntrospectionQuery } from 'graphql';
-import { minifyIntrospectionQuery } from '@urql/introspection';
 
 import { TadaError } from '../errors';
 import { PREAMBLE_IGNORE, ANNOTATION_DTS, ANNOTATION_TS } from './constants';
@@ -7,15 +6,6 @@ import { preprocessIntrospection } from './preprocess';
 
 const stringifyJson = (input: unknown | string): string =>
   typeof input === 'string' ? input : JSON.stringify(input, null, 2);
-
-export function minifyIntrospection(introspection: IntrospectionQuery): IntrospectionQuery {
-  return minifyIntrospectionQuery(introspection, {
-    includeDirectives: false,
-    includeEnums: true,
-    includeInputs: true,
-    includeScalars: true,
-  });
-}
 
 interface OutputIntrospectionFileOptions {
   fileType: '.ts' | '.d.ts' | string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,9 +206,6 @@ importers:
       '@urql/exchange-retry':
         specifier: ^1.2.1
         version: 1.2.1(graphql@16.8.1)
-      '@urql/introspection':
-        specifier: ^1.0.3
-        version: 1.0.3(graphql@16.8.1)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -2253,14 +2250,6 @@ packages:
       wonka: 6.3.4
     transitivePeerDependencies:
       - graphql
-    dev: true
-
-  /@urql/introspection@1.0.3(graphql@16.8.1):
-    resolution: {integrity: sha512-5zgnfUDV10c3qudqYvfZ/rOtWVB2QvqanmoDMttqpt+TCCPkSUZdb2qcLCEB6DL7ph8mQRTZhXI29J57nTnqKg==}
-    peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 16.8.1
     dev: true
 
   /@vitejs/plugin-react@4.2.1(vite@5.1.6):

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -1,452 +1,447 @@
-export type simpleSchema = {
-  query: 'Query';
-  mutation: 'Mutation';
-  subscription: 'Subscription';
-
-  types: {
-    Query: {
-      kind: 'OBJECT';
-      name: 'Query';
-      fields: {
-        todos: {
-          name: 'todos';
-          type: {
-            kind: 'LIST';
-            name: null;
-            ofType: {
+export type simpleSchema =
+  {
+    query: 'Query';
+    mutation: 'Mutation';
+    subscription: 'Subscription';
+    types: {
+      Author: {
+        kind: 'OBJECT';
+        name: 'Author';
+        fields: {
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          known: {
+            name: 'known';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+          name: {
+            name: 'name';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+        };
+      };
+      BigTodo: {
+        kind: 'OBJECT';
+        name: 'BigTodo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
+          };
+          complete: {
+            name: 'complete';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+          wallOfText: {
+            name: 'wallOfText';
+            type: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        };
+      };
+      Boolean: unknown;
+      DefaultPayload: {
+        kind: 'INPUT_OBJECT';
+        name: 'DefaultPayload';
+        inputFields: [
+          {
+            name: 'value';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: 'DEFAULT';
+          },
+        ];
+      };
+      ID: unknown;
+      ITodo: {
+        kind: 'INTERFACE';
+        name: 'ITodo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
+          };
+          complete: {
+            name: 'complete';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+        };
+        possibleTypes:
+          | 'BigTodo'
+          | 'SmallTodo';
+      };
+      Int: unknown;
+      LatestTodoResult: {
+        kind: 'UNION';
+        name: 'LatestTodoResult';
+        fields: {};
+        possibleTypes:
+          | 'NoTodosError'
+          | 'Todo';
+      };
+      Mutation: {
+        kind: 'OBJECT';
+        name: 'Mutation';
+        fields: {
+          toggleTodo: {
+            name: 'toggleTodo';
+            type: {
+              kind: 'OBJECT';
+              name: 'Todo';
+              ofType: null;
+            };
+          };
+          updateTodo: {
+            name: 'updateTodo';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+        };
+      };
+      NoTodosError: {
+        kind: 'OBJECT';
+        name: 'NoTodosError';
+        fields: {
+          message: {
+            name: 'message';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+        };
+      };
+      Query: {
+        kind: 'OBJECT';
+        name: 'Query';
+        fields: {
+          itodo: {
+            name: 'itodo';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'INTERFACE';
+                name: 'ITodo';
+                ofType: null;
+              };
+            };
+          };
+          latestTodo: {
+            name: 'latestTodo';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'UNION';
+                name: 'LatestTodoResult';
+                ofType: null;
+              };
+            };
+          };
+          test: {
+            name: 'test';
+            type: {
+              kind: 'UNION';
+              name: 'Search';
+              ofType: null;
+            };
+          };
+          todos: {
+            name: 'todos';
+            type: {
+              kind: 'LIST';
+              name: never;
+              ofType: {
+                kind: 'OBJECT';
+                name: 'Todo';
+                ofType: null;
+              };
+            };
+          };
+        };
+      };
+      Search: {
+        kind: 'UNION';
+        name: 'Search';
+        fields: {};
+        possibleTypes:
+          | 'BigTodo'
+          | 'SmallTodo';
+      };
+      SmallTodo: {
+        kind: 'OBJECT';
+        name: 'SmallTodo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
+          };
+          complete: {
+            name: 'complete';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          maxLength: {
+            name: 'maxLength';
+            type: {
+              kind: 'SCALAR';
+              name: 'Int';
+              ofType: null;
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+        };
+      };
+      String: unknown;
+      Subscription: {
+        kind: 'OBJECT';
+        name: 'Subscription';
+        fields: {
+          newTodo: {
+            name: 'newTodo';
+            type: {
               kind: 'OBJECT';
               name: 'Todo';
               ofType: null;
             };
           };
         };
-        latestTodo: {
-          name: 'latestTodo';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'UNION';
-              name: 'LatestTodoResult';
-              ofType: null;
-            };
-          };
-        };
-        itodo: {
-          name: 'itodo';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'INTERFACE';
-              name: 'ITodo';
-              ofType: null;
-            };
-          };
-        };
-
-        test: {
-          name: 'test';
-          type: {
-            kind: 'UNION';
-            name: 'Search';
-            ofType: null;
-          };
-        };
       };
-    };
-
-    Search: {
-      kind: 'UNION';
-      name: 'Search';
-      fields: {};
-      possibleTypes: 'SmallTodo' | 'BigTodo';
-    };
-
-    test: {
-      name: 'test';
-      enumValues: 'value' | 'more';
-    };
-
-    SmallTodo: {
-      kind: 'OBJECT';
-      name: 'SmallTodo';
-      fields: {
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
+      Todo: {
+        kind: 'OBJECT';
+        name: 'Todo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
               ofType: null;
             };
           };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
+          complete: {
+            name: 'complete';
+            type: {
               kind: 'SCALAR';
-              name: 'String';
+              name: 'Boolean';
               ofType: null;
             };
           };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-        maxLength: {
-          name: 'maxLength';
-          type: {
-            kind: 'SCALAR';
-            name: 'Int';
-            ofType: null;
-          };
-        };
-      };
-    };
-
-    BigTodo: {
-      kind: 'OBJECT';
-      name: 'BigTodo';
-      fields: {
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
-              ofType: null;
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
             };
           };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-        wallOfText: {
-          name: 'wallOfText';
-          type: {
-            kind: 'SCALAR';
-            name: 'String';
-            ofType: null;
-          };
-        };
-      };
-    };
-
-    ITodo: {
-      kind: 'INTERFACE';
-      name: 'ITodo';
-      possibleTypes: 'BigTodo' | 'SmallTodo';
-      fields: {
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
-              ofType: null;
-            };
-          };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-      };
-    };
-
-    TodoPayload: {
-      kind: 'INPUT_OBJECT';
-      name: 'TodoPayload';
-      inputFields: [
-        {
-          name: 'title';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-          defaultValue: null;
-        },
-        {
-          name: 'description';
-          type: {
-            kind: 'NON_NULL';
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-        },
-        {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-          defaultValue: null;
-        },
-      ];
-    };
-
-    DefaultPayload: {
-      kind: 'INPUT_OBJECT';
-      name: 'DefaultPayload';
-      inputFields: [
-        {
-          name: 'value';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-          defaultValue: 'DEFAULT';
-        },
-      ];
-    };
-
-    LatestTodoResult: {
-      kind: 'UNION';
-      name: 'LatestTodoResult';
-      fields: {};
-      possibleTypes: 'Todo' | 'NoTodosError';
-    };
-
-    NoTodosError: {
-      kind: 'OBJECT';
-      name: 'NoTodosError';
-      fields: {
-        message: {
-          name: 'message';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-        };
-      };
-    };
-
-    Todo: {
-      kind: 'OBJECT';
-      name: 'Todo';
-      fields: {
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
-              ofType: null;
-            };
-          };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        test: {
-          name: 'test';
-          type: {
-            kind: 'ENUM';
+          test: {
             name: 'test';
-            ofType: null;
-          };
-        };
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-      };
-    };
-
-    ID: unknown;
-    String: unknown;
-    Boolean: unknown;
-    Int: unknown;
-
-    Author: {
-      kind: 'OBJECT';
-      name: 'Author';
-      fields: {
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
+            type: {
+              kind: 'ENUM';
+              name: 'test';
               ofType: null;
             };
           };
-        };
-        name: {
-          name: 'name';
-          type: {
-            kind: 'NON_NULL';
-            name: null;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
             };
           };
         };
-        known: {
-          name: 'known';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
       };
-    };
-
-    Mutation: {
-      kind: 'OBJECT';
-      name: 'Mutation';
-      fields: {
-        toggleTodo: {
-          name: 'toggleTodo';
-          type: {
-            kind: 'OBJECT';
-            name: 'Todo';
-            ofType: null;
-          };
-        };
-        updateTodo: {
-          name: 'updateTodo';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
+      TodoPayload: {
+        kind: 'INPUT_OBJECT';
+        name: 'TodoPayload';
+        inputFields: [
+          {
+            name: 'title';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+          {
+            name: 'description';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+          {
+            name: 'complete';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+            defaultValue: null;
+          },
+        ];
       };
-    };
-
-    Subscription: {
-      kind: 'OBJECT';
-      name: 'Subscription';
-      fields: {
-        newTodo: {
-          name: 'newTodo';
-          type: {
-            kind: 'OBJECT';
-            name: 'Todo';
-            ofType: null;
-          };
-        };
+      test: {
+        name: 'test';
+        enumValues:
+          | 'value'
+          | 'more';
       };
     };
   };
-};

--- a/src/__tests__/introspection.test-d.ts
+++ b/src/__tests__/introspection.test-d.ts
@@ -5,8 +5,8 @@ import type { mapIntrospection, addIntrospectionScalars } from '../introspection
 
 describe('mapIntrospection', () => {
   it('prepares sample schema', () => {
-    type expected = addIntrospectionScalars<mapIntrospection<simpleIntrospection>>;
-    expectTypeOf<expected>().toMatchTypeOf<simpleSchema>();
+    type expected = mapIntrospection<simpleIntrospection>;
+    expectTypeOf<simpleSchema>().toMatchTypeOf<expected>();
   });
 
   it('applies scalar types as appropriate', () => {


### PR DESCRIPTION
## Summary

Replaces `minifyIntrospectionQuery` to presort some output (`inputFields` and `enumValues` sorting is left alone and left up to the API to sort).

This increases the consistency of our output to the point where we can re-generate `simpleSchema.ts` using our `preprocess` utility then enhance the tests to check against that, as a manual snapshot.

## Set of changes

- Replace `minifyIntrospectionQuery` with sorted equivalent
