### PR TITLE
fix(cli-utils): Add missing deduplication and normalization to `generate persisted` output

### DIFF
--- a/.changeset/slimy-boxes-try.md
+++ b/.changeset/slimy-boxes-try.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Add missing fragment deduplication to `generate persisted` command's output and add document normalization, which can be disabled using the `--disable-normalization` argument.

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -20,7 +20,7 @@ export interface OutputOptions {
   forceTSFormat?: boolean;
   /** Whether to disable the optimized output format for `.d.ts` files.
    * @defaultValue `false` */
-  disablePreprocessing: boolean;
+  disablePreprocessing?: boolean;
   /** The filename to write the cache file to.
    * @defaultValue The `tadaTurboLocation` configuration option */
   output: string | undefined;

--- a/packages/cli-utils/src/commands/generate-persisted/index.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/index.ts
@@ -11,6 +11,10 @@ export class GeneratePersisted extends Command {
     description: 'Specify the `tsconfig.json` used to read, unless `--output` is passed.',
   });
 
+  disableNormalization = Option.Boolean('--disable-normalization', false, {
+    description: 'Disables normalizing of GraphQL documents (parsing then printing documents)',
+  });
+
   failOnWarn = Option.Boolean('--fail-on-warn', false, {
     description: 'Triggers an error and a non-zero exit code if any warnings have been reported',
   });
@@ -25,6 +29,7 @@ export class GeneratePersisted extends Command {
     const tty = initTTY();
     const result = await tty.start(
       run(tty, {
+        disableNormalization: this.disableNormalization,
         failOnWarn: this.failOnWarn,
         output: this.output,
         tsconfig: this.tsconfig,

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -10,6 +10,13 @@ import type { PersistedDocument } from './types';
 import * as logger from './logger';
 
 export interface PersistedOptions {
+  /** Whether to disable normalization of GraphQL documents in the output.
+   * @defaultValue `false`
+   * @remarks
+   * Normalizing a GraphQL document means to parse then print them, which
+   * removes comments and normalizes formatting.
+   */
+  disableNormalization?: boolean;
   /** The `tsconfig.json` to use for configurations and the TypeScript program.
    * @defaultValue A `tsconfig.json` in the current or any parent directory. */
   tsconfig: string | undefined;
@@ -35,6 +42,7 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
   if (tty.isInteractive) yield logger.runningPersisted();
 
   const generator = runPersisted({
+    disableNormalization: !!opts.disableNormalization,
     rootPath: configResult.rootPath,
     configPath: configResult.configPath,
     pluginConfig,

--- a/packages/cli-utils/src/commands/generate-persisted/thread.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/thread.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { Kind, parse, print } from '@0no-co/graphql.web';
+import { parse, print } from '@0no-co/graphql.web';
 
 import type { FragmentDefinitionNode } from '@0no-co/graphql.web';
 import type { GraphQLSPConfig } from '@gql.tada/internal';

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -123,6 +123,7 @@ When this command is run inside a GitHub Action, [workflow commands](https://doc
 
 | Option              | Description                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------ |
+| `--disable-normalization`     | Whether to disable normalizing the GraphQL document. (Default: false) |
 | `--tsconfig,-c`     | Optionally, a `tsconfig.json` file to use instead of an automatically discovered one.            |
 | `--fail-on-warn,-w` | Triggers an error and a non-zero exit code if any warnings have been reported.                   |
 | `--output,-o`       | Specify where to output the file to. (Default: The `tadaPersistedLocation` configuration option) |
@@ -172,6 +173,7 @@ await generateOutput({
 
 |                     | Description                                                                                                           |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `disableNormalization`     | Disables normalizing the GraphQL document |
 | `output` option     | The filename to write the persisted JSON manifest file to (Default: the `tadaPersistedLocation` configuration option) |
 | `tsconfig` option   | The `tsconfig.json` to use instead of an automatically discovered one.                                                |
 | `failOnWarn` option | Whether to throw an error instead of logging warnings.                                                                |


### PR DESCRIPTION
## Summary

This adds missing fragment deduplication to the `generate-persisted` output, and also adds `parse(print())` normalization to the initial document string. The latter can be disabled now using the `--disable-normalization` argument, but it's unlikely that anyone would want to disable this.

> [!NOTE]
> I noticed that `unrollTadaFragments` pre-parses the document. As the function isn't used in `graphqlsp` itself that's likely unnecessary. Removing this allows us to surface parsing errors as warnings to users. That's a separate TODO from this change though.

## Set of changes

- Normalize documents output by the `generate persisted` command
- Add `--disable-normalization` argument
- Udpate docs
- Deduplicate fragments in output
