### PR TITLE
docs: Add missing sections and increase readability

### DIFF
--- a/packages/cli-utils/src/commands/generate-output/index.ts
+++ b/packages/cli-utils/src/commands/generate-output/index.ts
@@ -1,6 +1,6 @@
 import { Command, Option } from 'clipanion';
 
-import type { Options } from './runner';
+import type { OutputOptions } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -40,7 +40,15 @@ export class GenerateOutputCommand extends Command {
   }
 }
 
-export async function generateOutput(opts: Options): Promise<void> {
+/** Outputs the `gql.tada` output file manually.
+ *
+ * @remarks
+ * Loads the schema from the specified `schema` configuration option and writes the output file
+ * to the specified output location.
+ *
+ * @see {@link https://gql-tada.0no.co/reference/gql-tada-cli#generateoutput}
+ */
+export async function generateOutput(opts: OutputOptions): Promise<void> {
   const tty = initTTY({ disableTTY: true });
   const result = await tty.start(run(tty, opts));
   if (result instanceof Error) {

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -15,14 +15,22 @@ import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
 import * as logger from './logger';
 
-export interface Options {
+export interface OutputOptions {
+  /** Whether to output the `.ts` format when the CLI's standard output is piped to an output file.
+   * @defaultValue `false` */
   forceTSFormat?: boolean;
+  /** Whether to disable the optimized output format for `.d.ts` files.
+   * @defaultValue `false` */
   disablePreprocessing: boolean;
+  /** The filename to write the cache file to.
+   * @defaultValue The `tadaTurboLocation` configuration option */
   output: string | undefined;
+  /** The `tsconfig.json` to use for configurations and the TypeScript program.
+   * @defaultValue A `tsconfig.json` in the current or any parent directory. */
   tsconfig: string | undefined;
 }
 
-export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput> {
+export async function* run(tty: TTY, opts: OutputOptions): AsyncIterable<ComposeInput> {
   let configResult: LoadConfigResult;
   let pluginConfig: GraphQLSPConfig;
   try {

--- a/packages/cli-utils/src/commands/generate-persisted/index.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/index.ts
@@ -1,6 +1,6 @@
 import { Command, Option } from 'clipanion';
 
-import type { Options } from './runner';
+import type { PersistedOptions } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -34,7 +34,15 @@ export class GeneratePersisted extends Command {
   }
 }
 
-export async function generatePersisted(opts: Options) {
+/** Generates a JSON manifest file of all `graphql.persisted()` documents.
+ *
+ * @remarks
+ * Scans your code for `graphql.persisted()` calls and generates a JSON
+ * manifest file containing a mapping of document IDs to the GraphQL document strings.
+ *
+ * @see {@link https://gql-tada.0no.co/reference/gql-tada-cli#generatepersisted}
+ */
+export async function generatePersisted(opts: PersistedOptions) {
   const tty = initTTY({ disableTTY: true });
   const result = await tty.start(run(tty, opts));
   if (result instanceof Error) {

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -8,13 +8,18 @@ import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
 import * as logger from './logger';
 
-export interface Options {
+export interface PersistedOptions {
+  /** The `tsconfig.json` to use for configurations and the TypeScript program.
+   * @defaultValue A `tsconfig.json` in the current or any parent directory. */
   tsconfig: string | undefined;
+  /** The filename to write the persisted JSON manifest to.
+   * @defaultValue The `schema` configuration option */
   output: string | undefined;
+  /** Whether to fail instead of just logging a warning. */
   failOnWarn: boolean;
 }
 
-export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput> {
+export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<ComposeInput> {
   const { runPersisted } = await import('./thread');
 
   let configResult: LoadConfigResult;

--- a/packages/cli-utils/src/commands/generate-schema/index.ts
+++ b/packages/cli-utils/src/commands/generate-schema/index.ts
@@ -1,7 +1,7 @@
 import * as t from 'typanion';
 import { Command, Option } from 'clipanion';
 
-import type { Options } from './runner';
+import type { SchemaOptions } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -57,7 +57,15 @@ export class GenerateSchema extends Command {
   }
 }
 
-export async function generateSchema(opts: Options) {
+/** Generates a GraphQL SDL file from a given GraphQL API URL or schema file.
+ *
+ * @remarks
+ * Introspects a targeted GraphQL API by URL, a `.graphql` SDL or introspection
+ * JSON file, and outputs a `.graphql` SDL file.
+ *
+ * @see {@link https://gql-tada.0no.co/reference/gql-tada-cli#generateschema}
+ */
+export async function generateSchema(opts: SchemaOptions) {
   const tty = initTTY({ disableTTY: true });
   const result = await tty.start(run(tty, opts));
   if (result instanceof Error) {

--- a/packages/cli-utils/src/commands/generate-schema/runner.ts
+++ b/packages/cli-utils/src/commands/generate-schema/runner.ts
@@ -9,14 +9,20 @@ import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
 import * as logger from './logger';
 
-export interface Options {
+export interface SchemaOptions {
+  /** The filename to a `.graphql` SDL file, introspection JSON, or URL to a GraphQL API to introspect. */
   input: string;
+  /** Object of headers to send when introspection a GraphQL API. */
   headers: Record<string, string> | undefined;
+  /** The filename to write the GraphQL SDL file to.
+   * @defaultValue The `schema` configuration option */
   output: string | undefined;
+  /** The `tsconfig.json` to use for configurations and the TypeScript program.
+   * @defaultValue A `tsconfig.json` in the current or any parent directory. */
   tsconfig: string | undefined;
 }
 
-export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput> {
+export async function* run(tty: TTY, opts: SchemaOptions): AsyncIterable<ComposeInput> {
   const origin = opts.headers ? { url: opts.input, headers: opts.headers } : opts.input;
   const loader = load({ rootPath: process.cwd(), origin });
 

--- a/packages/cli-utils/src/commands/turbo/index.ts
+++ b/packages/cli-utils/src/commands/turbo/index.ts
@@ -1,6 +1,6 @@
 import { Command, Option } from 'clipanion';
 
-import type { Options } from './runner';
+import type { TurboOptions } from './runner';
 import { initTTY } from '../../term';
 import { run } from './runner';
 
@@ -34,7 +34,17 @@ export class TurboCommand extends Command {
   }
 }
 
-export async function generateTurbo(opts: Options) {
+/** Generates a cache typings file for all GraphQL document types ahead of time.
+ *
+ * @remarks
+ * The `generateTurbo()` function generates a cache for all GraphQL document types ahead of time.
+ * This cache speeds up type evaluation and is especially useful when it's checked into the
+ * repository after making changes to GraphQL documents, which speeds up all further type
+ * checks and evaluation.
+ *
+ * @see {@link https://gql-tada.0no.co/reference/gql-tada-cli#generateturbo}
+ */
+export async function generateTurbo(opts: TurboOptions) {
   const tty = initTTY({ disableTTY: true });
   const result = await tty.start(run(tty, opts));
   if (result instanceof Error) {

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -10,13 +10,18 @@ import * as logger from './logger';
 
 const PREAMBLE_IGNORE = ['/* eslint-disable */', '/* prettier-ignore */'].join('\n') + '\n';
 
-export interface Options {
+export interface TurboOptions {
+  /** Whether to fail instead of just logging a warning. */
   failOnWarn: boolean;
+  /** The `tsconfig.json` to use for configurations and the TypeScript program.
+   * @defaultValue A `tsconfig.json` in the current or any parent directory. */
   tsconfig: string | undefined;
+  /** The filename to write the cache file to.
+   * @defaultValue The `tadaTurboLocation` configuration option */
   output: string | undefined;
 }
 
-export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput> {
+export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeInput> {
   const { runTurbo } = await import('./thread');
 
   let configResult: LoadConfigResult;

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -423,7 +423,11 @@
 :root .VPContent .column {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-column-gap: 16px;
+  gap: 16px;
+}
+
+:root .VPContent .column > * {
+  margin: 0 !important;
 }
 
 @media (max-width: 768px) {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -190,7 +190,7 @@
   border: none;
 }
 
-:root .VPContent .vp-doc :where(:not(li, a, strong, em, del, span, input, code)) + :not(li, a, strong, em, del, span, input, code) {
+:root .VPContent .vp-doc :where(:not(li, a:not(.button), strong, em, del, span, input, code)) + :not(li, a, strong, em, del, span, input, code) {
   margin-top: 1.3rem;
 }
 
@@ -203,6 +203,10 @@
   color: var(--vp-c-white);
   line-height: 1.2;
   padding-top: 0;
+  border: none;
+}
+
+:root.dark .VPContent .vp-doc :is(h1, h2, h3, h4, h5) code {
   border: none;
 }
 
@@ -254,7 +258,11 @@
   }
 }
 
-:root .VPContent .vp-doc :where(h1, h2, h3, h4, h5) .header-anchor {
+:root .VPContent .vp-doc h1 .header-anchor {
+  display: none;
+}
+
+:root .VPContent .vp-doc :where(h2, h3, h4, h5) .header-anchor {
   display: none;
   font-weight: 400;
   color: var(--vp-c-gray-soft);
@@ -268,25 +276,30 @@
   }
 }
 
+:root .VPContent .vp-doc hr {
+  margin-top: 2.4rem;
+  margin-bottom: 2rem;
+}
+
 :root .VPContent .vp-doc h1 {
-  font-size: 2.625rem;
-  margin-bottom: 1.6rem;
+  font-size: 3rem;
+  margin-bottom: 3.4rem;
 }
 
 :root .VPContent .vp-doc h2 {
-  font-size: 2.1875rem;
+  font-size: 2.4rem;
 }
 
 :root .VPContent .vp-doc h3 {
-  font-size: 1.8125rem;
+  font-size: 1.62rem;
 }
 
 :root .VPContent .vp-doc h4 {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 }
 
 :root .VPContent .vp-doc h5 {
-  font-size: 1.125rem;
+  font-size: 1.12rem;
 }
 
 :root .VPContent .vp-doc ul {
@@ -354,6 +367,10 @@
   opacity: 0.78;
 }
 
+:root .VPContent :is(.VPButton, .button):not(.column > *) {
+  margin-top: 1.3rem;
+}
+
 :root .VPContent :is(.VPButton, .button).alt {
   background: none;
 }
@@ -398,7 +415,7 @@
 :root .VPContent :is(.VPButton, .button) :is(h1, h2, h3, h4, h5) {
   margin: 0;
   display: block;
-  line-height: 2.0;
+  line-height: 1.9;
   font-size: 19px;
   font-weight: 600;
 }
@@ -594,4 +611,8 @@
 :root .VPContent .sponsor-item > a {
   font-size: 1.4em;
   color: var(--vp-c-text-1);
+}
+
+:root .outline-marker {
+  margin-top: -0.45ch;
 }

--- a/website/get-started/writing-graphql.md
+++ b/website/get-started/writing-graphql.md
@@ -375,6 +375,260 @@ Meaning, while we can unmask and use the `PokemonFragment`’s data in the `Poke
 the `PokemonsListComponent` cannot access any of the data requirements defined by and meant for the
 `PokemonComponent`.
 
-<a href="/guides/fragment-colocation" class="button">
+<a href="../guides/fragment-colocation" class="button">
     Learn more about Fragment Colocation
 </a>
+
+## Scalars
+
+As we've seen in prior examples, when selection fields, `gql.tada` infers the type
+of fields from the given schema automatically. Fields will be nullable if the schema
+doesn't mark them as non-nullable. The default scalars will be typed by their
+[JSON serialization](https://spec.graphql.org/draft/#sec-JSON-Serialization)
+value.
+
+| Scalar | Type |
+| --| -- |
+| `String` | `string` |
+| `Boolean` | `boolean` |
+| `Int` | `number` |
+| `Float` | `number` |
+
+When customizing a scalar, the inferred value type of a field will change according
+to the type we pass in the `scalars` mapping type however, as seen in the
+["Customizing scalar types" section](./installation#customizing-scalar-types).
+
+:::code-group
+```ts twoslash [src/graphql.ts]
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from './graphql/graphql-env.d.ts';
+
+// ---cut-before---
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+// @annotate: The ID type now takes on a special type
+  scalars: {
+    ID: `${number}`;
+  };
+}>();
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+```
+:::
+
+Now, creating the `PokemonFragment` with our custom `graphql()` function,
+the `id` field changes to the specified `ID` type.
+
+::: code-group
+```tsx twoslash [components/Pokemon.tsx]
+// @filename: src/graphql.ts
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from '../graphql/graphql-env.d.ts';
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+  scalars: {
+    ID: `${number}`;
+  };
+}>();
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+// ---cut---
+// @filename: components/Pokemon.tsx
+// ---cut---
+import { graphql, readFragment, FragmentOf } from '../src/graphql';
+
+export const PokemonFragment = graphql(`
+  fragment Pokemon on Pokemon {
+    id
+    name
+  }
+`);
+
+interface Props {
+  data: FragmentOf<typeof PokemonFragment>;
+}
+
+export const PokemonComponent = ({ data }: Props) => {
+  const pokemon = readFragment(PokemonFragment, data);
+  return <li key={pokemon.id}>{pokemon.name}</li>;
+};
+```
+:::
+
+In this case, we've defined all `ID` types to instead use a more specific
+type to say that they're stringified numbers, to demonstrate how IDs are
+structured in this example API.
+
+### Reusing Scalar Types
+
+Scalar types are often reused in utility functions and it isn't
+always possible to [write a fragment](../guides/fragment-colocation)
+for all of our utility functions, as some of them may not be
+consuming more than a single scalar value.
+
+Following from our last code example, we'd like to now reuse
+the `ID` type in a small function that accepts the type and parses
+it further.
+
+To do this, we can use the [`graphql.scalar()` helper
+function](../reference/gql-tada-api#graphql-scalar) to retrieve
+the type of the scalar.
+
+::: code-group
+```tsx twoslash [utils/parseId.ts]
+// @filename: src/graphql.ts
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from '../graphql/graphql-env.d.ts';
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+  scalars: {
+    ID: `${number}`;
+  };
+}>();
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+// ---cut---
+// @filename: utils/parseId.ts
+// ---cut---
+import { graphql } from '../src/graphql';
+
+export type ID = ReturnType<typeof graphql.scalar<'ID'>>;
+
+export const parseId = (id: ID): number => {
+  return Number(id);
+};
+```
+:::
+
+In the above example, we've used `ReturnType<typeof graphql.scalar<'ID'>>`
+to retrieve the type of our scalar directly from our configuration.
+
+But `graphql.scalar` is also useful when we wish to repeat the type across
+the codebase instead. If we want to passively check that the GraphQL
+scalar type is compatible to a local type, we can also call `graphql.scalar()`
+directly and let TypeScript check for our value to be compatible with
+the configured type instead.
+
+::: code-group
+```tsx twoslash [utils/parseId.ts]
+// @filename: src/graphql.ts
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from '../graphql/graphql-env.d.ts';
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+  scalars: {
+    ID: `${number}`;
+  };
+}>();
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+// ---cut---
+// @filename: utils/parseId.ts
+// ---cut---
+import { graphql } from '../src/graphql';
+
+export type ID = `${number}`;
+
+export const parseId = (id: ID): number => {
+  const value = graphql.scalar('ID', id);
+  return Number(value);
+};
+```
+:::
+
+### Enum Types
+
+When `gql.tada` infers the type of an enum, the output type becomes
+a union of all possible literal values.
+
+<div class="column">
+
+```graphql
+enum PokemonType {
+  Bug
+  Dark
+  Dragon
+  # ...
+}
+```
+
+```ts
+type PokemonType =
+  | 'Bug'
+  | 'Dark'
+  | 'Dragon';
+  /* ...*/
+```
+
+</div>
+
+And similarly to scalars, we can retrieve the type of enums with the
+`graphql.scalar()` helper and reuse them.
+
+```tsx twoslash
+// @filename: src/graphql.ts
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from '../graphql/graphql-env.d.ts';
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+}>();
+// ---cut---
+// @filename: utils/pokemonType.ts
+// ---cut---
+import { graphql } from '../src/graphql';
+export type PokemonType = ReturnType<typeof graphql.scalar<'PokemonType'>>;
+
+export const isBugType = (input: 'Bug') => {
+  const pokemonType = graphql.scalar('PokemonType', input);
+  return input === 'Bug';
+};
+```
+
+Calling `graphql.scalar()` like in the above example also allows us to check
+a hardcoded subset of values against our scalar while implementing other
+utility functions.
+Since `graphql.scalar()` will enforce the second argument to be typed as
+the scalar itself, we can also use it to enforce compatibility of local
+types to GraphQL types.
+
+::: info TypeScript Enums
+Enum types can only be output as unions of string literals in `gql.tada`, but
+if you're migrating from a different code generator you may instead be using
+and importing generated TypeScript `enum`s or `const enum`s.
+
+You can still use your own values for enum types and configure them using the
+`scalars` option to replace their inferred values. But if you do this, `gql.tada`
+won't be able to keep them up-to-date for you.
+:::
+
+### Input Objects
+
+Lastly, the most complex types that `graphql.scalar()` can return for us
+are `input` types.
+
+```tsx twoslash
+// @filename: src/graphql.ts
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from '../graphql/graphql-env.d.ts';
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+}>();
+// ---cut---
+// @filename: utils/searchPokemon.ts
+// ---cut---
+import { graphql } from '../src/graphql';
+
+export type SearchPokemon = ReturnType<typeof graphql.scalar<'SearchPokemon'>>;
+```
+
+Reusing input types is common when we create local state that isn't immediately
+used as operation variables, or doesn't match the variables types of some operations.

--- a/website/get-started/writing-graphql.md
+++ b/website/get-started/writing-graphql.md
@@ -6,14 +6,20 @@ description: How to get set up and ready
 # Writing GraphQL
 
 In `gql.tada`, we write our GraphQL documents using the `graphql()`
-function.
+function and receive the result and variables types inferred from
+the document itself.
 
-> [!NOTE]
-> In the following examples, we’ll import `graphql()` from `gql.tada`.
-> However, if you’ve previously followed the steps on the “Installation” page
-> [to initialize `gql.tada` manually](./installation#initializing-gqltada-manually),
-> you’ll instead have to import your custom `graphql()` function, as
-> returned by `initGraphQLTada()`.
+In this section, we'll see what operation types look like, how
+we write fragments, and how to use scalar, enum, and input object
+types.
+
+::: info Imports
+Some code examples may import `graphql()` from `gql.tada`.
+However, if you’ve previously followed the steps on the “Installation” page
+[to initialize `gql.tada` manually](./installation#initializing-gqltada-manually),
+you’ll instead have to import your custom `graphql()` function, as
+returned by `initGraphQLTada()`.
+:::
 
 ## Queries
 

--- a/website/get-started/writing-graphql.md
+++ b/website/get-started/writing-graphql.md
@@ -119,6 +119,8 @@ returned by `graphql()`.
     Learn more about Typed Documents
 </a>
 
+---
+
 ## Fragments
 
 The `graphql()` function allows for fragment composition, which means we’re able to create

--- a/website/graphql/graphql-env.d.ts
+++ b/website/graphql/graphql-env.d.ts
@@ -17,6 +17,28 @@ export type introspection = {
     subscriptionType: null;
     types: [
       {
+        kind: 'INPUT_OBJECT';
+        name: 'SearchPokemon';
+        inputFields: [
+          {
+            name: 'name';
+            type: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          },
+          {
+            name: 'type';
+            type: {
+              kind: 'SCALAR';
+              name: 'PokemonType';
+              ofType: null;
+            };
+          },
+        ];
+      },
+      {
         kind: 'OBJECT';
         name: 'Attack';
         fields: [

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -103,6 +103,8 @@ const query = graphql(
 );
 ```
 
+---
+
 ### `graphql.scalar()`
 
 |                  | Description                                    |
@@ -170,6 +172,8 @@ function validateMediaEnum(value: 'Book' | 'Song' | 'Video') {
 
 type Media = ReturnType<typeof graphql.scalar<'Media'>>;
 ```
+
+---
 
 ### `graphql.persisted()`
 
@@ -263,6 +267,8 @@ const query = graphql(`
 const persistedOperation = graphql.persisted<typeof query>('sha256:x');
 ```
 
+---
+
 ### `readFragment()`
 
 |                               | Description                                                              |
@@ -293,7 +299,9 @@ since it's not used as a runtime value anyway:
 const unmaskedData = readFragment<typeof Fragment>(maskedData);
 ```
 
-[Read more about fragment masking on the “Writing GraphQL” page.](../get-started/writing-graphql#fragment-masking)
+<a href="../get-started/writing-graphql#fragment-masking" class="button">
+  Learn more about fragment masking
+</a>
 
 #### Example
 
@@ -331,6 +339,8 @@ const getQuery = (data: ResultOf<typeof pokemonQuery>) => {
   getPokemonItem(data.pokemon);
 };
 ```
+
+---
 
 ### `maskFragments()`
 
@@ -380,6 +390,8 @@ const data = maskFragments([pokemonItemFragment], {
   name: 'Bulbasaur',
 });
 ```
+
+---
 
 ### `unsafe_readResult()`
 
@@ -443,6 +455,8 @@ const data = unsafe_readResult(query, {
 });
 ```
 
+---
+
 ### `initGraphQLTada()`
 
 |                 | Description                                                           |
@@ -457,7 +471,10 @@ GraphQL schema.
 You should use and re-export the resulting function named as `graphql` or `gql` for your
 editor and the TypeScript language server to recognize your GraphQL documents correctly.
 
-[Read more about how to use `initGraphQLTada()` on the “Installation” page.](../get-started/installation#initializing-gqltada-manually)
+<a href="../get-started/installation#initializing-gqltada-manually" class="button">
+  <h4>Installation</h4>
+  <p>Learn how to use <code>initGraphQLTada()</code></p>
+</a>
 
 #### Example
 
@@ -491,6 +508,8 @@ const query = graphql(`
 This accepts a [`TadaDocumentNode`](#tadadocumentnode) and returns the attached `Result` type
 of GraphQL documents.
 
+---
+
 ### `VariablesOf`
 
 |                    | Description                                                        |
@@ -499,6 +518,8 @@ of GraphQL documents.
 
 This accepts a [`TadaDocumentNode`](#tadadocumentnode) and returns the attached `Variables` type
 of GraphQL documents.
+
+---
 
 ### `FragmentOf`
 
@@ -516,7 +537,9 @@ While [`readFragment()`](#readfragment) is used to unmask these fragment masks, 
 creates a fragment mask, so you can accept the masked data in the part of your
 codebase that defines a fragment.
 
-[Read more about fragment masking on the “Writing GraphQL” page.](../get-started/writing-graphql#fragment-masking)
+<a href="../get-started/writing-graphql#fragment-masking" class="button">
+  Learn more about fragment masking
+</a>
 
 #### Example
 
@@ -539,6 +562,8 @@ const getPokemonItem = (data: FragmentOf<typeof pokemonItemFragment>) => {
 };
 ```
 
+---
+
 ### `TadaDocumentNode`
 
 |                     | Description                                                                 |
@@ -553,6 +578,8 @@ This is used by GraphQL clients to infer the types of results and variables and 
 type-safety in GraphQL documents.
 
 You can create typed GraphQL documents using the [`graphql()` function.](#graphql)
+
+---
 
 ### `setupSchema`
 
@@ -584,6 +611,8 @@ declare module 'gql.tada' {
   }
 }
 ```
+
+---
 
 ### `AbstractSetupSchema`
 

--- a/website/reference/graphqlsp-config.md
+++ b/website/reference/graphqlsp-config.md
@@ -107,7 +107,14 @@ The `schema` option currently allows for three different formats to load a schem
 ```
 :::
 
-[Read more on how to configure the `schema` option, on the “Installation” page.](../get-started/installation#step-2-configuring-a-schema)
+<a href="../get-started/installation#step-2-configuring-a-schema" class="button">
+  <h4>Installation</h4>
+  <p>
+    Learn how to configure the <code>schema</code> option
+  </p>
+</a>
+
+---
 
 ### `tadaOutputLocation`
 
@@ -167,8 +174,6 @@ export const graphql = initGraphQLTada<{
 ```
 :::
 
-[Read more on how to configure the `tadaOutputLocation` option, on the “Installation” page.](../get-started/installation#step-3-configuring-typings)
-
 #### Format 2 — `.ts` file
 
 > [!WARNING]
@@ -197,7 +202,12 @@ Hence, with this format it’s required to import the introspection and to creat
 the [`initGraphQLTada<>()` function](./gql-tada-api#initgraphqltada). The introspection type won’t be set up project-wide, since the
 `.ts` output from `@0no-co/graphqlsp` doesn’t contain a `declare module` declaration.
 
-[Read more on how to configure the `tadaOutputLocation` option, on the “Installation” page.](../get-started/installation#initializing-gqltada-manually)
+<a href="../get-started/installation#initializing-gqltada-manually" class="button">
+  <h4>Installation</h4>
+  <p>
+    Learn how to configure the <code>tadaOutputLocation</code> option
+  </p>
+</a>
 
 ### `template`
 
@@ -233,6 +243,8 @@ if we wanted to name a function `parseGraphQL` instead, we may set the option to
 > custom tag functions with an inline `/* GraphQL */` comment.
 > However, this won’t work in every editor either!
 
+---
+
 ### `templateIsCallExpression`
 
 By default, this option is `true`.
@@ -244,6 +256,8 @@ template literals.
 >
 > TypeScript doesn’t currently support constant string literal types to be inferred
 > from tagged template literals. (See [`microsoft/typescript#49552`](https://github.com/microsoft/TypeScript/pull/49552))
+
+---
 
 ### `trackFieldUsage`
 


### PR DESCRIPTION
## Set of changes

- Add missing exports of `@gql.tada/cli-utils` to reference docs
- Increase readability of dense code examples
- Increase readability of headings and spacing
- Add TSDocs to `@gql.tada/cli-utils`
  - No changeset, since this isn't a relevant change for the library itself, but more for the hints in docs
- Add missing section to "Writing GraphQL" page on `graphql.scalar`
