### PR TITLE
fix(cli-utils): Fix `undefined` symbol crash and output bug in `turbo` command

### DIFF
--- a/.changeset/light-files-travel.md
+++ b/.changeset/light-files-travel.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Fix crash in `generate turbo` command when `returnType.symbol` is undefined

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -84,7 +84,8 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
       }
 
       cache = Object.assign(cache, signal.cache);
-      if ((warnings += signal.warnings.length)) {
+      warnings += signal.warnings.length;
+      if (signal.warnings.length) {
         let buffer = logger.warningFile(signal.filePath);
         for (const warning of signal.warnings) {
           buffer += logger.warningMessage(warning);

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -43,7 +43,9 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
     for (const call of calls) {
       const returnType = checker.getTypeAtLocation(call);
       const argumentType = checker.getTypeAtLocation(call.arguments[0]);
-      if (returnType.symbol.getEscapedName() !== 'TadaDocumentNode') {
+      // NOTE: `returnType.symbol` is incorrectly typed and is in fact
+      // optional and not always present
+      if (!returnType.symbol || returnType.symbol.getEscapedName() !== 'TadaDocumentNode') {
         const position = getFilePosition(sourceFile, call.getStart());
         warnings.push({
           message:


### PR DESCRIPTION
## Set of changes

- Fix crash when `returnType.symbol` is undefined
- Fix output logging all file names when warnings have been discovered in other files
