### PR TITLE
fix: add support for detecting argument deprecation

### DIFF
--- a/.changeset/friendly-beans-exist.md
+++ b/.changeset/friendly-beans-exist.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Add support for detecting argument deprecation

--- a/packages/internal/src/loaders/__tests__/query.test.ts
+++ b/packages/internal/src/loaders/__tests__/query.test.ts
@@ -102,7 +102,7 @@ describe('toSupportedFeatures', () => {
     };
 
     expect(toSupportedFeatures(input)).toMatchObject({
-      inputValueDeprecation: true,
+      argsValueDeprecation: true,
     });
   });
 });

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -18,6 +18,7 @@ const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: true,
   specifiedByURL: true,
   inputValueDeprecation: true,
+  argsValueDeprecation: true,
 };
 
 export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -18,12 +18,14 @@ const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: true,
   specifiedByURL: true,
   inputValueDeprecation: true,
+  argsValueDeprecation: true,
 };
 
 const NO_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: false,
   specifiedByURL: false,
   inputValueDeprecation: false,
+  argsValueDeprecation: false,
 };
 
 export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {


### PR DESCRIPTION
Resolves https://github.com/0no-co/gql.tada/issues/189

## Summary

It looks like `InputValueDeprecation` does not necessarily mean argument deprecation, the safe way to find this would be to look at the locations the directive can be specified on.

Hence our query now adds in

```
schema: __schema { directives { name locations } }
```

EDIT: I realised that both args and input-values are of type `__InputValue` which would be a really odd inconsistency in datocms