### PR TITLE
feat(cli-utils): Expose generate commands as exported functions (Re-add)

### DIFF
--- a/.changeset/lazy-seas-hunt.md
+++ b/.changeset/lazy-seas-hunt.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Expose internal generate commands as functions exported by `@gql.tada/cli-utils` (restoring prior functionality)

--- a/packages/cli-utils/src/api.ts
+++ b/packages/cli-utils/src/api.ts
@@ -1,0 +1,4 @@
+export { generateOutput } from './commands/generate-output';
+export { generatePersisted } from './commands/generate-persisted';
+export { generateSchema } from './commands/generate-schema';
+export { generateTurbo } from './commands/turbo';

--- a/packages/cli-utils/src/commands/generate-output/index.ts
+++ b/packages/cli-utils/src/commands/generate-output/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from 'clipanion';
 
+import type { Options } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -30,5 +31,13 @@ export class GenerateOutputCommand extends Command {
       })
     );
     return process.exitCode || (typeof result === 'object' ? result.exit : 0);
+  }
+}
+
+export async function generateOutput(opts: Options): Promise<void> {
+  const tty = initTTY({ disableTTY: true });
+  const result = await tty.start(run(tty, opts));
+  if (result instanceof Error) {
+    throw result;
   }
 }

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -15,7 +15,7 @@ import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
 import * as logger from './logger';
 
-interface Options {
+export interface Options {
   disablePreprocessing: boolean;
   output: string | undefined;
   tsconfig: string | undefined;

--- a/packages/cli-utils/src/commands/generate-persisted/index.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from 'clipanion';
 
+import type { Options } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -30,5 +31,13 @@ export class GeneratePersisted extends Command {
       })
     );
     return process.exitCode || (typeof result === 'object' ? result.exit : 0);
+  }
+}
+
+export async function generatePersisted(opts: Options) {
+  const tty = initTTY({ disableTTY: true });
+  const result = await tty.start(run(tty, opts));
+  if (result instanceof Error) {
+    throw result;
   }
 }

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -8,7 +8,7 @@ import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
 import * as logger from './logger';
 
-interface Options {
+export interface Options {
   tsconfig: string | undefined;
   output: string | undefined;
   failOnWarn: boolean;

--- a/packages/cli-utils/src/commands/generate-schema/index.ts
+++ b/packages/cli-utils/src/commands/generate-schema/index.ts
@@ -1,6 +1,7 @@
 import * as t from 'typanion';
 import { Command, Option } from 'clipanion';
 
+import type { Options } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -53,5 +54,13 @@ export class GenerateSchema extends Command {
       })
     );
     return process.exitCode || (typeof result === 'object' ? result.exit : 0);
+  }
+}
+
+export async function generateSchema(opts: Options) {
+  const tty = initTTY({ disableTTY: true });
+  const result = await tty.start(run(tty, opts));
+  if (result instanceof Error) {
+    throw result;
   }
 }

--- a/packages/cli-utils/src/commands/generate-schema/runner.ts
+++ b/packages/cli-utils/src/commands/generate-schema/runner.ts
@@ -9,7 +9,7 @@ import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
 import * as logger from './logger';
 
-interface Options {
+export interface Options {
   input: string;
   headers: Record<string, string> | undefined;
   output: string | undefined;

--- a/packages/cli-utils/src/commands/turbo/index.ts
+++ b/packages/cli-utils/src/commands/turbo/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from 'clipanion';
 
+import type { Options } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -30,5 +31,13 @@ export class TurboCommand extends Command {
       })
     );
     return process.exitCode || (typeof result === 'object' ? result.exit : 0);
+  }
+}
+
+export async function generateTurbo(opts: Options) {
+  const tty = initTTY({ disableTTY: true });
+  const result = await tty.start(run(tty, opts));
+  if (result instanceof Error) {
+    throw result;
   }
 }

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -10,7 +10,7 @@ import * as logger from './logger';
 
 const PREAMBLE_IGNORE = ['/* eslint-disable */', '/* prettier-ignore */'].join('\n') + '\n';
 
-interface Options {
+export interface Options {
   failOnWarn: boolean;
   tsconfig: string | undefined;
   output: string | undefined;

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -1,4 +1,5 @@
 import { Cli } from 'clipanion';
+import * as api from './api';
 
 import { CheckCommand } from './commands/check/index';
 import { DoctorCommand } from './commands/doctor/index';
@@ -8,7 +9,7 @@ import { GenerateSchema } from './commands/generate-schema/index';
 import { InitCommand } from './commands/init/index';
 import { TurboCommand } from './commands/turbo/index';
 
-function main() {
+async function _main() {
   const cli = new Cli({
     binaryVersion: process.env.npm_package_version || '0.0.0',
     binaryLabel: 'gql.tada CLI',
@@ -23,7 +24,11 @@ function main() {
   cli.register(InitCommand);
   cli.register(TurboCommand);
 
-  cli.runExit(process.argv.slice(2));
+  await cli.runExit(process.argv.slice(2));
 }
 
+type MainFn = typeof _main & typeof api;
+const main = Object.assign(_main, api) as MainFn;
+
+export * from './api';
 export default main;


### PR DESCRIPTION
Resolves #134

## Summary

This exposes all `generate` commands as functions exported by `@gql.tada/cli-utils`, which restores a prior feature as per the linked issue.
