### PR TITLE
patch(cli-utils/internal): Add preliminary open support from graphql 15-17

### DIFF
--- a/.changeset/nice-experts-float.md
+++ b/.changeset/nice-experts-float.md
@@ -1,0 +1,6 @@
+---
+"@gql.tada/cli-utils": patch
+"@gql.tada/internal": patch
+---
+
+Update CLI and `@gql.tada/internal` to variably support graphql `^15.5.0` in addition to the preferred v16, and include future support for v17.

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -60,11 +60,12 @@
     "@gql.tada/internal": "workspace:*",
     "@vue/compiler-dom": "^3.4.23",
     "@vue/language-core": "^2.0.0",
-    "graphql": "^16.8.1",
+    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "svelte2tsx": "^0.7.6"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -54,7 +54,7 @@
     "@0no-co/graphql.web": "^1.0.5"
   },
   "peerDependencies": {
-    "graphql": "^16.8.1",
+    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "typescript": "^5.0.0"
   },
   "publishConfig": {

--- a/packages/internal/src/loaders/__tests__/introspection.test.ts
+++ b/packages/internal/src/loaders/__tests__/introspection.test.ts
@@ -4,8 +4,24 @@ import { print } from '@0no-co/graphql.web';
 import {
   makeIntrospectionQuery,
   makeIntrospectSupportQuery,
+  getPeerSupportedFeatures,
   toSupportedFeatures,
 } from '../introspection';
+
+describe('getPeerSupportedFeatures', () => {
+  it('calculates supported features of local graphql installation', () => {
+    const support = getPeerSupportedFeatures();
+    expect(support).toMatchInlineSnapshot(`
+      {
+        "directiveArgumentsIsDeprecated": true,
+        "directiveIsRepeatable": true,
+        "fieldArgumentsIsDeprecated": true,
+        "inputValueDeprecation": true,
+        "specifiedByURL": true,
+      }
+    `);
+  });
+});
 
 describe('makeIntrospectSupportQuery', () => {
   it('prints to introspection support query', () => {

--- a/packages/internal/src/loaders/__tests__/introspection.test.ts
+++ b/packages/internal/src/loaders/__tests__/introspection.test.ts
@@ -1,7 +1,11 @@
 import { expect, describe, it } from 'vitest';
 import { print } from '@0no-co/graphql.web';
 
-import { makeIntrospectionQuery, makeIntrospectSupportQuery, toSupportedFeatures } from '../query';
+import {
+  makeIntrospectionQuery,
+  makeIntrospectSupportQuery,
+  toSupportedFeatures,
+} from '../introspection';
 
 describe('makeIntrospectSupportQuery', () => {
   it('prints to introspection support query', () => {

--- a/packages/internal/src/loaders/introspection.ts
+++ b/packages/internal/src/loaders/introspection.ts
@@ -1,0 +1,552 @@
+import { Kind, OperationTypeNode } from '@0no-co/graphql.web';
+
+import type {
+  SelectionSetNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+  FieldNode,
+  DocumentNode,
+} from '@0no-co/graphql.web';
+
+/** Support matrix to be used in the {@link makeIntrospectionQuery} builder */
+export interface SupportedFeatures {
+  directiveIsRepeatable: boolean;
+  specifiedByURL: boolean;
+  inputValueDeprecation: boolean;
+  directiveArgumentsIsDeprecated: boolean;
+  fieldArgumentsIsDeprecated: boolean;
+}
+
+/** Data from a {@link makeIntrospectSupportQuery} result */
+export interface IntrospectSupportQueryData {
+  directive: { fields: { name: string; args: { name: string }[] | null }[] | null } | null;
+  type: { fields: { name: string }[] | null } | null;
+  field: { fields: { name: string; args: { name: string }[] | null }[] | null } | null;
+  inputValue: { fields: { name: string }[] | null } | null;
+}
+
+const _hasField = (
+  data: IntrospectSupportQueryData[keyof IntrospectSupportQueryData],
+  fieldName: string
+): boolean => !!data && !!data.fields && data.fields.some((field) => field.name === fieldName);
+
+const _supportsDeprecatedArgumentsArg = (
+  data: IntrospectSupportQueryData['field' | 'directive']
+): boolean => {
+  const argsField = data && data.fields && data.fields.find((field) => field.name === 'args');
+  return !!(
+    argsField &&
+    argsField.args &&
+    argsField.args.find((arg) => arg.name === 'includeDeprecated')
+  );
+};
+
+/** Evaluates data from a {@link makeIntrospectSupportQuery} result to {@link SupportedFeatures} */
+export const toSupportedFeatures = (data: IntrospectSupportQueryData): SupportedFeatures => ({
+  directiveIsRepeatable: _hasField(data.directive, 'isRepeatable'),
+  specifiedByURL: _hasField(data.type, 'specifiedByURL'),
+  inputValueDeprecation: _hasField(data.inputValue, 'isDeprecated'),
+  directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.directive),
+  fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.field),
+});
+
+let _introspectionQuery: DocumentNode | undefined;
+let _previousSupport: SupportedFeatures | undefined;
+/** Builds an introspection query as AST */
+export const makeIntrospectionQuery = (support: SupportedFeatures): DocumentNode => {
+  if (_introspectionQuery && _previousSupport === support) {
+    return _introspectionQuery;
+  } else {
+    return (_introspectionQuery = _makeIntrospectionQuery((_previousSupport = support)));
+  }
+};
+
+const _makeIntrospectionQuery = (support: SupportedFeatures): DocumentNode => ({
+  kind: Kind.DOCUMENT,
+  definitions: [
+    {
+      kind: Kind.OPERATION_DEFINITION,
+      name: { kind: Kind.NAME, value: 'IntrospectionQuery' },
+      operation: OperationTypeNode.QUERY,
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: '__schema' },
+            selectionSet: _makeSchemaSelection(support),
+          },
+        ],
+      },
+    } satisfies OperationDefinitionNode,
+
+    _makeSchemaFullTypeFragment(support),
+    _makeSchemaInputValueFragment(support),
+    _makeTypeRefFragment(),
+  ],
+});
+
+/** Builds a support matrix query resulting in {@link IntrospectSupportQueryData} results */
+export const makeIntrospectSupportQuery = (): DocumentNode => ({
+  kind: Kind.DOCUMENT,
+  definitions: [
+    {
+      kind: Kind.OPERATION_DEFINITION,
+      name: { kind: Kind.NAME, value: 'IntrospectSupportQuery' },
+      operation: OperationTypeNode.QUERY,
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'directive' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__Directive' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection({ includeArgs: true }),
+          },
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'field' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__Field' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection({ includeArgs: true }),
+          },
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'type' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__Type' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection({ includeArgs: false }),
+          },
+          {
+            kind: Kind.FIELD,
+            alias: { kind: Kind.NAME, value: 'inputValue' },
+            name: { kind: Kind.NAME, value: '__type' },
+            arguments: [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'name' },
+                value: { kind: Kind.STRING, value: '__InputValue' },
+              },
+            ],
+            selectionSet: _makeFieldNamesSelection({ includeArgs: false }),
+          },
+        ],
+      },
+    } satisfies OperationDefinitionNode,
+  ],
+});
+
+const _makeFieldNamesSelection = (options: { includeArgs: boolean }): SelectionSetNode => ({
+  kind: Kind.SELECTION_SET,
+  selections: [
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'fields' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+          ...(options.includeArgs
+            ? ([
+                {
+                  kind: Kind.FIELD,
+                  name: { kind: Kind.NAME, value: 'args' },
+                  selectionSet: {
+                    kind: Kind.SELECTION_SET,
+                    selections: [
+                      {
+                        kind: Kind.FIELD,
+                        name: { kind: Kind.NAME, value: 'name' },
+                      },
+                    ],
+                  },
+                },
+              ] as const)
+            : []),
+        ],
+      },
+    },
+  ],
+});
+
+const _makeSchemaSelection = (support: SupportedFeatures): SelectionSetNode => ({
+  kind: Kind.SELECTION_SET,
+  selections: [
+    // queryType { name }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'queryType' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+    // mutationType { name }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'mutationType' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+    // subscriptionType { name }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'subscriptionType' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+      },
+    },
+    // types { ...FullType }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'types' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FRAGMENT_SPREAD,
+            name: { kind: Kind.NAME, value: 'FullType' },
+          },
+        ],
+      },
+    },
+    // directives { name description locations args }
+    {
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: 'directives' },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'description' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'locations' },
+          },
+          _makeSchemaArgsField(support.directiveArgumentsIsDeprecated),
+          ...(support.directiveIsRepeatable
+            ? ([
+                {
+                  kind: Kind.FIELD,
+                  name: { kind: Kind.NAME, value: 'isRepeatable' },
+                },
+              ] as const)
+            : []),
+        ],
+      },
+    },
+  ],
+});
+
+const _makeSchemaFullTypeFragment = (support: SupportedFeatures): FragmentDefinitionNode => ({
+  kind: Kind.FRAGMENT_DEFINITION,
+  name: { kind: Kind.NAME, value: 'FullType' },
+  typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: '__Type' } },
+  selectionSet: {
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'kind' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'name' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'description' },
+      },
+      ...(support.specifiedByURL
+        ? ([
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'specifiedByURL' },
+            },
+          ] as const)
+        : []),
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'fields' },
+        arguments: [
+          {
+            kind: Kind.ARGUMENT,
+            name: { kind: Kind.NAME, value: 'includeDeprecated' },
+            value: { kind: Kind.BOOLEAN, value: true },
+          },
+        ],
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'name' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'description' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'isDeprecated' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'deprecationReason' },
+            },
+            _makeSchemaArgsField(support.fieldArgumentsIsDeprecated),
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'type' },
+              selectionSet: {
+                kind: Kind.SELECTION_SET,
+                selections: [
+                  {
+                    kind: Kind.FRAGMENT_SPREAD,
+                    name: { kind: Kind.NAME, value: 'TypeRef' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'interfaces' },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'TypeRef' },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'possibleTypes' },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'TypeRef' },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'inputFields' },
+        arguments: support.inputValueDeprecation
+          ? [
+              {
+                kind: Kind.ARGUMENT,
+                name: { kind: Kind.NAME, value: 'includeDeprecated' },
+                value: { kind: Kind.BOOLEAN, value: true },
+              },
+            ]
+          : [],
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'InputValue' },
+            },
+          ],
+        },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'enumValues' },
+        arguments: [
+          {
+            kind: Kind.ARGUMENT,
+            name: { kind: Kind.NAME, value: 'includeDeprecated' },
+            value: { kind: Kind.BOOLEAN, value: true },
+          },
+        ],
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+
+          selections: [
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'name' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'description' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'isDeprecated' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'deprecationReason' },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+const _makeSchemaArgsField = (supportsValueDeprecation: boolean): FieldNode => ({
+  kind: Kind.FIELD,
+  name: { kind: Kind.NAME, value: 'args' },
+  arguments: supportsValueDeprecation
+    ? [
+        {
+          kind: Kind.ARGUMENT,
+          name: { kind: Kind.NAME, value: 'includeDeprecated' },
+          value: { kind: Kind.BOOLEAN, value: true },
+        },
+      ]
+    : [],
+  selectionSet: {
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FRAGMENT_SPREAD,
+        name: { kind: Kind.NAME, value: 'InputValue' },
+      },
+    ],
+  },
+});
+
+const _makeSchemaInputValueFragment = (support: SupportedFeatures): FragmentDefinitionNode => ({
+  kind: Kind.FRAGMENT_DEFINITION,
+  name: { kind: Kind.NAME, value: 'InputValue' },
+  typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: '__InputValue' } },
+  selectionSet: {
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'name' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'description' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'defaultValue' },
+      },
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'type' },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            {
+              kind: Kind.FRAGMENT_SPREAD,
+              name: { kind: Kind.NAME, value: 'TypeRef' },
+            },
+          ],
+        },
+      },
+      ...(support.inputValueDeprecation
+        ? ([
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'isDeprecated' },
+            },
+            {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: 'deprecationReason' },
+            },
+          ] as const)
+        : []),
+    ],
+  },
+});
+
+const _makeTypeRefFragment = (): FragmentDefinitionNode => ({
+  kind: Kind.FRAGMENT_DEFINITION,
+  name: { kind: Kind.NAME, value: 'TypeRef' },
+  typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: '__Type' } },
+  selectionSet: _makeTypeRefSelection(0),
+});
+
+const _makeTypeRefSelection = (depth: number): SelectionSetNode => ({
+  kind: Kind.SELECTION_SET,
+  selections:
+    depth < 9
+      ? [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'kind' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'ofType' },
+            selectionSet: _makeTypeRefSelection(depth + 1),
+          },
+        ]
+      : [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'kind' },
+          },
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'name' },
+          },
+        ],
+});

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -4,8 +4,8 @@ import { CombinedError } from '@urql/core';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { makeIntrospectionQuery } from './query';
-import type { SupportedFeatures } from './query';
+import { makeIntrospectionQuery } from './introspection';
+import type { SupportedFeatures } from './introspection';
 
 import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
 

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -4,8 +4,7 @@ import { CombinedError } from '@urql/core';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { makeIntrospectionQuery } from './introspection';
-import type { SupportedFeatures } from './introspection';
+import { makeIntrospectionQuery, getPeerSupportedFeatures } from './introspection';
 
 import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
 
@@ -14,14 +13,6 @@ interface LoadFromSDLConfig {
   assumeValid?: boolean;
   file: string;
 }
-
-const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
-  directiveIsRepeatable: true,
-  specifiedByURL: true,
-  inputValueDeprecation: true,
-  directiveArgumentsIsDeprecated: true,
-  fieldArgumentsIsDeprecated: true,
-};
 
 export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
   const subscriptions = new Set<OnSchemaUpdate>();
@@ -49,7 +40,7 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
       };
     } else {
       const schema = buildSchema(data, { assumeValidSDL: !!config.assumeValid });
-      const query = makeIntrospectionQuery(ALL_SUPPORTED_FEATURES);
+      const query = makeIntrospectionQuery(getPeerSupportedFeatures());
       const queryResult = executeSync({ schema, document: query });
       if (queryResult.errors) {
         throw new CombinedError({ graphQLErrors: queryResult.errors as any[] });

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -7,9 +7,11 @@ import {
   makeIntrospectionQuery,
   makeIntrospectSupportQuery,
   toSupportedFeatures,
+  ALL_SUPPORTED_FEATURES,
+  NO_SUPPORTED_FEATURES,
 } from './introspection';
-import type { SupportedFeatures, IntrospectSupportQueryData } from './introspection';
 
+import type { SupportedFeatures, IntrospectSupportQueryData } from './introspection';
 import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
 
 interface LoadFromURLConfig {
@@ -18,22 +20,6 @@ interface LoadFromURLConfig {
   headers?: HeadersInit;
   interval?: number;
 }
-
-const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
-  directiveIsRepeatable: true,
-  specifiedByURL: true,
-  inputValueDeprecation: true,
-  directiveArgumentsIsDeprecated: true,
-  fieldArgumentsIsDeprecated: true,
-};
-
-const NO_SUPPORTED_FEATURES: SupportedFeatures = {
-  directiveIsRepeatable: false,
-  specifiedByURL: false,
-  inputValueDeprecation: false,
-  directiveArgumentsIsDeprecated: false,
-  fieldArgumentsIsDeprecated: false,
-};
 
 export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
   const interval = config.interval || 60_000;

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -3,8 +3,12 @@ import { buildClientSchema } from 'graphql';
 import { Client, fetchExchange } from '@urql/core';
 import { retryExchange } from '@urql/exchange-retry';
 
-import { makeIntrospectionQuery, makeIntrospectSupportQuery, toSupportedFeatures } from './query';
-import type { SupportedFeatures, IntrospectSupportQueryData } from './query';
+import {
+  makeIntrospectionQuery,
+  makeIntrospectSupportQuery,
+  toSupportedFeatures,
+} from './introspection';
+import type { SupportedFeatures, IntrospectSupportQueryData } from './introspection';
 
 import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.14(typescript@5.4.5)
       graphql:
-        specifier: ^16.8.1
+        specifier: ^15.5.0 || ^16.0.0 || ^17.0.0
         version: 16.8.1
       svelte2tsx:
         specifier: ^0.7.6


### PR DESCRIPTION
## Summary

While we had a strong preference for `graphql@15`, despite a peer dependency, we should open up support to variably accept v15 and — for the future — v17.

This PR adds a `peerDependencies` entry for `graphql` to `@gql.tada/cli-utils`, while also preserving it as a direct dependency. This also widens the `peerDependencies.graphql` entry on `@gql.tada/internal`.

To support the widened range of `graphql` packages, the introspection support queries have been expanded to also run on local `graphql` installations for SDL-loaders.

## Set of changes

- Add local support introspection to SDL loader
- Widen peer dependency on `graphql`
