### PR TITLE
fix(cli-utils): Fix hash parsing in `generate-persisted`

### DIFF
--- a/.changeset/friendly-buses-sniff.md
+++ b/.changeset/friendly-buses-sniff.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Fix hash parsing in `generate-persisted` command

--- a/packages/cli-utils/src/commands/generate-persisted/thread.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/thread.ts
@@ -124,7 +124,7 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
 
       let document = operation;
       for (const fragment of fragments) document += '\n\n' + print(fragment);
-      documents[JSON.parse(hashArg.getFullText())] = document;
+      documents[hashArg.getText().slice(1, -1)] = document;
     }
 
     yield {


### PR DESCRIPTION
Resolve #211

## Summary

Fix incompatible slicing of hash argument with how it's done in GraphQLSP.
This is a regression and I ported this incorrectly.

## Set of changes

- Replace `JSON.parse` with `slice` in `generate-persisted`
