### PR TITLE
feat: Add support for the second argument to `graphql.persisted`

### DIFF
--- a/.changeset/late-mice-type.md
+++ b/.changeset/late-mice-type.md
@@ -1,0 +1,6 @@
+---
+"@gql.tada/cli-utils": minor
+"gql.tada": minor
+---
+
+Support a second argument in `graphql.persisted` which represents the `DocumentNode` to create the possibility of persisted-operations that still lock down the origin. Before this change we had to advise folks to use APQ.

--- a/.changeset/late-mice-type.md
+++ b/.changeset/late-mice-type.md
@@ -3,4 +3,4 @@
 "gql.tada": minor
 ---
 
-Support a second argument in `graphql.persisted` which represents the `DocumentNode` to create the possibility of persisted-operations that still lock down the origin. Before this change we had to advise folks to use APQ.
+Support a second argument in `graphql.persisted` which accepts a `TadaDocumentNode` rather than passing a generic. This allows the document node to not be hidden, to still generate `documentId` via `gql.tada` without having to hide the document during runtime.

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -53,10 +53,10 @@
     "wonka": "^6.3.4"
   },
   "dependencies": {
-    "@0no-co/graphqlsp": "^1.9.1",
     "@gql.tada/internal": "workspace:*",
-    "graphql": "^16.8.1",
-    "ts-morph": "~22.0.0"
+    "@0no-co/graphqlsp": "^1.10.0",
+    "ts-morph": "~22.0.0",
+    "graphql": "^16.8.1"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/cli-utils/src/commands/generate-persisted/thread.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/thread.ts
@@ -67,7 +67,7 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
         warnings.push({
           message:
             '"graphql.persisted" is missing a document.\n' +
-              'This may be passed as a generic such as `graphql.persisted<typeof document>` or as the second argument.',
+            'This may be passed as a generic such as `graphql.persisted<typeof document>` or as the second argument.',
           file: filePath,
           line: position.line,
           col: position.col,
@@ -78,19 +78,11 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
       let foundNode: ts.CallExpression | null = null;
       let referencingNode: ts.Node = call;
       if (docArg && (ts.isCallExpression(docArg) || ts.isIdentifier(docArg))) {
-        const result = getDocumentReferenceFromDocumentNode(
-          docArg,
-          filePath,
-          pluginInfo
-        );
+        const result = getDocumentReferenceFromDocumentNode(docArg, filePath, pluginInfo);
         foundNode = result.node;
         referencingNode = docArg;
       } else if (typeQuery && ts.isTypeQueryNode(typeQuery)) {
-        const result = getDocumentReferenceFromTypeQuery(
-          typeQuery,
-          filePath,
-          pluginInfo
-        );
+        const result = getDocumentReferenceFromTypeQuery(typeQuery, filePath, pluginInfo);
         foundNode = result.node;
         referencingNode = typeQuery;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
   packages/cli-utils:
     dependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.9.1
-        version: 1.9.1(typescript@5.4.2)
+        specifier: ^1.10.0
+        version: 1.10.0(typescript@5.4.2)
       '@gql.tada/internal':
         specifier: workspace:*
         version: link:../internal
@@ -289,10 +289,10 @@ packages:
     dependencies:
       graphql: 16.8.1
 
-  /@0no-co/graphqlsp@1.9.1(typescript@5.4.2):
-    resolution: {integrity: sha512-3mLLCNponLK84hVbBUZIXZhw1nvmWblRwFTJE7WCs312iqlCdLW+SZEt+HfhEgM03XhN0D0gQB/8KnZHKs9qwg==}
+  /@0no-co/graphqlsp@1.10.0(typescript@5.4.2):
+    resolution: {integrity: sha512-qPNjG9WOf2YwUKvyLazaj8piTffjKJ1m4gCuqRIbHy0iwsmquTSn0JtyNtO3aewjsfyI13pmsKqWs+v2BJPg1A==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.0.0
     dependencies:
       '@gql.tada/internal': 0.1.3(graphql@16.8.1)(typescript@5.4.2)
       graphql: 16.8.1
@@ -300,6 +300,20 @@ packages:
       typescript: 5.4.2
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@0no-co/graphqlsp@1.9.1(typescript@5.4.2):
+    resolution: {integrity: sha512-3mLLCNponLK84hVbBUZIXZhw1nvmWblRwFTJE7WCs312iqlCdLW+SZEt+HfhEgM03XhN0D0gQB/8KnZHKs9qwg==}
+    peerDependencies:
+      typescript: ^5.0.0
+    dependencies:
+      '@gql.tada/internal': 0.1.3(graphql@16.8.1)(typescript@5.4.2)
+      graphql: 16.8.1
+      node-fetch: 2.7.0
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
   /@0no-co/typescript.js@5.3.2-2:
     resolution: {integrity: sha512-IGQZZ7vcVD/GOUKLJckpQiq8F5raQZLR7kOVhxN5nHOywl1dB9EFMA7FJkyNoCEig7EkCb291X8FswMwwrz9yg==}
@@ -1473,7 +1487,7 @@ packages:
     resolution: {integrity: sha512-wIvykBId7O0gaizmSl5n5AhbQsgJVLTUsFBm3RsfQ9dVfpmT+Fhy2yHX+yNgiVECg2EimXMhs4ltcE4EuZ2WOA==}
     peerDependencies:
       graphql: ^16.8.1
-      typescript: ^5.3.3
+      typescript: ^5.0.0
     dependencies:
       '@0no-co/graphql.web': 1.0.5(graphql@16.8.1)
       graphql: 16.8.1
@@ -2397,7 +2411,7 @@ packages:
   /@vue/language-core@1.8.27(typescript@5.4.3):
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5417,7 +5431,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^5.3.3
+      typescript: ^4.5 || ^5.0
     dependencies:
       magic-string: 0.30.5
       rollup: 4.9.4
@@ -5969,7 +5983,7 @@ packages:
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
     dev: true
@@ -6008,7 +6022,7 @@ packages:
   /twoslash-vue@0.1.2(typescript@5.4.3):
     resolution: {integrity: sha512-LCD3VTw0+gKVMXou/nP8OAtpajGAoKuzFx9oyGteBkeMRgDj2DO95WDBHy/o+ihkckYZ0lUbvIFFjzmDy7zHag==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     dependencies:
       '@vue/language-core': 1.8.27(typescript@5.4.3)
       twoslash: 0.1.2(typescript@5.4.3)
@@ -6020,7 +6034,7 @@ packages:
   /twoslash@0.1.2(typescript@5.4.3):
     resolution: {integrity: sha512-q0jnapnD3b0umNGCJCRlo6Em1oSFl2OBPwsXqhLzijtEzuORrGVrJffG7E1k1KPHFlwBSRX2q6yYA61etn5hSg==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     dependencies:
       '@typescript/vfs': 1.5.0
       typescript: 5.4.3
@@ -6454,7 +6468,7 @@ packages:
   /vue@3.4.21(typescript@5.4.3):
     resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true

--- a/src/api.ts
+++ b/src/api.ts
@@ -209,7 +209,8 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
    * ```
    */
   persisted<Document extends DocumentNodeLike = never>(
-    documentId: string
+    documentId: string,
+    document?: Document
   ): Document extends DocumentDecoration<infer Result, infer Variables>
     ? TadaPersistedDocumentNode<Result, Variables>
     : never;
@@ -279,10 +280,13 @@ function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
     return value;
   };
 
-  graphql.persisted = function persisted(documentId: string): TadaPersistedDocumentNode {
+  graphql.persisted = function persisted(
+    documentId: string,
+    document?: TadaDocumentNode
+  ): TadaPersistedDocumentNode {
     return {
       kind: Kind.DOCUMENT,
-      definitions: [],
+      definitions: document ? document.definitions : [],
       documentId,
     };
   };
@@ -354,7 +358,7 @@ interface TadaPersistedDocumentNode<
   Variables = { [key: string]: any },
 > extends DocumentNode,
     DocumentDecoration<Result, Variables> {
-  definitions: readonly [];
+  definitions: readonly DefinitionNode[];
   documentId: string;
 }
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This adds support for `graphql.persisted(hash, document)` so we don't have to advise folks to use APQ when their GraphQL client does not support definition-less documents. To push this out we'll still need to add support to the LSP.
