### PR TITLE
fix(cli): Switch between ESM/CJS in CLI entrypoint

### DIFF
--- a/.changeset/thick-boats-sort.md
+++ b/.changeset/thick-boats-sort.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Switch between ESM and CJS when running CLI.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,2 +1,9 @@
 #!/usr/bin/env node
-require('../dist/gql-tada-cli.js');
+
+(async function main() {
+  try {
+    await import('../dist/gql-tada-cli.mjs');
+  } catch (_error) {
+    require('../dist/gql-tada-cli.js');
+  }
+})();

--- a/scripts/eslint-preset.js
+++ b/scripts/eslint-preset.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 9,
+    ecmaVersion: 2023,
     sourceType: 'module',
     ecmaFeatures: {
       modules: true,


### PR DESCRIPTION
We only ever used the CJS entrypoint before and the ESM one was also faulty.
In general, we should try to at least use either of them as needed.