### PR TITLE
feat(internal): Add support for `${configDir}` to directory path configs

### DIFF
--- a/.changeset/tame-beers-look.md
+++ b/.changeset/tame-beers-look.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Add support for `${configDir}` to directory path configs. When used in paths in our configuration, `${configDir}` will be substituted with the location of the main `tsconfig.json`

--- a/.changeset/twenty-students-hunt.md
+++ b/.changeset/twenty-students-hunt.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Add support for `${configDir}` to directory path configs.

--- a/packages/cli-utils/src/commands/check/runner.ts
+++ b/packages/cli-utils/src/commands/check/runner.ts
@@ -37,7 +37,7 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
   let pluginConfig: GraphQLSPConfig;
   try {
     configResult = await loadConfig(opts.tsconfig);
-    pluginConfig = parseConfig(configResult.pluginConfig);
+    pluginConfig = parseConfig(configResult.pluginConfig, configResult.rootPath);
   } catch (error) {
     throw logger.externalError('Failed to load configuration.', error);
   }

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -147,7 +147,7 @@ export async function* run(): AsyncIterable<ComposeInput> {
 
   let pluginConfig: GraphQLSPConfig;
   try {
-    pluginConfig = parseConfig(configResult.pluginConfig);
+    pluginConfig = parseConfig(configResult.pluginConfig, configResult.rootPath);
   } catch (error) {
     throw logger.externalError(
       `The plugin configuration for ${logger.code('"@0no-co/graphqlsp"')} seems to be invalid.`,

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -35,7 +35,7 @@ export async function* run(tty: TTY, opts: OutputOptions): AsyncIterable<Compose
   let pluginConfig: GraphQLSPConfig;
   try {
     configResult = await loadConfig(opts.tsconfig);
-    pluginConfig = parseConfig(configResult.pluginConfig);
+    pluginConfig = parseConfig(configResult.pluginConfig, configResult.rootPath);
   } catch (error) {
     throw logger.externalError('Failed to load configuration.', error);
   }

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -26,7 +26,7 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
   let pluginConfig: GraphQLSPConfig;
   try {
     configResult = await loadConfig(opts.tsconfig);
-    pluginConfig = parseConfig(configResult.pluginConfig);
+    pluginConfig = parseConfig(configResult.pluginConfig, configResult.rootPath);
   } catch (error) {
     throw logger.externalError('Failed to load configuration.', error);
   }

--- a/packages/cli-utils/src/commands/generate-schema/runner.ts
+++ b/packages/cli-utils/src/commands/generate-schema/runner.ts
@@ -44,7 +44,7 @@ export async function* run(tty: TTY, opts: SchemaOptions): AsyncIterable<Compose
     let pluginConfig: GraphQLSPConfig;
     try {
       configResult = await loadConfig(opts.tsconfig);
-      pluginConfig = parseConfig(configResult.pluginConfig);
+      pluginConfig = parseConfig(configResult.pluginConfig, configResult.rootPath);
     } catch (error) {
       throw logger.externalError('Failed to load configuration.', error);
     }

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -28,7 +28,7 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
   let pluginConfig: GraphQLSPConfig;
   try {
     configResult = await loadConfig(opts.tsconfig);
-    pluginConfig = parseConfig(configResult.pluginConfig);
+    pluginConfig = parseConfig(configResult.pluginConfig, configResult.rootPath);
   } catch (error) {
     throw logger.externalError('Failed to load configuration.', error);
   }

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 import { TadaError } from './errors';
-import type { SchemaOrigin } from './loaders/types';
+import { getURLConfig } from './loaders';
+import type { SchemaOrigin } from './loaders';
 
 export interface GraphQLSPConfig {
   schema: SchemaOrigin;
@@ -22,7 +23,7 @@ export const parseConfig = (
 ) => {
   const resolveConfigDir = (input: string | undefined) => {
     if (!input) return input;
-    return path.resolve(
+    return path.normalize(
       input.replace(/\${([^}]+)}/, (_match, name) => {
         if (name === 'configDir') {
           return rootPath;
@@ -85,6 +86,13 @@ export const parseConfig = (
   }
 
   const output = input as any as GraphQLSPConfig;
+
+  let schema: SchemaOrigin = output.schema;
+  if (typeof schema === 'string') {
+    const url = getURLConfig(schema);
+    if (!url) schema = resolveConfigDir(schema) || schema;
+  }
+
   return {
     ...output,
     tadaOutputLocation: resolveConfigDir(output.tadaOutputLocation),

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -7,7 +7,7 @@ import { loadFromURL } from './url';
 
 export { loadFromSDL, loadFromURL };
 
-const getURLConfig = (origin: SchemaOrigin | null) => {
+export const getURLConfig = (origin: SchemaOrigin | null) => {
   try {
     return origin
       ? {


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/pull/58042

## Summary

This adds support for a `${configDir}` substitution in our configuration.
This, by definition, must always point the path of the evaluated `tsconfig.json`, rather than the `tsconfig.json` the path was sourced from.

Support for this will land in TS with the linked PR.

## Set of changes

- Add `rootDir` to `${configPath}` substitution to `getConfig`
