### PR TITLE
fix(cli-utils): Add missing `--force-ts-format` option to `generate-output`

### DIFF
--- a/.changeset/friendly-brooms-glow.md
+++ b/.changeset/friendly-brooms-glow.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Add missing argument to `generate-output` command to force output the `.ts` format instead.

--- a/packages/cli-utils/src/commands/generate-output/index.ts
+++ b/packages/cli-utils/src/commands/generate-output/index.ts
@@ -7,6 +7,11 @@ import { run } from './runner';
 export class GenerateOutputCommand extends Command {
   static paths = [['generate-output'], ['generate', 'output']];
 
+  forceTSFormat = Option.Boolean('--force-ts-format', false, {
+    description: 'Forces the `.ts` output format when the output is piped',
+    hidden: true,
+  });
+
   disablePreprocessing = Option.Boolean('--disable-preprocessing', false, {
     description:
       'Disables pre-processing, which is an internal introspection format generated ahead of time',
@@ -25,6 +30,7 @@ export class GenerateOutputCommand extends Command {
     const tty = initTTY();
     const result = await tty.start(
       run(tty, {
+        forceTSFormat: this.forceTSFormat,
         disablePreprocessing: this.disablePreprocessing,
         output: this.output,
         tsconfig: this.tsconfig,

--- a/packages/cli-utils/src/commands/generate-output/logger.ts
+++ b/packages/cli-utils/src/commands/generate-output/logger.ts
@@ -1,10 +1,18 @@
 import * as t from '../../term';
 
+import { hint, code } from '../shared/logger';
 export * from '../shared/logger';
 
-export function summary() {
-  return t.text([
+export function summary(showHint?: boolean) {
+  let out = t.text([
     t.cmd(t.CSI.Style, t.Style.BrightGreen),
     `${t.Icons.Tick} Introspection output was generated successfully\n`,
   ]);
+  if (showHint) {
+    out += hint(
+      `The pipe output was generated in the ${code('.d.ts')} format.\n` +
+        `For the ${code('.ts')} format, pass the ${code('--force-ts-format')} argument.\n`
+    );
+  }
+  return out;
 }

--- a/packages/cli-utils/src/commands/shared/logger.ts
+++ b/packages/cli-utils/src/commands/shared/logger.ts
@@ -2,7 +2,11 @@ import * as t from '../../term';
 
 export function indent(text: string, indent: string) {
   if (text.includes('\n')) {
-    return text.split('\n').join(t.text([t.Chars.Newline, indent]));
+    const out = text
+      .trim()
+      .split('\n')
+      .join(t.text([t.Chars.Newline, indent]));
+    return text.endsWith('\n') ? out + '\n' : out;
   } else {
     return text;
   }


### PR DESCRIPTION
Follow-up to #225

This adds a hidden `--force-ts-format` option that a hint in the terminal mentions if the output is piped to reactive the `.ts` format for the piped output. Otherwise the `d.ts` output is the default.

This also reorders when the file is generated to prevent future mistakes, like the one in #225. For instance, after that PR the piped output would default to whatever the format of `tadaOutputLocation` is, which is unexpected.