### PR TITLE
patch(cli-utils): Add VSCode detection and warnings

### DIFF
--- a/.changeset/selfish-houses-impress.md
+++ b/.changeset/selfish-houses-impress.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Add checks for VSCode extensions to `doctor` command. The command now outputs a warning if the GraphQL syntax plugin is missing or if the GraphQL Language service is installed and misconfigured.

--- a/packages/cli-utils/src/commands/doctor/helpers/fs.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/fs.ts
@@ -1,0 +1,19 @@
+import * as fs from 'node:fs/promises';
+
+export const enum FileType {
+  File,
+  Directory,
+}
+
+export const stat = async (file: string, type = FileType.File): Promise<boolean> =>
+  await fs
+    .stat(file)
+    .then((stat) => {
+      switch (type) {
+        case FileType.File:
+          return stat.isFile();
+        case FileType.Directory:
+          return stat.isDirectory();
+      }
+    })
+    .catch(() => false);

--- a/packages/cli-utils/src/commands/doctor/helpers/graphqlConfig.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/graphqlConfig.ts
@@ -1,0 +1,26 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { stat, FileType } from './fs';
+
+const configFileRe = /^(?:graphql\.config|\.graphqlrc)\.(?:cjs|[jt]s|json|toml|ya?ml)$/i;
+
+/** Loads list of suggested in-repo VSCode extensions */
+export const findGraphQLConfig = async (targetPath?: string): Promise<string | null> => {
+  let target = targetPath || process.cwd();
+  const rootPath = path.resolve(target, '/');
+  while (target !== rootPath) {
+    let dir: readonly string[] = [];
+    try {
+      dir = await fs.readdir(target);
+    } catch (_error) {}
+    const configFile = dir.find((item) => configFileRe.test(item));
+    if (configFile) return configFile;
+    if (await stat(path.resolve(target, '.git'), FileType.Directory)) {
+      break;
+    } else if (await stat(path.resolve(target, '.vscode'), FileType.Directory)) {
+      break;
+    }
+    target = path.resolve(target, '..');
+  }
+  return null;
+};

--- a/packages/cli-utils/src/commands/doctor/helpers/vscode.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/vscode.ts
@@ -1,0 +1,73 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { parseJsonText, convertToObject } from 'typescript';
+import { stat, FileType } from './fs';
+
+const jsonParse = async (fileName: string): Promise<unknown> => {
+  const contents = await fs.readFile(fileName, 'utf8');
+  const sourceFile = parseJsonText(fileName, contents);
+  return convertToObject(sourceFile, []);
+};
+
+export const isVSCodeInstalled = async (): Promise<boolean> => {
+  if (!process.env.HOME) return false;
+  const vscodeFolder = path.resolve(process.env.HOME, '.vscode');
+  return !!(await stat(vscodeFolder, FileType.Directory));
+};
+
+/** Loads list of suggested in-repo VSCode extensions */
+export const loadSuggestedExtensionsList = async (
+  targetPath?: string
+): Promise<readonly string[]> => {
+  let target = targetPath || process.cwd();
+  const rootPath = path.resolve(target, '/');
+  while (target !== rootPath) {
+    if (await stat(path.resolve(target, '.git'), FileType.Directory)) {
+      break;
+    } else if (await stat(path.resolve(target, '.vscode'), FileType.Directory)) {
+      break;
+    }
+    target = path.resolve(target, '..');
+  }
+  const configFile = path.resolve(target, '.vscode', 'extensions.json');
+  if (!(await stat(configFile))) return [];
+  let json: unknown;
+  try {
+    json = await jsonParse(configFile);
+  } catch (_error) {
+    return [];
+  }
+  if (json && typeof json === 'object' && 'recommendations' in json) {
+    return Array.isArray(json.recommendations)
+      ? json.recommendations
+          .filter((x): x is string => x && typeof x === 'string')
+          .map((x) => `${x}`.toLowerCase())
+      : [];
+  } else {
+    return [];
+  }
+};
+
+/** Loads list of installed VSCode extensions */
+export const loadExtensionsList = async (): Promise<readonly string[]> => {
+  if (!process.env.HOME) return [];
+  const vscodeFolder = path.resolve(process.env.HOME, '.vscode');
+  const configFile = path.resolve(vscodeFolder, 'extensions', 'extensions.json');
+  if (!(await stat(configFile))) return [];
+  let json: unknown;
+  try {
+    json = await jsonParse(configFile);
+  } catch (_error) {
+    return [];
+  }
+  return (Array.isArray(json) ? json : [])
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object' || !('identifier' in entry)) return null;
+      if (!entry.identifier || typeof entry.identifier !== 'object' || !('id' in entry.identifier))
+        return null;
+      return entry.identifier.id && typeof entry.identifier.id === 'string'
+        ? `${entry.identifier.id}`.toLowerCase()
+        : null;
+    })
+    .filter((x): x is string => !!x);
+};

--- a/packages/cli-utils/src/commands/doctor/helpers/workspaceRoot.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/workspaceRoot.ts
@@ -1,0 +1,28 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { stat, FileType } from './fs';
+
+export const findWorkspaceRoot = async (targetPath?: string): Promise<string | null> => {
+  let target = targetPath || process.cwd();
+  const rootPath = path.resolve(target, '/');
+  while (target !== rootPath) {
+    if (await stat(path.resolve(target, '.git'), FileType.Directory)) {
+      return target;
+    } else if (await stat(path.resolve(target, '.vscode'), FileType.Directory)) {
+      return target;
+    } else if (await stat(path.resolve(target, 'pnpm-workspace.yml'))) {
+      return target;
+    }
+    const packageJsonPath = path.resolve(target, 'package.json');
+    if (await stat(packageJsonPath)) {
+      try {
+        const meta = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+        if (meta && typeof meta === 'object' && Array.isArray(meta.workspaces)) {
+          return target;
+        }
+      } catch (_error) {}
+    }
+    target = path.resolve(target, '..');
+  }
+  return null;
+};

--- a/packages/cli-utils/src/commands/doctor/logger.ts
+++ b/packages/cli-utils/src/commands/doctor/logger.ts
@@ -1,6 +1,7 @@
 import { pipe, interval, map } from 'wonka';
 
 import * as t from '../../term';
+import { indent } from '../shared/logger';
 
 export * from '../shared/logger';
 
@@ -63,6 +64,39 @@ export function failedTask(description: string) {
     t.cmd(t.CSI.Style, t.Style.Foreground),
     description,
     '\n',
+  ]);
+}
+
+export function warningTask(description: string) {
+  return t.text([
+    emptyLine(),
+    t.cmd(t.CSI.Style, t.Style.BrightBlack),
+    t.HeavyBox.VerticalRight,
+    ' ',
+    t.cmd(t.CSI.Style, t.Style.BrightYellow),
+    t.Icons.Warning,
+    ' ',
+    t.cmd(t.CSI.Style, t.Style.Foreground),
+    description,
+    '\n',
+  ]);
+}
+
+export function hintMessage(text: string) {
+  return t.text([
+    t.cmd(t.CSI.Style, t.Style.BrightBlack),
+    `${t.HeavyBox.VerticalRight} `,
+    t.cmd(t.CSI.Style, t.Style.BrightBlue),
+    `${t.Icons.Info} `,
+    t.cmd(t.CSI.Style, t.Style.Blue),
+    indent(
+      text,
+      t.text([
+        t.cmd(t.CSI.Style, t.Style.BrightBlack),
+        `${t.HeavyBox.Vertical} `,
+        t.cmd(t.CSI.Style, t.Style.Blue),
+      ])
+    ),
   ]);
 }
 

--- a/packages/cli-utils/src/commands/doctor/logger.ts
+++ b/packages/cli-utils/src/commands/doctor/logger.ts
@@ -93,7 +93,7 @@ export function hintMessage(text: string) {
       text,
       t.text([
         t.cmd(t.CSI.Style, t.Style.BrightBlack),
-        `${t.HeavyBox.Vertical} `,
+        `${t.HeavyBox.Vertical}   `,
         t.cmd(t.CSI.Style, t.Style.Blue),
       ])
     ),


### PR DESCRIPTION
Resolves #194

## Summary

This PR adds an addition to the `doctor` command that attempts to detect VSCode extensions.

When VSCode is installed and the GraphQL Syntax extension for it isn't installed, a warning is issued with a link to the extension.

When the suggested extensions file or the installed extensions contain the VSCode GraphQL Language Service extension and a GraphQL Config is present a warning is issued to prompt the user to check whether `documents` is targeting their files correctly.

This doesn't actually use `graphql-config` to validate the config, since that's quite a huge package for what it does (large dependency to handle TS & ESM files). So, unless we really need that, or want to just load the module from the user `node_modules`, I'd say this should be good enough.

<img width="684" alt="Screenshot 2024-04-18 at 16 04 04" src="https://github.com/0no-co/gql.tada/assets/2041385/cae1225c-103d-4216-807c-7f193b7abfdb">

## Set of changes

- Add check to `doctor` for VSCode syntax extension
- Add check to `doctor` for VSCode language service extension