### PR TITLE
patch(cli): Upgrade `@vue/language-core` and maintain backwards-compatibility

### DIFF
--- a/.changeset/lemon-moose-applaud.md
+++ b/.changeset/lemon-moose-applaud.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Upgrade `@vue/language-core` and maintain backwards-compatibility

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -59,7 +59,7 @@
     "@0no-co/graphqlsp": "^1.10.3",
     "@gql.tada/internal": "workspace:*",
     "@vue/compiler-dom": "^3.4.23",
-    "@vue/language-core": "^2.0.13",
+    "@vue/language-core": "^2.0.0",
     "graphql": "^16.8.1",
     "svelte2tsx": "^0.7.6"
   },

--- a/packages/cli-utils/src/ts/transformers/vue.ts
+++ b/packages/cli-utils/src/ts/transformers/vue.ts
@@ -4,22 +4,27 @@ import { forEachEmbeddedCode, getDefaultVueLanguagePlugins } from '@vue/language
 import * as vueCompilerDOM from '@vue/compiler-dom';
 import * as vue from '@vue/language-core';
 
-const VueVirtualCode =
-  vue.VueGeneratedCode || ((vue as any).VirtualCode as typeof vue.VueGeneratedCode);
+let VueVirtualCode: typeof vue.VueVirtualCode | undefined;
+if ('VueVirtualCode' in vue) {
+  VueVirtualCode = vue.VueVirtualCode;
+} else if ('VueGeneratedCode' in vue) {
+  VueVirtualCode = (vue as any).VueGeneratedCode;
+}
 
 const vueCompilerOptions = vue.resolveVueCompilerOptions({});
 
 let plugins: ReturnType<typeof getDefaultVueLanguagePlugins> | undefined;
 
 export const transform = (sourceFile: ts.SourceFile): VirtualCode | undefined => {
-  if (!plugins) {
+  if (!VueVirtualCode) {
+    return undefined;
+  } else if (!plugins) {
     plugins = getDefaultVueLanguagePlugins({
       modules: {
         typescript: ts,
         '@vue/compiler-dom': vueCompilerDOM,
       },
       compilerOptions: {},
-      codegenStack: false,
       globalTypesHolder: undefined,
       vueCompilerOptions,
     });
@@ -32,8 +37,7 @@ export const transform = (sourceFile: ts.SourceFile): VirtualCode | undefined =>
     snapshot,
     vueCompilerOptions,
     plugins,
-    ts,
-    false
+    ...([ts, false] as any as [typeof ts])
   );
   for (const code of forEachEmbeddedCode(root)) if (code.id.startsWith('script_')) return code;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
         specifier: ^3.4.23
         version: 3.4.25
       '@vue/language-core':
-        specifier: ^2.0.13
+        specifier: ^2.0.0
         version: 2.0.14(typescript@5.4.5)
       graphql:
         specifier: ^16.8.1


### PR DESCRIPTION
## Summary

This updates `@vue/language-core` and changes how `VueGeneratedCode` / `VueVirtualCode` is used, since the interface has changed

## Set of changes

- Switch between `VueGeneratedCode` and `VueVirtualCode` signatures
- Upgrade `@vue/language-core` but allow `^2.0.0`
