### PR TITLE
feat(cli-utils): Implement multi-schema support for CLI commands

### DIFF
--- a/.changeset/honest-suns-hammer.md
+++ b/.changeset/honest-suns-hammer.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Add multi-schema support to the CLI (See [RFC](https://github.com/0no-co/gql.tada/issues/248) for more details.) With multi-schema support, the configuration now accepts `schemas` as an option to set up multiple schemas that can be instantiated with `initGraphQLTada()` in parallel in the same codebase.

--- a/packages/cli-utils/src/commands/check/runner.ts
+++ b/packages/cli-utils/src/commands/check/runner.ts
@@ -42,11 +42,6 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
     throw logger.externalError('Failed to load configuration.', error);
   }
 
-  if (!('schema' in pluginConfig)) {
-    // TODO: Implement multi-schema support
-    throw logger.errorMessage('Multi-schema support is not implemented yet');
-  }
-
   const summary: SeveritySummary = { warn: 0, error: 0, info: 0 };
   const minSeverity = opts.minSeverity;
   const generator = runDiagnostics({

--- a/packages/cli-utils/src/commands/check/thread.ts
+++ b/packages/cli-utils/src/commands/check/thread.ts
@@ -41,7 +41,7 @@ async function* _runDiagnostics(
 
   for (const sourceFile of sourceFiles) {
     let filePath = sourceFile.fileName;
-    const diagnostics = getGraphQLDiagnostics(filePath, schemaRef as any, pluginInfo);
+    const diagnostics = getGraphQLDiagnostics(filePath, schemaRef, pluginInfo);
     const messages: DiagnosticMessage[] = [];
 
     if (diagnostics && diagnostics.length) {

--- a/packages/cli-utils/src/commands/check/thread.ts
+++ b/packages/cli-utils/src/commands/check/thread.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import * as path from 'node:path';
 
 import type { GraphQLSPConfig } from '@gql.tada/internal';
-import { load } from '@gql.tada/internal';
+import { loadRef } from '@gql.tada/internal';
 import { getGraphQLDiagnostics } from '@0no-co/graphqlsp/api';
 
 import { programFactory } from '../../ts';
@@ -19,13 +19,7 @@ export interface DiagnosticsParams {
 async function* _runDiagnostics(
   params: DiagnosticsParams
 ): AsyncIterableIterator<DiagnosticSignal> {
-  if (!('schema' in params.pluginConfig)) {
-    // TODO: Implement multi-schema support
-    throw new Error('Multi-schema support is not implemented yet');
-  }
-
   const projectPath = path.dirname(params.configPath);
-  const loader = load({ origin: params.pluginConfig.schema, rootPath: projectPath });
   const factory = programFactory(params);
 
   const externalFiles = factory.createExternalFiles();
@@ -34,10 +28,10 @@ async function* _runDiagnostics(
     await factory.addVirtualFiles(externalFiles);
   }
 
+  const schemaRef = await loadRef(params.pluginConfig).load({ rootPath: projectPath });
+
   const container = factory.build();
   const pluginInfo = container.buildPluginInfo(params.pluginConfig);
-  const loadResult = await loader.load();
-  const schemaRef = { current: loadResult.schema, version: 1 };
   const sourceFiles = container.getSourceFiles();
 
   yield {

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -98,7 +98,7 @@ export async function* run(tty: TTY, opts: OutputOptions): AsyncIterable<Compose
   } else {
     if (opts.output) {
       throw logger.errorMessage(
-        'Output path was specified with multiple schemas being configured..\n' +
+        'Output path was specified, while multiple schemas are configured.\n' +
           logger.hint(
             `You can only output all schemas to their ${logger.code(
               '"tadaOutputLocation"'

--- a/packages/cli-utils/src/commands/generate-persisted/logger.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/logger.ts
@@ -71,15 +71,8 @@ const documentSummary = (documentCount: number | Record<string, number>) => {
   return out;
 };
 
-export function warningSummary(
-  warningCount: number,
-  documentCount: number | Record<string, number>
-) {
-  return t.error([
-    t.cmd(t.CSI.Style, t.Style.Red),
-    `${t.Icons.Cross} ${warningCount} warnings\n`,
-    documentSummary(documentCount),
-  ]);
+export function warningSummary(warningCount: number) {
+  return t.error([t.cmd(t.CSI.Style, t.Style.Red), `${t.Icons.Cross} ${warningCount} warnings\n`]);
 }
 
 export function infoSummary(warningCount: number, documentCount: number | Record<string, number>) {

--- a/packages/cli-utils/src/commands/generate-persisted/logger.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/logger.ts
@@ -34,25 +34,20 @@ export function warningMessage(message: PersistedWarning) {
   ]);
 }
 
-export function warningSummary(warningCount: number, documentCount: number) {
-  return t.error([
-    t.cmd(t.CSI.Style, t.Style.Red),
-    `${t.Icons.Cross} ${warningCount} warnings `,
-    t.cmd(t.CSI.Style, t.Style.BrightBlack),
-    `(${documentCount} documents extracted)\n`,
-  ]);
-}
-
-export function infoSummary(warningCount: number, documentCount: number) {
+const documentSummary = (documentCount: number | Record<string, number>) => {
   let out = '';
-  if (warningCount) {
+  if (
+    typeof documentCount !== 'number'
+      ? Object.values(documentCount).every((value) => !value)
+      : !documentCount
+  ) {
     out += t.text([
-      t.cmd(t.CSI.Style, t.Style.BrightYellow),
-      t.Icons.Warning,
-      ` ${warningCount} warnings\n`,
+      t.cmd(t.CSI.Style, t.Style.Blue),
+      `${t.Icons.Info} No persisted documents were found `,
+      t.cmd(t.CSI.Style, t.Style.BrightBlack),
+      `(Persisted manifests were not generated)\n`,
     ]);
-  }
-  if (documentCount) {
+  } else if (typeof documentCount === 'number') {
     out += t.text([
       t.cmd(t.CSI.Style, t.Style.BrightGreen),
       `${t.Icons.Tick} Persisted manifest was generated successfully `,
@@ -61,12 +56,42 @@ export function infoSummary(warningCount: number, documentCount: number) {
     ]);
   } else {
     out += t.text([
-      t.cmd(t.CSI.Style, t.Style.Blue),
-      `${t.Icons.Info} No persisted documents were found `,
-      t.cmd(t.CSI.Style, t.Style.BrightBlack),
-      `(Persisted manifest was not generated)\n`,
+      t.cmd(t.CSI.Style, t.Style.BrightGreen),
+      `${t.Icons.Tick} Persisted manifests were generated successfully.\n`,
+    ]);
+    for (const schemaName in documentCount) {
+      out += t.text([
+        t.cmd(t.CSI.Style, t.Style.BrightBlack),
+        `${t.HeavyBox.BottomLeft} `,
+        t.cmd(t.CSI.Style, t.Style.BrightBlue),
+        `${documentCount[schemaName]} documents extracted for the '${schemaName}' schema\n`,
+      ]);
+    }
+  }
+  return out;
+};
+
+export function warningSummary(
+  warningCount: number,
+  documentCount: number | Record<string, number>
+) {
+  return t.error([
+    t.cmd(t.CSI.Style, t.Style.Red),
+    `${t.Icons.Cross} ${warningCount} warnings\n`,
+    documentSummary(documentCount),
+  ]);
+}
+
+export function infoSummary(warningCount: number, documentCount: number | Record<string, number>) {
+  let out = '';
+  if (warningCount) {
+    out += t.text([
+      t.cmd(t.CSI.Style, t.Style.BrightYellow),
+      t.Icons.Warning,
+      ` ${warningCount} warnings\n`,
     ]);
   }
+  out += documentSummary(documentCount);
   return out;
 }
 

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -147,8 +147,10 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
         documentCount[name] = 0;
         const json: Record<string, string> = {};
         for (const item of documents) {
-          json[item.hashKey] = item.document;
-          documentCount[name]++;
+          if (item.schemaName === name) {
+            json[item.hashKey] = item.document;
+            documentCount[name]++;
+          }
         }
         if (documentCount[name]) {
           const contents = JSON.stringify(json, null, 2);

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -101,7 +101,7 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
     }
 
     if (warnings && opts.failOnWarn) {
-      throw logger.warningSummary(warnings, documents.length);
+      throw logger.warningSummary(warnings);
     } else if (documents.length) {
       try {
         const json: Record<string, string> = {};
@@ -165,7 +165,7 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
     }
 
     if (warnings && opts.failOnWarn) {
-      throw logger.warningSummary(warnings, documentCount);
+      throw logger.warningSummary(warnings);
     } else {
       yield logger.infoSummary(warnings, documentCount);
     }

--- a/packages/cli-utils/src/commands/generate-persisted/thread.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/thread.ts
@@ -56,7 +56,9 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
         warnings.push({
           message: call.schema
             ? `The '${call.schema}' schema is not in the configuration but was referenced by "graphql.persisted".`
-            : 'Multiple schemas are configured, but the document is not for a specific schema.',
+            : schemaNames.size > 1
+              ? 'The document is not for a known schema. Have you re-generated the output file?'
+              : 'Multiple schemas are configured, but the document is not for a specific schema.',
           file: position.fileName,
           line: position.line,
           col: position.col,

--- a/packages/cli-utils/src/commands/generate-persisted/thread.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/thread.ts
@@ -3,6 +3,7 @@ import { print } from '@0no-co/graphql.web';
 
 import type { FragmentDefinitionNode } from '@0no-co/graphql.web';
 import type { GraphQLSPConfig } from '@gql.tada/internal';
+import { getSchemaNamesFromConfig } from '@gql.tada/internal';
 
 import {
   findAllPersistedCallExpressions,
@@ -14,7 +15,7 @@ import {
 import { programFactory } from '../../ts';
 import { expose } from '../../threads';
 
-import type { PersistedSignal, PersistedWarning } from './types';
+import type { PersistedSignal, PersistedWarning, PersistedDocument } from './types';
 
 export interface PersistedParams {
   rootPath: string;
@@ -23,6 +24,7 @@ export interface PersistedParams {
 }
 
 async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<PersistedSignal> {
+  const schemaNames = getSchemaNamesFromConfig(params.pluginConfig);
   const factory = programFactory(params);
 
   const externalFiles = factory.createExternalFiles();
@@ -32,6 +34,7 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
   }
 
   const container = factory.build();
+  const pluginInfo = container.buildPluginInfo(params.pluginConfig);
   const sourceFiles = container.getSourceFiles();
 
   yield {
@@ -41,17 +44,29 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
 
   for (const sourceFile of sourceFiles) {
     let filePath = sourceFile.fileName;
-    const documents: Record<string, string> = {};
+    const documents: PersistedDocument[] = [];
     const warnings: PersistedWarning[] = [];
 
-    const calls = findAllPersistedCallExpressions(sourceFile);
+    const calls = findAllPersistedCallExpressions(sourceFile, pluginInfo);
     for (const call of calls) {
-      const position = container.getSourcePosition(sourceFile, call.getStart());
+      const position = container.getSourcePosition(sourceFile, call.node.getStart());
       filePath = position.fileName;
 
-      const hashArg = call.arguments[0];
-      const docArg = call.arguments[1];
-      const typeQuery = call.typeArguments && call.typeArguments[0];
+      if (!schemaNames.has(call.schema)) {
+        warnings.push({
+          message: call.schema
+            ? `The '${call.schema}' schema is not in the configuration but was referenced by "graphql.persisted".`
+            : 'Multiple schemas are configured, but the document is not for a specific schema.',
+          file: position.fileName,
+          line: position.line,
+          col: position.col,
+        });
+        continue;
+      }
+
+      const hashArg = call.node.arguments[0];
+      const docArg = call.node.arguments[1];
+      const typeQuery = call.node.typeArguments && call.node.typeArguments[0];
       if (!hashArg || !ts.isStringLiteral(hashArg)) {
         warnings.push({
           message:
@@ -74,12 +89,12 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
       }
 
       let foundNode: ts.CallExpression | null = null;
-      let referencingNode: ts.Node = call;
+      let referencingNode: ts.Node = call.node;
       if (docArg && (ts.isCallExpression(docArg) || ts.isIdentifier(docArg))) {
         const result = getDocumentReferenceFromDocumentNode(
           docArg,
           sourceFile.fileName,
-          container.buildPluginInfo(params.pluginConfig)
+          pluginInfo
         );
         foundNode = result.node;
         referencingNode = docArg;
@@ -87,7 +102,7 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
         const result = getDocumentReferenceFromTypeQuery(
           typeQuery,
           sourceFile.fileName,
-          container.buildPluginInfo(params.pluginConfig)
+          pluginInfo
         );
         foundNode = result.node;
         referencingNode = typeQuery;
@@ -134,7 +149,12 @@ async function* _runPersisted(params: PersistedParams): AsyncIterableIterator<Pe
 
       let document = operation;
       for (const fragment of fragments) document += '\n\n' + print(fragment);
-      documents[hashArg.getText().slice(1, -1)] = document;
+
+      documents.push({
+        schemaName: call.schema,
+        hashKey: hashArg.getText().slice(1, -1),
+        document,
+      });
     }
 
     yield {

--- a/packages/cli-utils/src/commands/generate-persisted/types.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/types.ts
@@ -5,10 +5,16 @@ export interface PersistedWarning {
   col: number;
 }
 
+export interface PersistedDocument {
+  schemaName: string | null;
+  hashKey: string;
+  document: string;
+}
+
 export interface FilePersistedSignal {
   kind: 'FILE_PERSISTED';
   filePath: string;
-  documents: Record<string, string>;
+  documents: PersistedDocument[];
   warnings: PersistedWarning[];
 }
 

--- a/packages/cli-utils/src/commands/generate-schema/runner.ts
+++ b/packages/cli-utils/src/commands/generate-schema/runner.ts
@@ -49,25 +49,30 @@ export async function* run(tty: TTY, opts: SchemaOptions): AsyncIterable<Compose
       throw logger.externalError('Failed to load configuration.', error);
     }
 
-    if (!('schema' in pluginConfig)) {
-      // TODO: Implement multi-schema support
-      throw logger.errorMessage('Multi-schema support is not implemented yet');
-    }
-
     if (
+      'schema' in pluginConfig &&
       typeof pluginConfig.schema === 'string' &&
       path.extname(pluginConfig.schema) === '.graphql'
     ) {
       destination = path.resolve(path.dirname(configResult.configPath), pluginConfig.schema);
+    } else if (!('schema' in pluginConfig)) {
+      throw logger.errorMessage(
+        `Output path cannot be automatically determined when multiple schemas are configured,\n` +
+          `because multiple ${logger.code('schemas')} are set up.` +
+          logger.hint(
+            `You have to explicitly pass an ${logger.code(
+              '--output'
+            )} argument to this command,\n` + 'or pipe this command to an output file.'
+          )
+      );
     } else {
       throw logger.errorMessage(
-        `No output path was specified but writing to ${logger.code(
-          'schema'
-        )} is not a file path.\n` +
+        `Output path cannot be automatically determined,\n` +
+          `because ${logger.code('schema')} is not a file path.\n` +
           logger.hint(
-            `You have to either set ${logger.code('"schema"')} to a ${logger.code(
-              '.graphql'
-            )} file in your configuration,\n` +
+            `You have to either set ${logger.code(
+              '"schema"'
+            )} in your configuration to a ${logger.code('.graphql')} file,\n` +
               `pass an ${logger.code('--output')} argument to this command,\n` +
               'or pipe this command to an output file.'
           )

--- a/packages/cli-utils/src/commands/shared/logger.ts
+++ b/packages/cli-utils/src/commands/shared/logger.ts
@@ -77,7 +77,7 @@ export function externalError(message: string, error: unknown) {
     `\n${message.trim()}\n`,
     t.cmd(t.CSI.Style, t.Style.BrightBlack),
     `${t.HeavyBox.BottomLeft} `,
-    indent(text, '  '),
+    indent(!text.endsWith('\n') ? text + '\n' : text, '  '),
   ]);
 }
 

--- a/packages/cli-utils/src/commands/turbo/logger.ts
+++ b/packages/cli-utils/src/commands/turbo/logger.ts
@@ -60,16 +60,8 @@ const documentSummary = (documentCount: number | Record<string, number>) => {
   return out;
 };
 
-export function warningSummary(
-  warningCount: number,
-  documentCount: number | Record<string, number>
-) {
-  return t.error([
-    t.cmd(t.CSI.Style, t.Style.Red),
-    `${t.Icons.Cross} ${warningCount} warnings `,
-    t.cmd(t.CSI.Style, t.Style.BrightBlack),
-    documentSummary(documentCount),
-  ]);
+export function warningSummary(warningCount: number) {
+  return t.error([t.cmd(t.CSI.Style, t.Style.Red), `${t.Icons.Cross} ${warningCount} warnings\n`]);
 }
 
 export function infoSummary(warningCount: number, documentCount: number | Record<string, number>) {

--- a/packages/cli-utils/src/commands/turbo/logger.ts
+++ b/packages/cli-utils/src/commands/turbo/logger.ts
@@ -34,16 +34,45 @@ export function warningMessage(message: TurboWarning) {
   ]);
 }
 
-export function warningSummary(warningCount: number, documentCount: number) {
+const documentSummary = (documentCount: number | Record<string, number>) => {
+  let out = '';
+  if (typeof documentCount === 'number') {
+    out += t.text([
+      t.cmd(t.CSI.Style, t.Style.BrightGreen),
+      `${t.Icons.Tick} Type cache was generated successfully `,
+      t.cmd(t.CSI.Style, t.Style.BrightBlack),
+      `(${documentCount} document types cached)\n`,
+    ]);
+  } else {
+    out += t.text([
+      t.cmd(t.CSI.Style, t.Style.BrightGreen),
+      `${t.Icons.Tick} Type caches were generated successfully.\n`,
+    ]);
+    for (const schemaName in documentCount) {
+      out += t.text([
+        t.cmd(t.CSI.Style, t.Style.BrightBlack),
+        `${t.HeavyBox.BottomLeft} `,
+        t.cmd(t.CSI.Style, t.Style.BrightBlue),
+        `${documentCount[schemaName]} document types cached for the '${schemaName}' schema\n`,
+      ]);
+    }
+  }
+  return out;
+};
+
+export function warningSummary(
+  warningCount: number,
+  documentCount: number | Record<string, number>
+) {
   return t.error([
     t.cmd(t.CSI.Style, t.Style.Red),
     `${t.Icons.Cross} ${warningCount} warnings `,
     t.cmd(t.CSI.Style, t.Style.BrightBlack),
-    `(${documentCount} document types cached)\n`,
+    documentSummary(documentCount),
   ]);
 }
 
-export function infoSummary(warningCount: number, documentCount: number) {
+export function infoSummary(warningCount: number, documentCount: number | Record<string, number>) {
   let out = '';
   if (warningCount) {
     out += t.text([
@@ -52,16 +81,7 @@ export function infoSummary(warningCount: number, documentCount: number) {
       ` ${warningCount} warnings\n`,
     ]);
   }
-  if (documentCount) {
-    out += t.text([
-      t.cmd(t.CSI.Style, t.Style.BrightGreen),
-      `${t.Icons.Tick} Type cache was generated successfully `,
-      t.cmd(t.CSI.Style, t.Style.BrightBlack),
-      `(${documentCount} document types cached)\n`,
-    ]);
-  } else {
-    out += t.text([t.cmd(t.CSI.Style, t.Style.Blue), `${t.Icons.Info} No documents were found\n`]);
-  }
+  out += documentSummary(documentCount);
   return out;
 }
 

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -114,7 +114,7 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
     }
 
     if (warnings && opts.failOnWarn) {
-      throw logger.warningSummary(warnings, documents.length);
+      throw logger.warningSummary(warnings);
     }
 
     try {
@@ -170,7 +170,11 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
       }
     }
 
-    yield logger.infoSummary(warnings, documentCount);
+    if (warnings && opts.failOnWarn) {
+      throw logger.warningSummary(warnings);
+    } else {
+      yield logger.infoSummary(warnings, documentCount);
+    }
   }
 }
 

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -155,8 +155,10 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
         documentCount[name] = 0;
         const cache: Record<string, string> = {};
         for (const item of documents) {
-          cache[item.argumentKey] = item.documentType;
-          documentCount[name]++;
+          if (item.schemaName === name) {
+            cache[item.argumentKey] = item.documentType;
+            documentCount[name]++;
+          }
         }
         const contents = createCacheContents(cache);
         await writeOutput(path.resolve(projectPath, tadaTurboLocation), contents);

--- a/packages/cli-utils/src/commands/turbo/types.ts
+++ b/packages/cli-utils/src/commands/turbo/types.ts
@@ -5,10 +5,16 @@ export interface TurboWarning {
   col: number;
 }
 
+export interface TurboDocument {
+  schemaName: string | null;
+  argumentKey: string;
+  documentType: string;
+}
+
 export interface FileTurboSignal {
   kind: 'FILE_TURBO';
   filePath: string;
-  cache: Record<string, string>;
+  documents: TurboDocument[];
   warnings: TurboWarning[];
 }
 

--- a/packages/cli-utils/src/term/tty.ts
+++ b/packages/cli-utils/src/term/tty.ts
@@ -110,10 +110,7 @@ export function initTTY(params: TTYParams = {}): TTY {
   function _end() {
     if (isTTY) {
       output.write(
-        cmd(CSI.Reset) +
-          cmd(CSI.ResetPrivateMode) +
-          cmd(CSI.SetPrivateMode, PrivateMode.ShowCursor) +
-          '\n'
+        cmd(CSI.Reset) + cmd(CSI.ResetPrivateMode) + cmd(CSI.SetPrivateMode, PrivateMode.ShowCursor)
       );
     }
   }

--- a/packages/cli-utils/src/term/write.ts
+++ b/packages/cli-utils/src/term/write.ts
@@ -82,8 +82,10 @@ async function* convertError(outputs: AsyncIterable<ComposeInput>): AsyncIterabl
   try {
     yield* outputs;
   } catch (error) {
-    yield error instanceof CLIError ? error : '' + error;
+    yield !(error instanceof CLIError) ? ('' + error).trim() + '\n' : error;
   }
+
+  yield '\n';
 }
 
 function compose(outputs: AsyncIterable<ComposeInput>): Source<string | CLIError> {

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -172,6 +172,13 @@ export const parseConfig = (
   }
 };
 
+export const getSchemaNamesFromConfig = (config: GraphQLSPConfig): Set<null | string> => {
+  return new Set<null | string>([
+    ...('schema' in config ? [null] : []),
+    ...('schemas' in config ? config.schemas.map((input) => input.name) : []),
+  ]);
+};
+
 export const getSchemaConfigForName = (
   config: GraphQLSPConfig,
   name: string | undefined


### PR DESCRIPTION
Resolves #248
Related to #257


This implements multi-schema support, as per the RFC, in the CLI. This, together with https://github.com/0no-co/GraphQLSP/pull/303 fully resolves the RFC and implements true multi-schema support.

A given `tsconfig.json` with the plugin configuration can now set up multiple schemas:

```json
{
  "compilerOptions": {
    "plugins": [
      {
        "name": "@0no-co/graphqlsp",
        "schemas": [
          {
            "name": "pokemon",
            "schema": "./schema.graphql",
            "tadaOutputLocation": "./src/graphql-env.d.ts",
            "tadaTurboLocation": "./src/graphql-cache.d.ts",
            "tadaPersistedLocation": "./src/persisted.json"
          },
          // ...
        ]
      }
    ]
  }
}
```

These can be used by instantiating them with `initGraphQLTada` via the output file (as specified by `tadaOutputLocation`).
The new configuration is fully validated (as can be seen when running `gql.tada doctor`.

> [!WARNING]
> Whenever a command accepts an `--output` argument, this is now unsupported by the CLI command in favour of clear configuration options (i.e. `tadaOutputLocation`, `tadaTurboLocation`, and `tadaPersistedLocation`)
> This is except for the `generate schema` command, with which multiple schema _requires_ the `--output` option now.