### PR TITLE
fix(cli-utils): Fix `turbo` command reusing its own prior cache output

### DIFF
--- a/.changeset/cool-dolphins-clean.md
+++ b/.changeset/cool-dolphins-clean.md
@@ -1,0 +1,6 @@
+---
+"gql.tada": patch
+"@gql.tada/cli-utils": patch
+---
+
+Fix `turbo` command reusing previously cached turbo typings. Instead, we now set a flag to disable the cache temporarily inside the command.

--- a/src/api.ts
+++ b/src/api.ts
@@ -85,6 +85,7 @@ interface setupSchema extends AbstractSetupSchema {
 }
 
 interface AbstractSetupCache {
+  readonly __cacheDisabled: unknown;
   [key: string]: unknown;
 }
 
@@ -134,7 +135,14 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
     input: In,
     fragments?: Fragments
   ): setupCache[In] extends DocumentNodeLike
-    ? setupCache[In]
+    ? unknown extends setupCache['__cacheDisabled']
+      ? setupCache[In]
+      : getDocumentNode<
+          parseDocument<In>,
+          Schema,
+          getFragmentsOfDocuments<Fragments>,
+          Config['isMaskingDisabled']
+        >
     : getDocumentNode<
         parseDocument<In>,
         Schema,


### PR DESCRIPTION
## Summary

Fixes a regression; the turbo command can accidentally reuse its own cache if we don't disable the cache or remove the cached typings file.

Instead of removing the file or discovering and shadowing it, we now add a global flag to disable the cache entirely while inferring the turbo cache.

## Set of changes

- Add `__disableCache` flag to turbo cache
- Add virtual declaration file to declare `__disableCache: true` during `turbo` command