### PR TITLE
patch(internal): Reflect `tada*` options received in `loadRef` to result type

### DIFF
--- a/.changeset/weak-horses-relax.md
+++ b/.changeset/weak-horses-relax.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Update `loadRef` to reflect `tada*` options to result types.

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -44,22 +44,29 @@ export function load(config: LoadConfig): SchemaLoader {
   }
 }
 
-type SingleSchema = { name?: string; schema: SchemaOrigin };
-type MultiSchema = { schemas?: SingleSchema[] };
+export type SingleSchemaInput = {
+  name?: string;
+  schema: SchemaOrigin;
+  tadaOutputLocation?: string;
+  tadaTurboLocation?: string;
+  tadaPersistedLocation?: string;
+};
+
+export type MultiSchemaInput = { schemas?: SingleSchemaInput[] };
 
 export function loadRef(
-  input: SingleSchema | MultiSchema | (SingleSchema & MultiSchema),
+  input: SingleSchemaInput | MultiSchemaInput | (SingleSchemaInput & MultiSchemaInput),
   config?: BaseLoadConfig
 ): SchemaRef {
   const teardowns: (() => void)[] = [];
 
-  const loaders = (('schemas' in input && input.schemas) || []).map((item) => ({
-    name: item.name,
-    loader: load({ ...config, origin: item.schema }),
+  const loaders = (('schemas' in input && input.schemas) || []).map((input) => ({
+    input,
+    loader: load({ ...config, origin: input.schema }),
   }));
   if ('schema' in input && input.schema) {
     loaders.push({
-      name: input.name,
+      input,
       loader: load({ ...config, origin: input.schema }),
     });
   }
@@ -67,28 +74,28 @@ export function loadRef(
   const ref: SchemaRef = {
     version: 0,
     current: null,
-    multi: loaders.reduce((acc, { name }) => {
-      if (name) acc[name] = null;
+    multi: loaders.reduce((acc, { input }) => {
+      if (input.name) acc[input.name] = null;
       return acc;
     }, {}),
 
     autoupdate() {
       teardowns.push(
-        ...loaders.map(({ name, loader }) => {
+        ...loaders.map(({ input, loader }) => {
           loader.load().then((result) => {
             ref.version++;
-            if (name) {
-              ref.multi[name] = result;
+            if (input.name) {
+              ref.multi[input.name] = { ...input, ...result };
             } else {
-              ref.current = result;
+              ref.current = { ...input, ...result };
             }
           });
           return loader.notifyOnUpdate((result) => {
             ref.version++;
-            if (name) {
-              ref.multi[name] = result;
+            if (input.name) {
+              ref.multi[input.name] = { ...input, ...result };
             } else {
-              ref.current = result;
+              ref.current = { ...input, ...result };
             }
           });
         })
@@ -100,12 +107,13 @@ export function loadRef(
     },
     async load() {
       await Promise.all(
-        loaders.map(async ({ name, loader }) => {
+        loaders.map(async ({ input, loader }) => {
+          const result = await loader.load();
           ref.version++;
-          if (name) {
-            ref.multi[name] = await loader.load();
+          if (input.name) {
+            ref.multi[input.name] = { ...input, ...result };
           } else {
-            ref.current = await loader.load();
+            ref.current = { ...input, ...result };
           }
         })
       );

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -7,6 +7,9 @@ export interface IntrospectionResult extends IntrospectionQuery {
 export interface SchemaLoaderResult {
   introspection: IntrospectionResult;
   schema: GraphQLSchema;
+  tadaOutputLocation?: string;
+  tadaTurboLocation?: string;
+  tadaPersistedLocation?: string;
 }
 
 export type OnSchemaUpdate = (result: SchemaLoaderResult) => void;


### PR DESCRIPTION
Related to #248
Follow-up to #257