### PR TITLE
fix: Prevent `readFragment` from falling back to `any` return types

### DIFF
--- a/.changeset/tall-starfishes-hunt.md
+++ b/.changeset/tall-starfishes-hunt.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Fix `readFragment` falling back to `any` type when called with invalid data or invalid type.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -408,6 +408,18 @@ describe('readFragment', () => {
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 
+  it('falls back to unmasking to `never` with a missing generic', () => {
+    type fragment = parseDocument<`
+      fragment Fields on Todo {
+        id
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+    // @ts-expect-error
+    const _result = readFragment({} as FragmentOf<document>);
+  });
+
   it('should be callable on already unmasked fragments', () => {
     type fragment = parseDocument<`
       fragment Fields on Todo {

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -368,8 +368,7 @@ describe('readFragment', () => {
     type document = getDocumentNode<query, schema>;
     // @ts-expect-error
     const result = readFragment({} as document, {} as FragmentOf<document>);
-    // TODO: Ensure this is never
-    expectTypeOf<typeof result>().toBeAny();
+    expectTypeOf<typeof result>().toBeUnknown();
   });
 
   it('should not accept empty objects', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -485,31 +485,31 @@ type fragmentRefsOfFragmentsRec<
  *
  * @see {@link readFragment} for how to read from fragment masks.
  */
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: resultOrFragmentOf<Document>
 ): ResultOf<Document>;
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: resultOrFragmentOf<Document> | null
 ): ResultOf<Document> | null;
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: resultOrFragmentOf<Document> | undefined
 ): ResultOf<Document> | undefined;
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: resultOrFragmentOf<Document> | null | undefined
 ): ResultOf<Document> | null | undefined;
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: readonly resultOrFragmentOf<Document>[]
 ): readonly ResultOf<Document>[];
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: readonly (resultOrFragmentOf<Document> | null)[]
 ): readonly (ResultOf<Document> | null)[];
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: readonly (resultOrFragmentOf<Document> | undefined)[]
 ): readonly (ResultOf<Document> | undefined)[];
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   fragment: readonly (resultOrFragmentOf<Document> | null | undefined)[]
 ): readonly (ResultOf<Document> | null | undefined)[];
-function readFragment<const Document extends FragmentShape>(
+function readFragment<const Document extends FragmentShape = never>(
   _document: Document,
   fragment: resultOrFragmentOf<Document>
 ): ResultOf<Document>;

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -113,7 +113,7 @@ interface DefinitionDecoration<Definition = FragmentDefDecorationLike> {
 
 interface FragmentShape<
   Definition extends FragmentDefDecorationLike = FragmentDefDecorationLike,
-  Result = any,
+  Result = unknown,
 > extends DocumentDecoration<Result>,
     DefinitionDecoration<Definition> {}
 


### PR DESCRIPTION
Resolves #215

## Summary

This prevents `readFragment(data)` from falling back to `any` as a return type when no generic was passed. It also prevents `readFragment(document, data)` to evaluate to `any` when an invalid document is passed. This already errored previously on the `document` argument, but now also prevents `any` from being returned.

## Set of changes

- Prevent `readFragment<DocumentType>(data)` from evaluating to `any` when `DocumentType` is left out
- Prevent `readFragment(document, data)` from evaluating to `any`, instead falling back to `unknown` on invalid inputs