### PR TITLE
fix: support opting out of the includeDeprecated argument

### DIFF
--- a/.changeset/plenty-games-smoke.md
+++ b/.changeset/plenty-games-smoke.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Support opting out of `includeDeprecated` on `__Directive` and `__Field` in accordance with the October 2021 spec

--- a/packages/internal/src/loaders/__tests__/query.test.ts
+++ b/packages/internal/src/loaders/__tests__/query.test.ts
@@ -46,6 +46,8 @@ describe('toSupportedFeatures', () => {
       directiveIsRepeatable: false,
       specifiedByURL: false,
       inputValueDeprecation: false,
+      supportsDirectiveIsDeprecatedArgument: false,
+      supportsFieldIsDeprecatedArgument: false,
     });
   });
 
@@ -55,7 +57,10 @@ describe('toSupportedFeatures', () => {
       inputValue: null, // stubbed
       field: null, // stubbed
       directive: {
-        fields: [{ name: 'isRepeatable', args: [{ name: 'includeDeprecated' }] }],
+        fields: [
+          { name: 'isRepeatable', args: [] },
+          { name: 'args', args: [{ name: 'includeDeprecated' }] },
+        ],
       },
     };
 
@@ -71,7 +76,7 @@ describe('toSupportedFeatures', () => {
       inputValue: null, // stubbed
       directive: null, // stubbed
       field: {
-        fields: [{ name: 'test', args: [{ name: 'includeDeprecated' }] }],
+        fields: [{ name: 'args', args: [{ name: 'includeDeprecated' }] }],
       },
     };
 

--- a/packages/internal/src/loaders/__tests__/query.test.ts
+++ b/packages/internal/src/loaders/__tests__/query.test.ts
@@ -46,8 +46,8 @@ describe('toSupportedFeatures', () => {
       directiveIsRepeatable: false,
       specifiedByURL: false,
       inputValueDeprecation: false,
-      supportsDirectiveIsDeprecatedArgument: false,
-      supportsFieldIsDeprecatedArgument: false,
+      directiveArgumentsIsDeprecated: false,
+      fieldArgumentsIsDeprecated: false,
     });
   });
 
@@ -66,7 +66,7 @@ describe('toSupportedFeatures', () => {
 
     expect(toSupportedFeatures(input)).toMatchObject({
       directiveIsRepeatable: true,
-      supportsDirectiveIsDeprecatedArgument: true,
+      directiveArgumentsIsDeprecated: true,
     });
   });
 
@@ -81,7 +81,7 @@ describe('toSupportedFeatures', () => {
     };
 
     expect(toSupportedFeatures(input)).toMatchObject({
-      supportsFieldIsDeprecatedArgument: true,
+      fieldArgumentsIsDeprecated: true,
     });
   });
 
@@ -122,8 +122,8 @@ describe('makeIntrospectionQuery', () => {
       directiveIsRepeatable: true,
       specifiedByURL: true,
       inputValueDeprecation: true,
-      supportsDirectiveIsDeprecatedArgument: true,
-      supportsFieldIsDeprecatedArgument: true,
+      directiveArgumentsIsDeprecated: true,
+      fieldArgumentsIsDeprecated: true,
     };
 
     const output = print(makeIntrospectionQuery(support));
@@ -252,8 +252,8 @@ describe('makeIntrospectionQuery', () => {
       directiveIsRepeatable: false,
       specifiedByURL: false,
       inputValueDeprecation: false,
-      supportsDirectiveIsDeprecatedArgument: false,
-      supportsFieldIsDeprecatedArgument: false,
+      directiveArgumentsIsDeprecated: false,
+      fieldArgumentsIsDeprecated: false,
     };
 
     const output = print(makeIntrospectionQuery(support));

--- a/packages/internal/src/loaders/__tests__/query.test.ts
+++ b/packages/internal/src/loaders/__tests__/query.test.ts
@@ -10,6 +10,17 @@ describe('makeIntrospectSupportQuery', () => {
         directive: __type(name: "__Directive") {
           fields {
             name
+            args {
+              name
+            }
+          }
+        }
+        field: __type(name: "__Field") {
+          fields {
+            name
+            args {
+              name
+            }
           }
         }
         type: __type(name: "__Type") {
@@ -29,24 +40,43 @@ describe('makeIntrospectSupportQuery', () => {
 
 describe('toSupportedFeatures', () => {
   it('outputs default with no features enabled', () => {
-    expect(toSupportedFeatures({ type: null, inputValue: null, directive: null })).toEqual({
+    expect(
+      toSupportedFeatures({ type: null, inputValue: null, directive: null, field: null })
+    ).toEqual({
       directiveIsRepeatable: false,
       specifiedByURL: false,
       inputValueDeprecation: false,
     });
   });
 
-  it('detects `isRepeatable` support on directives', () => {
+  it('detects `isRepeatable` and `includeDeprectaed` support on directives', () => {
     const input = {
       type: null, // stubbed
       inputValue: null, // stubbed
+      field: null, // stubbed
       directive: {
-        fields: [{ name: 'isRepeatable' }],
+        fields: [{ name: 'isRepeatable', args: [{ name: 'includeDeprecated' }] }],
       },
     };
 
     expect(toSupportedFeatures(input)).toMatchObject({
       directiveIsRepeatable: true,
+      supportsDirectiveIsDeprecatedArgument: true,
+    });
+  });
+
+  it('detects `includeDeprectaed` support on fields', () => {
+    const input = {
+      type: null, // stubbed
+      inputValue: null, // stubbed
+      directive: null, // stubbed
+      field: {
+        fields: [{ name: 'test', args: [{ name: 'includeDeprecated' }] }],
+      },
+    };
+
+    expect(toSupportedFeatures(input)).toMatchObject({
+      supportsFieldIsDeprecatedArgument: true,
     });
   });
 
@@ -54,6 +84,7 @@ describe('toSupportedFeatures', () => {
     const input = {
       inputValue: null, // stubbed
       directive: null, // stubbed
+      field: null, // stubbed
       type: {
         fields: [{ name: 'specifiedByURL' }],
       },
@@ -68,6 +99,7 @@ describe('toSupportedFeatures', () => {
     const input = {
       type: null, // stubbed
       directive: null, // stubbed
+      field: null, // stubbed
       inputValue: {
         fields: [{ name: 'isDeprecated' }],
       },
@@ -85,6 +117,8 @@ describe('makeIntrospectionQuery', () => {
       directiveIsRepeatable: true,
       specifiedByURL: true,
       inputValueDeprecation: true,
+      supportsDirectiveIsDeprecatedArgument: true,
+      supportsFieldIsDeprecatedArgument: true,
     };
 
     const output = print(makeIntrospectionQuery(support));
@@ -213,6 +247,8 @@ describe('makeIntrospectionQuery', () => {
       directiveIsRepeatable: false,
       specifiedByURL: false,
       inputValueDeprecation: false,
+      supportsDirectiveIsDeprecatedArgument: false,
+      supportsFieldIsDeprecatedArgument: false,
     };
 
     const output = print(makeIntrospectionQuery(support));

--- a/packages/internal/src/loaders/query.ts
+++ b/packages/internal/src/loaders/query.ts
@@ -118,7 +118,7 @@ export const makeIntrospectSupportQuery = (): DocumentNode => ({
           {
             kind: Kind.FIELD,
             alias: { kind: Kind.NAME, value: 'field' },
-            name: { kind: Kind.NAME, value: '__field' },
+            name: { kind: Kind.NAME, value: '__type' },
             arguments: [
               {
                 kind: Kind.ARGUMENT,
@@ -319,15 +319,13 @@ const _makeSchemaFullTypeFragment = (support: SupportedFeatures): FragmentDefini
       {
         kind: Kind.FIELD,
         name: { kind: Kind.NAME, value: 'fields' },
-        arguments: support.supportsFieldIsDeprecatedArgument
-          ? [
-              {
-                kind: Kind.ARGUMENT,
-                name: { kind: Kind.NAME, value: 'includeDeprecated' },
-                value: { kind: Kind.BOOLEAN, value: true },
-              },
-            ]
-          : undefined,
+        arguments: [
+          {
+            kind: Kind.ARGUMENT,
+            name: { kind: Kind.NAME, value: 'includeDeprecated' },
+            value: { kind: Kind.BOOLEAN, value: true },
+          },
+        ],
         selectionSet: {
           kind: Kind.SELECTION_SET,
           selections: [
@@ -347,7 +345,7 @@ const _makeSchemaFullTypeFragment = (support: SupportedFeatures): FragmentDefini
               kind: Kind.FIELD,
               name: { kind: Kind.NAME, value: 'deprecationReason' },
             },
-            _makeSchemaArgsField(support.inputValueDeprecation),
+            _makeSchemaArgsField(support.supportsFieldIsDeprecatedArgument),
             {
               kind: Kind.FIELD,
               name: { kind: Kind.NAME, value: 'type' },

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -18,6 +18,8 @@ const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: true,
   specifiedByURL: true,
   inputValueDeprecation: true,
+  supportsDirectiveIsDeprecatedArgument: true,
+  supportsFieldIsDeprecatedArgument: true,
 };
 
 export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -18,8 +18,8 @@ const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: true,
   specifiedByURL: true,
   inputValueDeprecation: true,
-  supportsDirectiveIsDeprecatedArgument: true,
-  supportsFieldIsDeprecatedArgument: true,
+  directiveArgumentsIsDeprecated: true,
+  fieldArgumentsIsDeprecated: true,
 };
 
 export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -18,12 +18,16 @@ const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: true,
   specifiedByURL: true,
   inputValueDeprecation: true,
+  supportsDirectiveIsDeprecatedArgument: true,
+  supportsFieldIsDeprecatedArgument: true,
 };
 
 const NO_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: false,
   specifiedByURL: false,
   inputValueDeprecation: false,
+  supportsDirectiveIsDeprecatedArgument: false,
+  supportsFieldIsDeprecatedArgument: false,
 };
 
 export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -18,16 +18,16 @@ const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: true,
   specifiedByURL: true,
   inputValueDeprecation: true,
-  supportsDirectiveIsDeprecatedArgument: true,
-  supportsFieldIsDeprecatedArgument: true,
+  directiveArgumentsIsDeprecated: true,
+  fieldArgumentsIsDeprecated: true,
 };
 
 const NO_SUPPORTED_FEATURES: SupportedFeatures = {
   directiveIsRepeatable: false,
   specifiedByURL: false,
   inputValueDeprecation: false,
-  supportsDirectiveIsDeprecatedArgument: false,
-  supportsFieldIsDeprecatedArgument: false,
+  directiveArgumentsIsDeprecated: false,
+  fieldArgumentsIsDeprecated: false,
 };
 
 export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {


### PR DESCRIPTION
Resolves #189 

## Summary

In the October 2021 spec `__Field.args` and `__Directive.args` aren't explicitly said to support `includeDeprecated: Boolean` as an argument.

https://spec.graphql.org/October2021/#sec-The-__Field-Type
https://spec.graphql.org/October2021/#sec-The-__Directive-Type

vs

https://spec.graphql.org/draft/#sec-The-__Field-Type
https://spec.graphql.org/draft/#sec-The-__Directive-Type