### PR TITLE
fix(internal, cli-utils): Remove `null` cases from schema loaders, simplifying error handling

### DIFF
--- a/.changeset/soft-clouds-cough.md
+++ b/.changeset/soft-clouds-cough.md
@@ -1,0 +1,6 @@
+---
+"@gql.tada/cli-utils": patch
+"@gql.tada/internal": patch
+---
+
+Remove `null` cases from schema loaders, simplifying error handling in the CLI.

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -169,14 +169,10 @@ export async function* run(): AsyncIterable<ComposeInput> {
     rootPath: path.dirname(configResult.configPath),
   });
 
-  let hasSchema = false;
   try {
-    hasSchema = !!(await loader.loadIntrospection());
+    await loader.loadIntrospection();
   } catch (error) {
     throw logger.externalError('Failed to load schema.', error);
-  }
-  if (!hasSchema) {
-    throw logger.errorMessage('Failed to load schema.');
   }
 
   yield logger.completedTask(Messages.CHECK_SCHEMA, true);

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -37,15 +37,12 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
     rootPath: path.dirname(configResult.configPath),
   });
 
-  let introspection: IntrospectionQuery | null;
+  let introspection: IntrospectionQuery;
   try {
-    introspection = await loader.loadIntrospection();
+    const loadResult = await loader.load();
+    introspection = loadResult.introspection;
   } catch (error) {
     throw logger.externalError('Failed to load introspection.', error);
-  }
-
-  if (!introspection) {
-    throw logger.errorMessage('Failed to load introspection.');
   }
 
   let contents: string;

--- a/packages/cli-utils/src/commands/generate-schema/runner.ts
+++ b/packages/cli-utils/src/commands/generate-schema/runner.ts
@@ -20,15 +20,12 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
   const origin = opts.headers ? { url: opts.input, headers: opts.headers } : opts.input;
   const loader = load({ rootPath: process.cwd(), origin });
 
-  let schema: GraphQLSchema | null;
+  let schema: GraphQLSchema;
   try {
-    schema = await loader.loadSchema();
+    const loadResult = await loader.load();
+    schema = loadResult.schema;
   } catch (error) {
     throw logger.externalError('Failed to load schema.', error);
-  }
-
-  if (!schema) {
-    throw logger.errorMessage('Failed to load schema.');
   }
 
   let destination: WriteTarget;

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -8,7 +8,7 @@ export interface SchemaLoaderResult {
 export type OnSchemaUpdate = (result: SchemaLoaderResult) => void;
 
 export interface SchemaLoader {
-  load(reload?: boolean): Promise<SchemaLoaderResult | null>;
+  load(reload?: boolean): Promise<SchemaLoaderResult>;
   notifyOnUpdate(onUpdate: OnSchemaUpdate): () => void;
 
   /** @internal */

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -58,7 +58,7 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
     }
   };
 
-  const introspect = async (support: SupportedFeatures): Promise<typeof result> => {
+  const introspect = async (support: SupportedFeatures): Promise<SchemaLoaderResult> => {
     const query = makeIntrospectionQuery(support);
     const introspectionResult = await client.query<IntrospectionQuery>(query, {});
     try {
@@ -71,14 +71,17 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
           schema: buildClientSchema(introspection, { assumeValid: true }),
         };
       } else {
-        return null;
+        throw new Error(
+          'Executing introspection against API failed.\n' +
+            'The API failed to return any schema data or error.'
+        );
       }
     } finally {
       scheduleUpdate();
     }
   };
 
-  const load = async (): Promise<typeof result> => {
+  const load = async (): Promise<SchemaLoaderResult> => {
     if (!supportedFeatures) {
       const query = makeIntrospectSupportQuery();
       const supportResult = await client.query<IntrospectSupportQueryData>(query, {});


### PR DESCRIPTION
## Summary

When applied, this change removes `null` cases from the schema loaders and replaces them with appropriate errors. Instead of having to handle missing schemas separately, the CLI now receives errors for each case where we previously fell back to returning a `null` result.

## Set of changes

- Remove `null` cases from SDL loader
- Remove `null` case from URL loader
- Update types
- Update commands using schema loaders to remove `null` cases
