### PR TITLE
docs: fix 'environment' typo in get-started/workflows.md

### DIFF
--- a/website/get-started/workflows.md
+++ b/website/get-started/workflows.md
@@ -59,7 +59,7 @@ your setup, the `doctor` command exists.
 gql.tada doctor
 ```
 
-The `doctor` command runs through several environemnt checks,
+The `doctor` command runs through several environment checks,
 loads your configuration, and checks your schema to make sure
 you don't run into any unexpected issues.
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->
I noticed a typo in `get-started/workflows.md` and wanted to fix it.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
Fixes the spelling of the word "environment" in `get-started/workflows.md`.