### PR TITLE
chore(docs): update API documentation with CLI and persisted

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -129,6 +129,10 @@ export default defineConfig({
             link: '/reference/gql-tada-api',
           },
           {
+            text: 'gql.tada CLI',
+            link: '/reference/gql-tada-cli',
+          },
+          {
             text: 'GraphQLSP Config',
             link: '/reference/graphqlsp-config',
           },

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -177,21 +177,23 @@ type Media = ReturnType<typeof graphql.scalar<'Media'>>;
 |                  | Description                                    |
 | ---------------- | ---------------------------------------------- |
 | `hash` argument  | A hash associated with this query.             |
+| `document` optional argument  | Optionally, the document, if it's supposed to be accessible during runtime.             |
 
 Generates a faux-document containing a property called `documentId` which
 can be used to send off queries as [Persisted Operations](https://github.com/graphql/graphql-over-http/blob/main/rfcs/PersistedOperations.md).
 
-In the LSP we'll check the `generic` associated with `graphql.persisted<typeof document>()`
-and give you a code-action to generate a hash.
+We must either pass the document as a generic type argument or as the second argument:
+- `graphql.persisted<typeof document>("abc...")`
+- `graphql.persisted("abc...", document)`
 
-Because we use a generic and no explicit reference to the document these will
-be seen as dead-code in your front-end bundle and hence, given the appropriate
-bundler configuration, removed.
+`@0no-co/graphqlsp` will then check that the document is available and offer a code action to automatically update the hash to a SHA256-hash of the document.
+
+This is useful to implement and extract persisted operations using the CLI. Additionally, when the document is passed as a generic — as long as our GraphQL cache supports this — it can be fully omitted during runtime from the client-side bundle.
 
 > [!NOTE]
-> As it stands we'll omit the document-definitions from the AST which
-> could give problems with some GraphQL Client caches. We'll work on
-> adding support for this.
+> When you use the generic API, passing the document by type using `graphql.persisted<typeof document>("...")`, your runtime code won’t see any `definitions` on the AST.
+> This may cause problems with GraphQL clients (especially normalised caches) that rely on the AST to be available, since the full document will transpile away.
+> For such clients, you may want to preserve the document by passing it as a second argument instead.
 
 #### Example
 

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -208,17 +208,31 @@ export type introspection = {
       {
         "kind": "OBJECT",
         "name": "Query",
-        "fields": [],
+        "fields": [
+          {
+            "name": "hello",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "world",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
         "interfaces": []
       },
       {
-        "kind": "ENUM",
-        "name": "Media",
-        "enumValues": [
-          { "name": "Book" },
-          { "name": "Song" },
-          { "name": "Video" }
-        ]
+        "kind": "SCALAR",
+        "name": "String"
       }
     ],
     "directives": []
@@ -238,8 +252,8 @@ declare module 'gql.tada' {
 import { graphql } from 'gql.tada';
 
 const query = graphql(`
-  query Pokemon($id: ID!) {
-    pokemon(id: $id) { id }
+  query Hello {
+    hello
   }
 `)
 

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -31,52 +31,52 @@ If you instead would like to manually create a `graphql` function with an explic
 ```ts twoslash
 // @filename: graphq-env.d.ts
 export type introspection = {
-  "__schema": {
-    "queryType": {
-      "name": "Query"
-    },
-    "mutationType": null,
-    "subscriptionType": null,
-    "types": [
+  __schema: {
+    queryType: {
+      name: 'Query';
+    };
+    mutationType: null;
+    subscriptionType: null;
+    types: [
       {
-        "kind": "OBJECT",
-        "name": "Query",
-        "fields": [
+        kind: 'OBJECT';
+        name: 'Query';
+        fields: [
           {
-            "name": "hello",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "args": []
+            name: 'hello';
+            type: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+            args: [];
           },
           {
-            "name": "world",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
+            name: 'world';
+            type: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+            args: [];
+          },
+        ];
+        interfaces: [];
       },
       {
-        "kind": "SCALAR",
-        "name": "String"
-      }
-    ],
-    "directives": []
-  }
+        kind: 'SCALAR';
+        name: 'String';
+      },
+    ];
+    directives: [];
+  };
 };
 
 import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
   interface setupSchema {
-    introspection: introspection
+    introspection: introspection;
   }
 }
 
@@ -92,12 +92,15 @@ const fragment = graphql(`
   }
 `);
 
-const query = graphql(`
-  query HelloQuery {
-    hello
-    ...HelloWorld
-  }
-`, [fragment]);
+const query = graphql(
+  `
+    query HelloQuery {
+      hello
+      ...HelloWorld
+    }
+  `,
+  [fragment]
+);
 ```
 
 ### `graphql.scalar()`
@@ -126,38 +129,34 @@ a scalar or enum, but not a full fragment.
 ```ts twoslash
 // @filename: graphq-env.d.ts
 export type introspection = {
-  "__schema": {
-    "queryType": {
-      "name": "Query"
-    },
-    "mutationType": null,
-    "subscriptionType": null,
-    "types": [
+  __schema: {
+    queryType: {
+      name: 'Query';
+    };
+    mutationType: null;
+    subscriptionType: null;
+    types: [
       {
-        "kind": "OBJECT",
-        "name": "Query",
-        "fields": [],
-        "interfaces": []
+        kind: 'OBJECT';
+        name: 'Query';
+        fields: [];
+        interfaces: [];
       },
       {
-        "kind": "ENUM",
-        "name": "Media",
-        "enumValues": [
-          { "name": "Book" },
-          { "name": "Song" },
-          { "name": "Video" }
-        ]
-      }
-    ],
-    "directives": []
-  }
+        kind: 'ENUM';
+        name: 'Media';
+        enumValues: [{ name: 'Book' }, { name: 'Song' }, { name: 'Video' }];
+      },
+    ];
+    directives: [];
+  };
 };
 
 import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
   interface setupSchema {
-    introspection: introspection
+    introspection: introspection;
   }
 }
 
@@ -174,15 +173,16 @@ type Media = ReturnType<typeof graphql.scalar<'Media'>>;
 
 ### `graphql.persisted()`
 
-|                  | Description                                    |
-| ---------------- | ---------------------------------------------- |
-| `hash` argument  | A hash associated with this query.             |
-| `document` optional argument  | Optionally, the document, if it's supposed to be accessible during runtime.             |
+|                              | Description                                                                 |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| `hash` argument              | A hash associated with this query.                                          |
+| `document` optional argument | Optionally, the document, if it's supposed to be accessible during runtime. |
 
 Generates a faux-document containing a property called `documentId` which
 can be used to send off queries as [Persisted Operations](https://github.com/graphql/graphql-over-http/blob/main/rfcs/PersistedOperations.md).
 
 We must either pass the document as a generic type argument or as the second argument:
+
 - `graphql.persisted<typeof document>("abc...")`
 - `graphql.persisted("abc...", document)`
 
@@ -200,52 +200,52 @@ This is useful to implement and extract persisted operations using the CLI. Addi
 ```ts twoslash
 // @filename: graphq-env.d.ts
 export type introspection = {
-  "__schema": {
-    "queryType": {
-      "name": "Query"
-    },
-    "mutationType": null,
-    "subscriptionType": null,
-    "types": [
+  __schema: {
+    queryType: {
+      name: 'Query';
+    };
+    mutationType: null;
+    subscriptionType: null;
+    types: [
       {
-        "kind": "OBJECT",
-        "name": "Query",
-        "fields": [
+        kind: 'OBJECT';
+        name: 'Query';
+        fields: [
           {
-            "name": "hello",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "args": []
+            name: 'hello';
+            type: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+            args: [];
           },
           {
-            "name": "world",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
+            name: 'world';
+            type: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+            args: [];
+          },
+        ];
+        interfaces: [];
       },
       {
-        "kind": "SCALAR",
-        "name": "String"
-      }
-    ],
-    "directives": []
-  }
+        kind: 'SCALAR';
+        name: 'String';
+      },
+    ];
+    directives: [];
+  };
 };
 
 import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
   interface setupSchema {
-    introspection: introspection
+    introspection: introspection;
   }
 }
 
@@ -257,10 +257,10 @@ const query = graphql(`
   query Hello {
     hello
   }
-`)
+`);
 
 // You can now use this in your `useQuery` calls.
-const persistedOperation = graphql.persisted<typeof query>("sha256:x")
+const persistedOperation = graphql.persisted<typeof query>('sha256:x');
 ```
 
 ### `readFragment()`
@@ -309,22 +309,23 @@ const pokemonItemFragment = graphql(`
   }
 `);
 
-const getPokemonItem = (
-  data: FragmentOf<typeof pokemonItemFragment> | null
-) => {
-// @annotate: Unmasks the fragment and casts to the result type:
+const getPokemonItem = (data: FragmentOf<typeof pokemonItemFragment> | null) => {
+  // @annotate: Unmasks the fragment and casts to the result type:
 
   const pokemon = readFragment(pokemonItemFragment, data);
 };
 
-const pokemonQuery = graphql(`
-  query Pokemon($id: ID!) {
-    pokemon(id: $id) {
-      id
-      ...PokemonItem
+const pokemonQuery = graphql(
+  `
+    query Pokemon($id: ID!) {
+      pokemon(id: $id) {
+        id
+        ...PokemonItem
+      }
     }
-  }
-`, [pokemonItemFragment]);
+  `,
+  [pokemonItemFragment]
+);
 
 const getQuery = (data: ResultOf<typeof pokemonQuery>) => {
   getPokemonItem(data.pokemon);
@@ -376,7 +377,7 @@ const pokemonItemFragment = graphql(`
 
 const data = maskFragments([pokemonItemFragment], {
   id: '001',
-  name: 'Bulbasaur'
+  name: 'Bulbasaur',
 });
 ```
 
@@ -424,13 +425,16 @@ const pokemonItemFragment = graphql(`
   }
 `);
 
-const query = graphql(`
-  query {
-    pokemon(id: "001") {
-      ...PokemonItem
+const query = graphql(
+  `
+    query {
+      pokemon(id: "001") {
+        ...PokemonItem
+      }
     }
-  }
-`, [pokemonItemFragment]);
+  `,
+  [pokemonItemFragment]
+);
 
 // @warn: data will be cast (unsafely!) to the result type
 

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -172,6 +172,69 @@ function validateMediaEnum(value: 'Book' | 'Song' | 'Video') {
 type Media = ReturnType<typeof graphql.scalar<'Media'>>;
 ```
 
+### `graphql.persisted()`
+
+|                  | Description                                    |
+| ---------------- | ---------------------------------------------- |
+| `hash` argument  | A hash associated with this query.             |
+
+Generates a faux-document containing a property called `documentId` which
+can be used to send off queries as [Persisted Operations](https://github.com/graphql/graphql-over-http/blob/main/rfcs/PersistedOperations.md).
+
+#### Example
+
+```ts twoslash
+// @filename: graphq-env.d.ts
+export type introspection = {
+  "__schema": {
+    "queryType": {
+      "name": "Query"
+    },
+    "mutationType": null,
+    "subscriptionType": null,
+    "types": [
+      {
+        "kind": "OBJECT",
+        "name": "Query",
+        "fields": [],
+        "interfaces": []
+      },
+      {
+        "kind": "ENUM",
+        "name": "Media",
+        "enumValues": [
+          { "name": "Book" },
+          { "name": "Song" },
+          { "name": "Video" }
+        ]
+      }
+    ],
+    "directives": []
+  }
+};
+
+import * as gqlTada from 'gql.tada';
+
+declare module 'gql.tada' {
+  interface setupSchema {
+    introspection: introspection
+  }
+}
+
+// @filename: index.ts
+// ---cut-before---
+import { graphql } from 'gql.tada';
+
+const query = graphql(`
+  query Pokemon($id: ID!) {
+    pokemon(id: $id) { id }
+  }
+`)
+
+// You can now use this in your `useQuery` calls.
+const persistedOperation = graphql.persisted<typeof query>("sha256:x")
+```
+
 ### `readFragment()`
 
 |                               | Description                                                              |

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -181,6 +181,18 @@ type Media = ReturnType<typeof graphql.scalar<'Media'>>;
 Generates a faux-document containing a property called `documentId` which
 can be used to send off queries as [Persisted Operations](https://github.com/graphql/graphql-over-http/blob/main/rfcs/PersistedOperations.md).
 
+In the LSP we'll check the `generic` associated with `graphql.persisted<typeof document>()`
+and give you a code-action to generate a hash.
+
+Because we use a generic and no explicit reference to the document these will
+be seen as dead-code in your front-end bundle and hence, given the appropriate
+bundler configuration, removed.
+
+> [!NOTE]
+> As it stands we'll omit the document-definitions from the AST which
+> could give problems with some GraphQL Client caches. We'll work on
+> adding support for this.
+
 #### Example
 
 ```ts twoslash

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -1,0 +1,220 @@
+---
+title: gql.tada CLI
+---
+
+# `gql.tada` CLI (BETA)
+
+## Commands
+
+### `init`
+
+The `init` command takes care of everything required to setup a `gql.tada`
+project. The main tasks involved here are:
+
+- Getting to the schema
+- Locating where we need to output your `graphql-env`
+- Configuring the `tsconfig.json`
+- Installing the dependencies
+
+You can run this command with
+
+::: code-group
+
+```sh [npm]
+npx gql-tada init ./my-project
+```
+
+```sh [pnpm]
+pnpm gql-tada init ./my-project
+```
+
+```sh [yarn]
+yarn gql-tada init ./my-project
+```
+
+```sh [bun]
+bun gql-tada init ./my-project
+```
+
+:::
+
+### `doctor`
+
+The `doctor` command will check for common mistakes in the configuration of `gql.tada`
+by checking the versions of `typescript`, your `tsconfig`, ...
+
+You can run this command with
+
+::: code-group
+
+```sh [npm]
+npx gql-tada doctor
+```
+
+```sh [pnpm]
+pnpm gql-tada doctor
+```
+
+```sh [yarn]
+yarn gql-tada doctor
+```
+
+```sh [bun]
+bun gql-tada doctor
+```
+
+:::
+
+### `check`
+
+One of the short-comings of the LSP plugin method is that these don't run during `tsc`
+hence we added the `check` command which will run the same diagnostics logic of our LSP
+on your project.
+
+It has two options
+
+- `level` allowing you to tweak what level of diagnostics we'll try to find, the options for this are `error`, `warn` and `info`. (Default: Error)
+- `exit-on-warn` by default we will do a non-zero exit when we find errors, with this option you can tell us to do the same for warnings. (Default: false)
+
+Example usage could look like the following:
+
+::: code-group
+
+```sh [npm]
+npx gql-tada check --level warn --exit-on-warn
+```
+
+```sh [pnpm]
+pnpm gql-tada check --level warn --exit-on-warn
+```
+
+```sh [yarn]
+yarn gql-tada check --level warn --exit-on-warn
+```
+
+```sh [bun]
+bun gql-tada check --level warn --exit-on-warn
+```
+
+:::
+
+### `generate-schema`
+
+Generating your schema can sometimes be behind auth, ... with this command you can
+generate the schema from a URL and use environment variables in your shell rather than
+having to add them in the `tsconfig.json`.
+
+You can feed in a URL or an introspection JSON file and a two other options:
+
+- `header` a header key-value string to use when retrieving the introspection from a URL.
+- `output` a specified location to output the schema to, for instance `./schema.graphql`. (by default this will take the `schema` option from your `@0no-co/graphqlsp` plugin configuration)
+
+Example usage could look like the following:
+
+::: code-group
+
+```sh [npm]
+npx gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
+```
+
+```sh [pnpm]
+pnpm gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
+```
+
+```sh [yarn]
+yarn gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
+```
+
+```sh [bun]
+bun gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
+```
+
+:::
+
+### `generate-output`
+
+The `generate-output` command mimics the behavior of our LSP where it will look at
+your configured `schema` and output the `graphql-env` to your configured
+`tadaOutputLocation`.
+
+This command accepts 1 option `disable-preprocessing` when used this will give you the
+old introspection types output which is slower.
+
+Example usage could look like the following:
+
+::: code-group
+
+```sh [npm]
+npx gql-tada generate-output
+```
+
+```sh [pnpm]
+pnpm gql-tada generate-output
+```
+
+```sh [yarn]
+yarn gql-tada generate-output
+```
+
+```sh [bun]
+bun gql-tada generate-output
+```
+
+:::
+
+### `turbo`
+
+The `turbo` command allows you to cache all the existing GraphQL query types ahead
+of time. This step can make checking out the repository faster for other people and
+reduce the time spent calculating the types. See it as taking a snapshot of your
+current types, when you start editing your queries it will not find it in the cache
+anymore and revert to the runtime behavior.
+
+Example usage could look like the following:
+
+::: code-group
+
+```sh [npm]
+npx gql-tada turbo
+```
+
+```sh [pnpm]
+pnpm gql-tada turbo
+```
+
+```sh [yarn]
+yarn gql-tada turbo
+```
+
+```sh [bun]
+bun gql-tada turbo
+```
+
+:::
+
+### `generate-persisted`
+
+This will look for all the `graphql.persisted()` calls in your codebase and generate
+a JSON-file containing a mapping of `hash: document` which can then be used with
+a server implementation to lock down your API with the documents that are allowed
+to be sent.
+
+::: code-group
+
+```sh [npm]
+npx gql-tada generate-persisted ./persisted-operations.json
+```
+
+```sh [pnpm]
+pnpm gql-tada generate-persisted ./persisted-operations.json
+```
+
+```sh [yarn]
+yarn gql-tada generate-persisted ./persisted-operations.json
+```
+
+```sh [bun]
+bun gql-tada generate-persisted ./persisted-operations.json
+```
+
+:::

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -2,183 +2,100 @@
 title: gql.tada CLI
 ---
 
-# `gql.tada` CLI (BETA)
+# `gql.tada` CLI <Badge type="warning" text="beta" />
 
 ## Commands
 
 ### `init`
 
+> [!NOTE]
+>
+> The `gql.tada init` command is still a work in progress.
+> If you run into any trouble, feel free to let us know what you’d like to see added or changed.
+
 | Option               | Description                                                                                |
 | -------------------- | ------------------------------------------------------------------------------------------ |
-| `dir`              | A relative location from your current working directory where we should be running `init`.   |
+| `dir`              | A relative location from your current working directory where the project should be initialized.   |
 
 The `init` command takes care of everything required to setup a `gql.tada`
 project. The main tasks involved here are:
 
-- Getting to the schema
-- Locating where we need to output your `graphql-env`
+- Locating the schema
+- Locating where `gql.tada`’s `graphql-env.d.ts` shall be placed
 - Configuring the `tsconfig.json`
-- Installing the dependencies
+- Installing required dependencies
 
-You can run this command with
+You can run this command with your preferred package manager:
 
 ::: code-group
 
 ```sh [npm]
-npx gql-tada init ./my-project
+npx gql.tada init ./my-project
 ```
 
 ```sh [pnpm]
-pnpm gql-tada init ./my-project
-```
-
-```sh [yarn]
-yarn gql-tada init ./my-project
+pnpx gql.tada init ./my-project
 ```
 
 ```sh [bun]
-bun gql-tada init ./my-project
+bunx gql.tada init ./my-project
 ```
 
 :::
 
 ### `doctor`
 
-The `doctor` command will check for common mistakes in the configuration of `gql.tada`
-by checking the versions of `typescript`, your `tsconfig`, ...
+> [!NOTE]
+>
+> The `gql.tada doctor` command is still a work in progress.
+> If you run into any trouble, feel free to let us know what you’d like to see added or changed.
 
-You can run this command with
-
-::: code-group
-
-```sh [npm]
-npx gql-tada doctor
-```
-
-```sh [pnpm]
-pnpm gql-tada doctor
-```
-
-```sh [yarn]
-yarn gql-tada doctor
-```
-
-```sh [bun]
-bun gql-tada doctor
-```
-
-:::
+The `doctor` command will check for common mistakes in the `gql.tada`’s setup and configuration. It will check installed versions of packages, check the configuration, and check the schema.
 
 ### `check`
 
 | Option               | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
-| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.      |
+| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
 | `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
-| `--level,-l`         | The minimum severity of diagnostics to display: info, warn or error (default: info).            |
+| `--level,-l`         | The minimum severity of diagnostics to display: `info`, `warn` or `error` (default: `info`).            |
 
-One of the short-comings of the LSP plugin method is that these don't run during `tsc`
-hence we added the `check` command which will run the same diagnostics logic of our LSP
-on your project.
+Usually, `@0no-co/graphqlsp` runs as a TypeScript language server plugin to report warnings and errors. However, these diagnostics don’t show up when `tsc` is run.
 
-Example usage could look like the following:
+The `gql.tada check` command exists to run these diagnostics in a standalone command, outside of editing the relevant files and reports these errors to the console.
 
-::: code-group
-
-```sh [npm]
-npx gql-tada check --level warn --exit-on-warn
-```
-
-```sh [pnpm]
-pnpm gql-tada check --level warn --exit-on-warn
-```
-
-```sh [yarn]
-yarn gql-tada check --level warn --exit-on-warn
-```
-
-```sh [bun]
-bun gql-tada check --level warn --exit-on-warn
-```
-
-:::
+When this command is run inside a GitHub Action, [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) are used to annotate errors within the GitHub UI.
 
 ### `generate-schema`
 
 | Option               | Description                                                                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------------ |
-| `schema`             | A relative location from your current working directory where we should write the schema to.           |
-| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.             |
-| `--output,-o`        | Specify where to output the file to. (Default: The `schema` configuration option, if it's a file path) |
-| `--header,`          | A header key-value string to use when retrieving the introspection from a URL.                         |
+| `schema`             | A relative file path to a schema or URL to a GraphQL API to introspect.           |
+| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
+| `--output,-o`        | An output location to write the `.graphql` schema file to. (Default: The `schema` configuration option) |
+| `--header,`          | A key-value header entry to use when retrieving the introspection from a GraphQL API.                         |
 
-Generating your schema can sometimes be behind auth, ... with this command you can
-generate the schema from a URL and use environment variables in your shell rather than
-having to add them in the `tsconfig.json`.
+Oftentimes, an API may not be running in development, is maintained in a separate repository, or requires authorization headers, and specifying a URL in the `schema` configuration can slow down development.
 
-Example usage could look like the following:
-
-::: code-group
-
-```sh [npm]
-npx gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
-```
-
-```sh [pnpm]
-pnpm gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
-```
-
-```sh [yarn]
-yarn gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
-```
-
-```sh [bun]
-bun gql-tada generate-schema http://example.com --header 'Authorization: Bearer token'
-```
-
-:::
+The `gql.tada generate-schema` command can output a `.graphql` SDL file from a URL and use environment variables. Using this command we can avoid having to add a URL in the `tsconfig.json` configuration.
 
 ### `generate-output`
 
 | Option                    | Description                                                                                            |
 | ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `--disable-preprocessing` | Whether to use our less-efficient legacy format. (Default: false)                                      |
-| `--tsconfig,-c`           | A relative location from your current working directory where we can find your `tsconfig`.             |
-| `--output,-o`             | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option)          |
+| `--disable-preprocessing` | Whether to use the less efficient `.d.ts` introspection format. (Default: false)                                   |
+| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
+| `--output,-o`        | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option) |
 
-The `generate-output` command mimics the behavior of our LSP where it will look at
-your configured `schema` and output the `graphql-env` to your configured
-`tadaOutputLocation`.
-
-Example usage could look like the following:
-
-::: code-group
-
-```sh [npm]
-npx gql-tada generate-output
-```
-
-```sh [pnpm]
-pnpm gql-tada generate-output
-```
-
-```sh [yarn]
-yarn gql-tada generate-output
-```
-
-```sh [bun]
-bun gql-tada generate-output
-```
-
-:::
+The `gql.tada generate-output` command mimics the behavior of `@0no-co/graphqlsp`, outputting the `gql.tada` output file manually. It will load the schema from the specified `schema` configuration option and write the output file.
 
 ### `turbo`
 
 | Option               | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
-| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.      |
-| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
-| `--output,-o`        | Specifies where to output the file to. (Default: The `tadaTurboLocation` configuration option)  |
+| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
+| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported. |
+| `--output,-o`        | Specify where to output the file to. (Default: The `tadaTurboLocation` configuration option) |
 
 The `turbo` command allows you to cache all the existing GraphQL query types ahead
 of time. This step can make checking out the repository faster for other people and
@@ -186,57 +103,18 @@ reduce the time spent calculating the types. See it as taking a snapshot of your
 current types, when you start editing your queries it will not find it in the cache
 anymore and revert to the runtime behavior.
 
-Example usage could look like the following:
-
-::: code-group
-
-```sh [npm]
-npx gql-tada turbo
-```
-
-```sh [pnpm]
-pnpm gql-tada turbo
-```
-
-```sh [yarn]
-yarn gql-tada turbo
-```
-
-```sh [bun]
-bun gql-tada turbo
-```
-
-:::
+When this command is run inside a GitHub Action, [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) are used to annotate errors within the GitHub UI.
 
 ### `generate-persisted`
 
 | Option               | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
-| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.      |
-| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
-| `--output,-o`        | Specifies where to output the file to. (Default: The `tadaTurboLocation` configuration option)  |
+| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
+| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported. |
+| `--output,-o`        | Specify where to output the file to. (Default: The `tadaPersistedLocation` configuration option) |
 
-This will look for all the `graphql.persisted()` calls in your codebase and generate
-a JSON-file containing a mapping of `hash: document` which can then be used with
-a server implementation to lock down your API with the documents that are allowed
-to be sent.
+The `gql.tada generate-persisted` command will scan your code for `graphql.persisted()` calls and generate
+a JSON file containing a mapping of document IDs to the GraphQL document strings.
+These can then be used to register known and accepted documents (known as “persisted operations”) with your GraphQL API to lock down accepted documents that are allowed to be sent.
 
-::: code-group
-
-```sh [npm]
-npx gql-tada generate-persisted ./persisted-operations.json
-```
-
-```sh [pnpm]
-pnpm gql-tada generate-persisted ./persisted-operations.json
-```
-
-```sh [yarn]
-yarn gql-tada generate-persisted ./persisted-operations.json
-```
-
-```sh [bun]
-bun gql-tada generate-persisted ./persisted-operations.json
-```
-
-:::
+When this command is run inside a GitHub Action, [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) are used to annotate errors within the GitHub UI.

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -8,6 +8,10 @@ title: gql.tada CLI
 
 ### `init`
 
+| Option               | Description                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `dir`              | A relative location from your current working directory where we should be running `init`.   |
+
 The `init` command takes care of everything required to setup a `gql.tada`
 project. The main tasks involved here are:
 
@@ -67,14 +71,15 @@ bun gql-tada doctor
 
 ### `check`
 
+| Option               | Description                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------- |
+| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.      |
+| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
+| `--level,-l`         | The minimum severity of diagnostics to display: info, warn or error (default: info).            |
+
 One of the short-comings of the LSP plugin method is that these don't run during `tsc`
 hence we added the `check` command which will run the same diagnostics logic of our LSP
 on your project.
-
-It has two options
-
-- `level` allowing you to tweak what level of diagnostics we'll try to find, the options for this are `error`, `warn` and `info`. (Default: Error)
-- `exit-on-warn` by default we will do a non-zero exit when we find errors, with this option you can tell us to do the same for warnings. (Default: false)
 
 Example usage could look like the following:
 
@@ -100,14 +105,16 @@ bun gql-tada check --level warn --exit-on-warn
 
 ### `generate-schema`
 
+| Option               | Description                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `schema`             | A relative location from your current working directory where we should write the schema to.           |
+| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.             |
+| `--output,-o`        | Specify where to output the file to. (Default: The `schema` configuration option, if it's a file path) |
+| `--header,`          | A header key-value string to use when retrieving the introspection from a URL.                         |
+
 Generating your schema can sometimes be behind auth, ... with this command you can
 generate the schema from a URL and use environment variables in your shell rather than
 having to add them in the `tsconfig.json`.
-
-You can feed in a URL or an introspection JSON file and a two other options:
-
-- `header` a header key-value string to use when retrieving the introspection from a URL.
-- `output` a specified location to output the schema to, for instance `./schema.graphql`. (by default this will take the `schema` option from your `@0no-co/graphqlsp` plugin configuration)
 
 Example usage could look like the following:
 
@@ -132,6 +139,13 @@ bun gql-tada generate-schema http://example.com --header 'Authorization: Bearer 
 :::
 
 ### `generate-output`
+
+| Option               | Description                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `--disable-pre`             | A relative location from your current working directory where we should write the schema to.           |
+| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.             |
+| `--output,-o`        | Specify where to output the file to. (Default: The `schema` configuration option, if it's a file path) |
+| `--header,`          | A header key-value string to use when retrieving the introspection from a URL.                         |
 
 The `generate-output` command mimics the behavior of our LSP where it will look at
 your configured `schema` and output the `graphql-env` to your configured
@@ -164,6 +178,12 @@ bun gql-tada generate-output
 
 ### `turbo`
 
+| Option               | Description                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------- |
+| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.      |
+| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
+| `--output,-o`        | Specifies where to output the file to. (Default: The `tadaTurboLocation` configuration option)  |
+
 The `turbo` command allows you to cache all the existing GraphQL query types ahead
 of time. This step can make checking out the repository faster for other people and
 reduce the time spent calculating the types. See it as taking a snapshot of your
@@ -193,6 +213,12 @@ bun gql-tada turbo
 :::
 
 ### `generate-persisted`
+
+| Option               | Description                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------- |
+| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.      |
+| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
+| `--output,-o`        | Specifies where to output the file to. (Default: The `tadaTurboLocation` configuration option)  |
 
 This will look for all the `graphql.persisted()` calls in your codebase and generate
 a JSON-file containing a mapping of `hash: document` which can then be used with

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -13,9 +13,9 @@ title: gql.tada CLI
 > The `gql.tada init` command is still a work in progress.
 > If you run into any trouble, feel free to let us know what you’d like to see added or changed.
 
-| Option               | Description                                                                                |
-| -------------------- | ------------------------------------------------------------------------------------------ |
-| `dir`              | A relative location from your current working directory where the project should be initialized.   |
+| Option | Description                                                                                      |
+| ------ | ------------------------------------------------------------------------------------------------ |
+| `dir`  | A relative location from your current working directory where the project should be initialized. |
 
 The `init` command takes care of everything required to setup a `gql.tada`
 project. The main tasks involved here are:
@@ -54,11 +54,11 @@ The `doctor` command will check for common mistakes in the `gql.tada`’s setup 
 
 ### `check`
 
-| Option               | Description                                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------------------- |
-| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
-| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
-| `--level,-l`         | The minimum severity of diagnostics to display: `info`, `warn` or `error` (default: `info`).            |
+| Option              | Description                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| `--tsconfig,-c`     | Optionally, an alternative relative location to the project’s `tsconfig.json`.                  |
+| `--fail-on-warn,-w` | Triggers an error and a non-zero exit code if any warnings have been reported (default: false). |
+| `--level,-l`        | The minimum severity of diagnostics to display: `info`, `warn` or `error` (default: `info`).    |
 
 Usually, `@0no-co/graphqlsp` runs as a TypeScript language server plugin to report warnings and errors. However, these diagnostics don’t show up when `tsc` is run.
 
@@ -68,12 +68,12 @@ When this command is run inside a GitHub Action, [workflow commands](https://doc
 
 ### `generate-schema`
 
-| Option               | Description                                                                                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------ |
-| `schema`             | A relative file path to a schema or URL to a GraphQL API to introspect.           |
-| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
-| `--output,-o`        | An output location to write the `.graphql` schema file to. (Default: The `schema` configuration option) |
-| `--header,`          | A key-value header entry to use when retrieving the introspection from a GraphQL API.                         |
+| Option          | Description                                                                                             |
+| --------------- | ------------------------------------------------------------------------------------------------------- |
+| `schema`        | A relative file path to a schema or URL to a GraphQL API to introspect.                                 |
+| `--tsconfig,-c` | Optionally, an alternative relative location to the project’s `tsconfig.json`.                          |
+| `--output,-o`   | An output location to write the `.graphql` schema file to. (Default: The `schema` configuration option) |
+| `--header,`     | A key-value header entry to use when retrieving the introspection from a GraphQL API.                   |
 
 Oftentimes, an API may not be running in development, is maintained in a separate repository, or requires authorization headers, and specifying a URL in the `schema` configuration can slow down development.
 
@@ -81,21 +81,21 @@ The `gql.tada generate-schema` command can output a `.graphql` SDL file from a U
 
 ### `generate-output`
 
-| Option                    | Description                                                                                            |
-| ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `--disable-preprocessing` | Whether to use the less efficient `.d.ts` introspection format. (Default: false)                                   |
-| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
-| `--output,-o`        | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option) |
+| Option                    | Description                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `--disable-preprocessing` | Whether to use the less efficient `.d.ts` introspection format. (Default: false)              |
+| `--tsconfig,-c`           | Optionally, an alternative relative location to the project’s `tsconfig.json`.                |
+| `--output,-o`             | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option) |
 
 The `gql.tada generate-output` command mimics the behavior of `@0no-co/graphqlsp`, outputting the `gql.tada` output file manually. It will load the schema from the specified `schema` configuration option and write the output file.
 
 ### `turbo`
 
-| Option               | Description                                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------------------- |
-| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
-| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported. |
-| `--output,-o`        | Specify where to output the file to. (Default: The `tadaTurboLocation` configuration option) |
+| Option              | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `--tsconfig,-c`     | Optionally, an alternative relative location to the project’s `tsconfig.json`.               |
+| `--fail-on-warn,-w` | Triggers an error and a non-zero exit code if any warnings have been reported.               |
+| `--output,-o`       | Specify where to output the file to. (Default: The `tadaTurboLocation` configuration option) |
 
 The `turbo` command allows you to cache all the existing GraphQL query types ahead
 of time. This step can make checking out the repository faster for other people and
@@ -107,11 +107,11 @@ When this command is run inside a GitHub Action, [workflow commands](https://doc
 
 ### `generate-persisted`
 
-| Option               | Description                                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------------------- |
-| `--tsconfig,-c`      | Optionally, an alternative relative location to the project’s `tsconfig.json`.      |
-| `--fail-on-warn,-w`  | Triggers an error and a non-zero exit code if any warnings have been reported. |
-| `--output,-o`        | Specify where to output the file to. (Default: The `tadaPersistedLocation` configuration option) |
+| Option              | Description                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------ |
+| `--tsconfig,-c`     | Optionally, an alternative relative location to the project’s `tsconfig.json`.                   |
+| `--fail-on-warn,-w` | Triggers an error and a non-zero exit code if any warnings have been reported.                   |
+| `--output,-o`       | Specify where to output the file to. (Default: The `tadaPersistedLocation` configuration option) |
 
 The `gql.tada generate-persisted` command will scan your code for `graphql.persisted()` calls and generate
 a JSON file containing a mapping of document IDs to the GraphQL document strings.

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -140,19 +140,15 @@ bun gql-tada generate-schema http://example.com --header 'Authorization: Bearer 
 
 ### `generate-output`
 
-| Option               | Description                                                                                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------ |
-| `--disable-pre`             | A relative location from your current working directory where we should write the schema to.           |
-| `--tsconfig,-c`      | A relative location from your current working directory where we can find your `tsconfig`.             |
-| `--output,-o`        | Specify where to output the file to. (Default: The `schema` configuration option, if it's a file path) |
-| `--header,`          | A header key-value string to use when retrieving the introspection from a URL.                         |
+| Option                    | Description                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `--disable-preprocessing` | Whether to use our less-efficient legacy format. (Default: false)                                      |
+| `--tsconfig,-c`           | A relative location from your current working directory where we can find your `tsconfig`.             |
+| `--output,-o`             | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option)          |
 
 The `generate-output` command mimics the behavior of our LSP where it will look at
 your configured `schema` and output the `graphql-env` to your configured
 `tadaOutputLocation`.
-
-This command accepts 1 option `disable-preprocessing` when used this will give you the
-old introspection types output which is slower.
 
 Example usage could look like the following:
 


### PR DESCRIPTION
This adds `graphql.persisted` to the API documentation and also adds a new page for the CLI.
