### PR TITLE
fix: gql.tada generate --output *.ts was outputting .d.ts

### DIFF
--- a/.changeset/silent-apes-shop.md
+++ b/.changeset/silent-apes-shop.md
@@ -1,5 +1,5 @@
 ---
-"@gql.tada/internal": patch
+"@gql.tada/cli-utils": patch
 ---
 
-Fix CLI outputting .d.ts when .ts input file specified
+Fix `generate-output` command outputting the `.d.ts` format when `.ts` extension was specified instead

--- a/.changeset/silent-apes-shop.md
+++ b/.changeset/silent-apes-shop.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Fix CLI outputting .d.ts when .ts input file specified

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -48,7 +48,7 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
   let contents: string;
   try {
     contents = outputIntrospectionFile(minifyIntrospection(introspection), {
-      fileType: pluginConfig.tadaOutputLocation || '.d.ts',
+      fileType: opts.output || pluginConfig.tadaOutputLocation || '.d.ts',
       shouldPreprocess: !opts.disablePreprocessing,
     });
   } catch (error) {


### PR DESCRIPTION
If you use `gql.tada generate --output introspection.ts` and there is no tadaOutputLocation in tsconfig.json, .d.ts contents will be output into a .ts file. Then initGraphQLTada will fail.