### PR TITLE
feat(internal): Implement initial multi-schema utilities

### DIFF
--- a/.changeset/nice-pears-pump.md
+++ b/.changeset/nice-pears-pump.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": minor
+---
+
+Add multi-schema config format and schema loading.

--- a/packages/cli-utils/src/commands/check/runner.ts
+++ b/packages/cli-utils/src/commands/check/runner.ts
@@ -42,6 +42,11 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
     throw logger.externalError('Failed to load configuration.', error);
   }
 
+  if (!('schema' in pluginConfig)) {
+    // TODO: Implement multi-schema support
+    throw logger.errorMessage('Multi-schema support is not implemented yet');
+  }
+
   const summary: SeveritySummary = { warn: 0, error: 0, info: 0 };
   const minSeverity = opts.minSeverity;
   const generator = runDiagnostics({

--- a/packages/cli-utils/src/commands/check/thread.ts
+++ b/packages/cli-utils/src/commands/check/thread.ts
@@ -19,6 +19,11 @@ export interface DiagnosticsParams {
 async function* _runDiagnostics(
   params: DiagnosticsParams
 ): AsyncIterableIterator<DiagnosticSignal> {
+  if (!('schema' in params.pluginConfig)) {
+    // TODO: Implement multi-schema support
+    throw new Error('Multi-schema support is not implemented yet');
+  }
+
   const projectPath = path.dirname(params.configPath);
   const loader = load({ origin: params.pluginConfig.schema, rootPath: projectPath });
   const factory = programFactory(params);

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -155,6 +155,11 @@ export async function* run(): AsyncIterable<ComposeInput> {
     );
   }
 
+  if (!('schema' in pluginConfig)) {
+    // TODO: Implement multi-schema support
+    throw logger.errorMessage('Multi-schema support is not implemented yet');
+  }
+
   if (!pluginConfig.schema) {
     yield logger.failedTask(Messages.CHECK_TSCONFIG);
     throw logger.errorMessage(

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -40,6 +40,11 @@ export async function* run(tty: TTY, opts: OutputOptions): AsyncIterable<Compose
     throw logger.externalError('Failed to load configuration.', error);
   }
 
+  if (!('schema' in pluginConfig)) {
+    // TODO: Implement multi-schema support
+    throw logger.errorMessage('Multi-schema support is not implemented yet');
+  }
+
   // TODO: allow this to be overwritten using arguments (like in `generate schema`)
   const loader = load({
     origin: pluginConfig.schema,

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -31,6 +31,11 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
     throw logger.externalError('Failed to load configuration.', error);
   }
 
+  if (!('schema' in pluginConfig)) {
+    // TODO: Implement multi-schema support
+    throw logger.errorMessage('Multi-schema support is not implemented yet');
+  }
+
   let destination: WriteTarget;
   if (!opts.output && tty.pipeTo) {
     destination = tty.pipeTo;

--- a/packages/cli-utils/src/commands/generate-schema/runner.ts
+++ b/packages/cli-utils/src/commands/generate-schema/runner.ts
@@ -49,6 +49,11 @@ export async function* run(tty: TTY, opts: SchemaOptions): AsyncIterable<Compose
       throw logger.externalError('Failed to load configuration.', error);
     }
 
+    if (!('schema' in pluginConfig)) {
+      // TODO: Implement multi-schema support
+      throw logger.errorMessage('Multi-schema support is not implemented yet');
+    }
+
     if (
       typeof pluginConfig.schema === 'string' &&
       path.extname(pluginConfig.schema) === '.graphql'

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -33,6 +33,11 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
     throw logger.externalError('Failed to load configuration.', error);
   }
 
+  if (!('schema' in pluginConfig)) {
+    // TODO: Implement multi-schema support
+    throw logger.errorMessage('Multi-schema support is not implemented yet');
+  }
+
   let destination: WriteTarget;
   if (!opts.output && tty.pipeTo) {
     destination = tty.pipeTo;

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -15,6 +15,13 @@ export interface SchemaConfig {
   tadaPersistedLocation?: string;
 }
 
+const SCHEMA_PROPS = [
+  'name',
+  'tadaOutputLocation',
+  'tadaTurboLocation',
+  'tadaPersistedLocation',
+] as const;
+
 interface MultiSchemaConfig extends SchemaConfig {
   name: string;
 }
@@ -153,9 +160,10 @@ export const parseConfig = (
       };
     });
 
-    const names = new Set(schemas.map((schema) => schema.name));
-    if (names.size !== schemas.length) {
-      throw new TadaError('All `name` labels in `schemas` must be unique.');
+    for (const prop of SCHEMA_PROPS) {
+      const values = new Set(schemas.map((schema) => schema[prop])).size;
+      if (values !== schemas.length)
+        throw new TadaError(`All '${prop}' values in 'schemas' must be unique.`);
     }
 
     return { ...input, schemas };

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -3,24 +3,25 @@ import { TadaError } from './errors';
 import { getURLConfig } from './loaders';
 import type { SchemaOrigin } from './loaders';
 
-export interface GraphQLSPConfig {
+export interface BaseConfig {
+  template?: string;
+}
+
+export interface SchemaConfig {
+  name?: string;
   schema: SchemaOrigin;
   tadaOutputLocation?: string;
   tadaTurboLocation?: string;
   tadaPersistedLocation?: string;
-  template?: string;
 }
 
-export const parseConfig = (
-  input: unknown,
-  /** Defines the path of the "main" `tsconfig.json` file.
-   * @remarks
-   * This should be the `rootPath` output from `loadConfig`,
-   * which is the path of the user's `tsconfig.json` before
-   * resolving `extends` options.
-   */
-  rootPath: string = process.cwd()
-): GraphQLSPConfig => {
+interface MultiSchemaConfig extends SchemaConfig {
+  name: string;
+}
+
+export type GraphQLSPConfig = BaseConfig & (SchemaConfig | { schemas: MultiSchemaConfig[] });
+
+const parseSchemaConfig = (input: unknown, rootPath: string): SchemaConfig => {
   const resolveConfigDir = (input: string | undefined) => {
     if (!input) return input;
     return path.normalize(
@@ -37,13 +38,13 @@ export const parseConfig = (
   };
 
   if (input == null || typeof input !== 'object') {
-    throw new TadaError(`Configuration was not loaded properly (Received: ${input})`);
+    throw new TadaError(`Schema is not configured properly (Received: ${input})`);
   }
 
   if ('schema' in input && input.schema && typeof input.schema === 'object') {
     const { schema } = input;
     if (!('url' in schema)) {
-      throw new TadaError('Configuration contains a `schema` object, but no `url` property');
+      throw new TadaError('Schema contains a `schema` object, but no `url` property');
     }
 
     if ('headers' in schema && schema.headers && typeof schema.headers === 'object') {
@@ -55,41 +56,37 @@ export const parseConfig = (
         }
       }
     } else if ('headers' in schema) {
-      throw new TadaError(
-        "Configuration contains a `schema.headers` property, but it's not an object"
-      );
+      throw new TadaError("Schema contains a `schema.headers` property, but it's not an object");
     }
-  } else if (!('schema' in input) || typeof input.schema !== 'string') {
-    throw new TadaError('Configuration is missing a `schema` property');
+  }
+
+  if (!('schema' in input) || typeof input.schema !== 'string') {
+    throw new TadaError('Schema is missing a `schema` property');
   } else if (
     'tadaOutputLocation' in input &&
     input.tadaOutputLocation &&
     typeof input.tadaOutputLocation !== 'string'
   ) {
     throw new TadaError(
-      "Configuration contains a `tadaOutputLocation` property, but it's not a file path"
+      "Schema contains a `tadaOutputLocation` property, but it's not a file path"
     );
   } else if (
     'tadaTurboLocation' in input &&
     input.tadaTurboLocation &&
     typeof input.tadaTurboLocation !== 'string'
   ) {
-    throw new TadaError(
-      "Configuration contains a `tadaTurboLocation` property, but it's not a file path"
-    );
+    throw new TadaError("Schema contains a `tadaTurboLocation` property, but it's not a file path");
   } else if (
     'tadaPersistedLocation' in input &&
     input.tadaPersistedLocation &&
     typeof input.tadaPersistedLocation !== 'string'
   ) {
     throw new TadaError(
-      "Configuration contains a `tadaPersistedLocation` property, but it's not a file path"
+      "Schema contains a `tadaPersistedLocation` property, but it's not a file path"
     );
-  } else if ('template' in input && input.template && typeof input.template !== 'string') {
-    throw new TadaError("Configuration contains a `template` property, but it's not a string");
   }
 
-  const output = input as any as GraphQLSPConfig;
+  const output = input as any as SchemaConfig;
 
   let schema: SchemaOrigin = output.schema;
   if (typeof schema === 'string') {
@@ -99,8 +96,87 @@ export const parseConfig = (
 
   return {
     ...output,
+    schema,
     tadaOutputLocation: resolveConfigDir(output.tadaOutputLocation),
     tadaTurboLocation: resolveConfigDir(output.tadaTurboLocation),
     tadaPersistedLocation: resolveConfigDir(output.tadaPersistedLocation),
   };
+};
+
+export const parseConfig = (
+  input: unknown,
+  /** Defines the path of the "main" `tsconfig.json` file.
+   * @remarks
+   * This should be the `rootPath` output from `loadConfig`,
+   * which is the path of the user's `tsconfig.json` before
+   * resolving `extends` options.
+   */
+  rootPath: string = process.cwd()
+): GraphQLSPConfig => {
+  if (input == null || typeof input !== 'object') {
+    throw new TadaError(`Configuration is of an invalid type (Received: ${input})`);
+  } else if ('template' in input && input.template && typeof input.template !== 'string') {
+    throw new TadaError("Configuration contains a `template` property, but it's not a string");
+  } else if ('name' in input && input.name && typeof input.name !== 'string') {
+    throw new TadaError("Configuration contains a `name` property, but it's not a string");
+  }
+
+  if ('schemas' in input) {
+    if (!Array.isArray(input.schemas)) {
+      throw new TadaError("Configuration contains a `schema` property, but it's not an array");
+    }
+
+    if ('schema' in input) {
+      throw new TadaError(
+        'If configuration contains a `schemas` property, it cannot contain a `schema` configuration.'
+      );
+    } else if ('tadaOutputLocation' in input) {
+      throw new TadaError(
+        "If configuration contains a `schemas` property, it cannot contain a 'tadaOutputLocation` configuration."
+      );
+    } else if ('tadaTurboLocation' in input) {
+      throw new TadaError(
+        "If configuration contains a `schemas` property, it cannot contain a 'tadaTurboLocation` configuration."
+      );
+    } else if ('tadaPersistedLocation' in input) {
+      throw new TadaError(
+        "If configuration contains a `schemas` property, it cannot contain a 'tadaPersistedLocation` configuration."
+      );
+    }
+
+    const schemas = input.schemas.map((schema): MultiSchemaConfig => {
+      if (!('name' in schema) || !schema.name || typeof schema.name !== 'string')
+        throw new TadaError('All `schemas` configurations must contain a `name` label.');
+      return {
+        ...parseSchemaConfig(schema, rootPath),
+        name: schema.name,
+      };
+    });
+
+    const names = new Set(schemas.map((schema) => schema.name));
+    if (names.size !== schemas.length) {
+      throw new TadaError('All `name` labels in `schemas` must be unique.');
+    }
+
+    return { ...input, schemas };
+  } else {
+    return { ...input, ...parseSchemaConfig(input, rootPath) };
+  }
+};
+
+export const getSchemaConfigForName = (
+  config: GraphQLSPConfig,
+  name: string | undefined
+): SchemaConfig | null => {
+  if (name && 'name' in config && config.name === name) {
+    return config;
+  } else if (!name && !('schemas' in config)) {
+    return config;
+  } else if (name && 'schemas' in config) {
+    for (let index = 0; index < config.schemas.length; index++)
+      if (config.schemas[index].name === name) return config.schemas[index];
+    return null;
+  } else {
+    return null;
+  }
 };

--- a/packages/internal/src/introspection/minify.ts
+++ b/packages/internal/src/introspection/minify.ts
@@ -10,6 +10,8 @@ import type {
   IntrospectionField,
 } from 'graphql';
 
+import type { IntrospectionResult } from '../loaders';
+
 function nameCompare(objA: { name: string }, objB: { name: string }) {
   return objA.name < objB.name ? -1 : objA.name > objB.name ? 1 : 0;
 }
@@ -149,7 +151,9 @@ function minifyIntrospectionType(type: IntrospectionType): IntrospectionType {
  * If `schema` receives an object that isn’t an {@link IntrospectionQuery}, a
  * {@link TypeError} will be thrown.
  */
-export const minifyIntrospectionQuery = (schema: IntrospectionQuery): IntrospectionQuery => {
+export const minifyIntrospectionQuery = (
+  schema: IntrospectionQuery | IntrospectionResult
+): IntrospectionResult => {
   if (!schema || !('__schema' in schema)) {
     throw new TypeError('Expected to receive an IntrospectionQuery.');
   }
@@ -185,6 +189,7 @@ export const minifyIntrospectionQuery = (schema: IntrospectionQuery): Introspect
     .sort(nameCompare);
 
   return {
+    name: 'name' in schema ? schema.name : undefined,
     __schema: {
       queryType: {
         kind: queryType.kind,

--- a/packages/internal/src/introspection/preprocess.ts
+++ b/packages/internal/src/introspection/preprocess.ts
@@ -8,6 +8,8 @@ import type {
   IntrospectionField,
 } from 'graphql';
 
+import type { IntrospectionResult } from '../loaders';
+
 const printName = (input: string | undefined | null): string => (input ? `'${input}'` : 'never');
 
 const printTypeRef = (typeRef: IntrospectionTypeRef) => {
@@ -78,7 +80,11 @@ export const printIntrospectionType = (type: IntrospectionType) => {
   }
 };
 
-export function preprocessIntrospection({ __schema: schema }: IntrospectionQuery): string {
+export function preprocessIntrospection(
+  introspection: IntrospectionResult | IntrospectionQuery
+): string {
+  const { __schema: schema } = introspection;
+  const name = 'name' in introspection ? introspection.name : undefined;
   const queryName = printName(schema.queryType.name);
   const mutationName = printName(schema.mutationType && schema.mutationType.name);
   const subscriptionName = printName(schema.subscriptionType && schema.subscriptionType.name);
@@ -92,6 +98,7 @@ export function preprocessIntrospection({ __schema: schema }: IntrospectionQuery
 
   return (
     '{\n' +
+    `  name: ${printName(name)};\n` +
     `  query: ${queryName};\n` +
     `  mutation: ${mutationName};\n` +
     `  subscription: ${subscriptionName};\n` +

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -45,16 +45,19 @@ export function load(config: LoadConfig): SchemaLoader {
 }
 
 type SingleSchema = { name?: string; schema: SchemaOrigin };
-type MultiSchema = { schemas: SingleSchema[] };
+type MultiSchema = { schemas?: SingleSchema[] };
 
-export function loadRef(input: SingleSchema & MultiSchema, config?: BaseLoadConfig): SchemaRef {
+export function loadRef(
+  input: SingleSchema | MultiSchema | (SingleSchema & MultiSchema),
+  config?: BaseLoadConfig
+): SchemaRef {
   const teardowns: (() => void)[] = [];
 
-  const loaders = input.schemas.map((item) => ({
+  const loaders = (('schemas' in input && input.schemas) || []).map((item) => ({
     name: item.name,
     loader: load({ ...config, origin: item.schema }),
   }));
-  if (input.schema) {
+  if ('schema' in input && input.schema) {
     loaders.push({
       name: input.name,
       loader: load({ ...config, origin: input.schema }),

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -21,6 +21,7 @@ export const getURLConfig = (origin: SchemaOrigin | null) => {
 };
 
 export interface LoadConfig {
+  name?: string;
   origin: SchemaOrigin;
   rootPath?: string;
   fetchInterval?: number;
@@ -30,11 +31,11 @@ export interface LoadConfig {
 export function load(config: LoadConfig): SchemaLoader {
   const urlOrigin = getURLConfig(config.origin);
   if (urlOrigin) {
-    return loadFromURL({ ...urlOrigin, interval: config.fetchInterval });
+    return loadFromURL({ ...urlOrigin, interval: config.fetchInterval, name: config.name });
   } else if (typeof config.origin === 'string') {
     const file = config.rootPath ? path.resolve(config.rootPath, config.origin) : config.origin;
     const assumeValid = config.assumeValid != null ? config.assumeValid : true;
-    return loadFromSDL({ file, assumeValid });
+    return loadFromSDL({ file, assumeValid, name: config.name });
   } else {
     throw new Error(`Configuration contains an invalid "schema" option`);
   }

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -25,7 +25,7 @@ export interface SchemaLoader {
 export interface SchemaRef<Result = SchemaLoaderResult | null> {
   /** Starts automatically updating the ref */
   autoupdate(): () => void;
-  /** Loads the initial values for the schema */
+  /** Loads the initial result for the schema */
   load(): Promise<SchemaRef<SchemaLoaderResult>>;
   current: Result;
   multi: { [name: string]: Result };

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -22,6 +22,16 @@ export interface SchemaLoader {
   loadSchema(): Promise<GraphQLSchema | null>;
 }
 
+export interface SchemaRef<Result = SchemaLoaderResult | null> {
+  /** Starts automatically updating the ref */
+  autoupdate(): () => void;
+  /** Loads the initial values for the schema */
+  load(): Promise<SchemaRef<SchemaLoaderResult>>;
+  current: Result;
+  multi: { [name: string]: Result };
+  version: number;
+}
+
 export type SchemaOrigin =
   | string
   | {

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -1,18 +1,23 @@
 import type { IntrospectionQuery, GraphQLSchema } from 'graphql';
 
+export interface IntrospectionResult extends IntrospectionQuery {
+  name: string | undefined;
+}
+
 export interface SchemaLoaderResult {
-  introspection: IntrospectionQuery;
+  introspection: IntrospectionResult;
   schema: GraphQLSchema;
 }
 
 export type OnSchemaUpdate = (result: SchemaLoaderResult) => void;
 
 export interface SchemaLoader {
+  readonly name: string | undefined;
   load(reload?: boolean): Promise<SchemaLoaderResult>;
   notifyOnUpdate(onUpdate: OnSchemaUpdate): () => void;
 
   /** @internal */
-  loadIntrospection(): Promise<IntrospectionQuery | null>;
+  loadIntrospection(): Promise<IntrospectionResult | null>;
   /** @internal */
   loadSchema(): Promise<GraphQLSchema | null>;
 }

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -9,6 +9,7 @@ import type { SupportedFeatures, IntrospectSupportQueryData } from './query';
 import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
 
 interface LoadFromURLConfig {
+  name?: string;
   url: URL | string;
   headers?: HeadersInit;
   interval?: number;
@@ -78,7 +79,10 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
       } else if (introspectionResult.data) {
         const introspection = introspectionResult.data;
         return {
-          introspection,
+          introspection: {
+            ...introspection,
+            name: config.name,
+          },
           schema: buildClientSchema(introspection, { assumeValid: true }),
         };
       } else {
@@ -124,6 +128,9 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
   };
 
   return {
+    get name() {
+      return config.name;
+    },
     async load(reload?: boolean) {
       return reload || !result ? (result = await load()) : result;
     },

--- a/src/__tests__/fixtures/simpleIntrospection.json
+++ b/src/__tests__/fixtures/simpleIntrospection.json
@@ -1,4 +1,5 @@
 {
+  "name": "simpleSchema",
   "__schema": {
     "queryType": {
       "name": "Query"

--- a/src/__tests__/fixtures/simpleIntrospection.ts
+++ b/src/__tests__/fixtures/simpleIntrospection.ts
@@ -1,4 +1,5 @@
 export type simpleIntrospection = {
+  name: 'simpleSchema',
   __schema: {
     queryType: {
       name: 'Query',

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -1,5 +1,6 @@
 export type simpleSchema =
   {
+    name: 'simpleSchema';
     query: 'Query';
     mutation: 'Mutation';
     subscription: 'Subscription';

--- a/src/api.ts
+++ b/src/api.ts
@@ -92,6 +92,10 @@ interface AbstractSetupCache {
 interface setupCache extends AbstractSetupCache {}
 
 interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfig> {
+  /** In "multi-schema" mode this identifies the schema.
+   * @internal */
+  readonly __name: Schema['name'];
+
   /** Function to create and compose GraphQL documents with result and variable types.
    *
    * @param input - A string of a GraphQL document.

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -10,6 +10,8 @@ import type { obj } from './utils';
  * @see {@link setupSchema} for where to use this data.
  */
 export interface IntrospectionQuery {
+  /** This identifies the schema in a "multi-schema" configuration */
+  readonly name?: string;
   readonly __schema: IntrospectionSchema;
 }
 
@@ -186,6 +188,7 @@ type mapIntrospectionScalarTypes<Scalars extends ScalarsLike = DefaultScalars> =
 /** @internal */
 type mapIntrospection<Query extends IntrospectionLikeInput> = Query extends IntrospectionQuery
   ? {
+      name: Query['name'];
       query: Query['__schema']['queryType']['name'];
       mutation: Query['__schema']['mutationType'] extends { name: string }
         ? Query['__schema']['mutationType']['name']
@@ -201,6 +204,7 @@ type addIntrospectionScalars<
   Schema extends SchemaLike,
   Scalars extends ScalarsLike = DefaultScalars,
 > = {
+  name: Schema['name'];
   query: Schema['query'];
   mutation: Schema['mutation'];
   subscription: Schema['subscription'];
@@ -216,6 +220,7 @@ export type ScalarsLike = {
 };
 
 export type SchemaLike = {
+  name?: string;
   query: string;
   mutation?: any;
   subscription?: any;


### PR DESCRIPTION
Related to #248

- Add support for new config format for multiple schemas
- Add utilities to load multiple schemas at the same time
- Pass through `name` from input config to introspection to output format to API