### PR TITLE
feat(tada): add isOneOf to the introspection type and support query

### DIFF
--- a/.changeset/cuddly-beers-hug.md
+++ b/.changeset/cuddly-beers-hug.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": minor
+---
+
+Add support for querying `isOneOf` in the introspection

--- a/.changeset/thirty-moose-brake.md
+++ b/.changeset/thirty-moose-brake.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": minor
+---
+
+Add support for `oneOf` input objects as specified in [the RFC](https://github.com/graphql/graphql-spec/pull/825)

--- a/packages/internal/src/introspection/minify.ts
+++ b/packages/internal/src/introspection/minify.ts
@@ -21,7 +21,7 @@ function mapTypeRef(fromType: IntrospectionTypeRef): IntrospectionTypeRef;
 function mapTypeRef(fromType: IntrospectionOutputTypeRef): IntrospectionOutputTypeRef;
 function mapTypeRef(fromType: IntrospectionInputTypeRef): IntrospectionInputTypeRef;
 
-function mapTypeRef(fromType: IntrospectionTypeRef): IntrospectionTypeRef {
+function mapTypeRef(fromType: IntrospectionTypeRef): IntrospectionTypeRef & { isOneOf?: boolean } {
   switch (fromType.kind) {
     case 'NON_NULL':
       return {
@@ -33,8 +33,8 @@ function mapTypeRef(fromType: IntrospectionTypeRef): IntrospectionTypeRef {
         kind: fromType.kind,
         ofType: mapTypeRef(fromType.ofType),
       };
-    case 'ENUM':
     case 'INPUT_OBJECT':
+    case 'ENUM':
     case 'SCALAR':
     case 'OBJECT':
     case 'INTERFACE':
@@ -99,7 +99,8 @@ function minifyIntrospectionType(type: IntrospectionType): IntrospectionType {
         kind: 'INPUT_OBJECT',
         name: type.name,
         inputFields: type.inputFields.map(mapInputField),
-      };
+        isOneOf: (type as any).isOneOf || false,
+      } as IntrospectionType;
     }
 
     case 'OBJECT':

--- a/packages/internal/src/introspection/preprocess.ts
+++ b/packages/internal/src/introspection/preprocess.ts
@@ -62,7 +62,9 @@ export const printIntrospectionType = (type: IntrospectionType) => {
     return `{ name: ${printName(type.name)}; enumValues: ${values}; }`;
   } else if (type.kind === 'INPUT_OBJECT') {
     const fields = printInputFields(type.inputFields);
-    return `{ kind: 'INPUT_OBJECT'; name: ${printName(type.name)}; inputFields: ${fields}; }`;
+    return `{ kind: 'INPUT_OBJECT'; name: ${printName(type.name)}; isOneOf: ${
+      (type as any).isOneOf || false
+    }; inputFields: ${fields}; }`;
   } else if (type.kind === 'OBJECT') {
     const fields = printFields(type.fields);
     return `{ kind: 'OBJECT'; name: ${printName(type.name)}; fields: ${fields}; }`;

--- a/packages/internal/src/loaders/__tests__/introspection.test.ts
+++ b/packages/internal/src/loaders/__tests__/introspection.test.ts
@@ -18,7 +18,7 @@ describe('getPeerSupportedFeatures', () => {
         "fieldArgumentsIsDeprecated": true,
         "inputValueDeprecation": true,
         "specifiedByURL": true,
-        "typesIsOneOf": false,
+        "inputOneOf": false,
       }
     `);
   });
@@ -69,7 +69,7 @@ describe('toSupportedFeatures', () => {
       inputValueDeprecation: false,
       directiveArgumentsIsDeprecated: false,
       fieldArgumentsIsDeprecated: false,
-      typesIsOneOf: false,
+      inputOneOf: false,
     });
   });
 
@@ -146,7 +146,7 @@ describe('makeIntrospectionQuery', () => {
       inputValueDeprecation: true,
       directiveArgumentsIsDeprecated: true,
       fieldArgumentsIsDeprecated: true,
-      typesIsOneOf: true,
+      inputOneOf: true,
     };
 
     const output = print(makeIntrospectionQuery(support));
@@ -278,7 +278,7 @@ describe('makeIntrospectionQuery', () => {
       inputValueDeprecation: false,
       directiveArgumentsIsDeprecated: false,
       fieldArgumentsIsDeprecated: false,
-      typesIsOneOf: false,
+      inputOneOf: false,
     };
 
     const output = print(makeIntrospectionQuery(support));

--- a/packages/internal/src/loaders/__tests__/introspection.test.ts
+++ b/packages/internal/src/loaders/__tests__/introspection.test.ts
@@ -16,9 +16,9 @@ describe('getPeerSupportedFeatures', () => {
         "directiveArgumentsIsDeprecated": true,
         "directiveIsRepeatable": true,
         "fieldArgumentsIsDeprecated": true,
+        "inputOneOf": false,
         "inputValueDeprecation": true,
         "specifiedByURL": true,
-        "inputOneOf": false,
       }
     `);
   });

--- a/packages/internal/src/loaders/__tests__/introspection.test.ts
+++ b/packages/internal/src/loaders/__tests__/introspection.test.ts
@@ -18,6 +18,7 @@ describe('getPeerSupportedFeatures', () => {
         "fieldArgumentsIsDeprecated": true,
         "inputValueDeprecation": true,
         "specifiedByURL": true,
+        "typesIsOneOf": false,
       }
     `);
   });
@@ -68,6 +69,7 @@ describe('toSupportedFeatures', () => {
       inputValueDeprecation: false,
       directiveArgumentsIsDeprecated: false,
       fieldArgumentsIsDeprecated: false,
+      typesIsOneOf: false,
     });
   });
 
@@ -144,6 +146,7 @@ describe('makeIntrospectionQuery', () => {
       inputValueDeprecation: true,
       directiveArgumentsIsDeprecated: true,
       fieldArgumentsIsDeprecated: true,
+      typesIsOneOf: true,
     };
 
     const output = print(makeIntrospectionQuery(support));
@@ -183,6 +186,7 @@ describe('makeIntrospectionQuery', () => {
         kind
         name
         description
+        isOneOf
         specifiedByURL
         fields(includeDeprecated: true) {
           name
@@ -274,6 +278,7 @@ describe('makeIntrospectionQuery', () => {
       inputValueDeprecation: false,
       directiveArgumentsIsDeprecated: false,
       fieldArgumentsIsDeprecated: false,
+      typesIsOneOf: false,
     };
 
     const output = print(makeIntrospectionQuery(support));

--- a/packages/internal/src/loaders/introspection.ts
+++ b/packages/internal/src/loaders/introspection.ts
@@ -16,6 +16,7 @@ export interface SupportedFeatures {
   inputValueDeprecation: boolean;
   directiveArgumentsIsDeprecated: boolean;
   fieldArgumentsIsDeprecated: boolean;
+  typesIsOneOf: boolean;
 }
 
 /** Data from a {@link makeIntrospectSupportQuery} result */
@@ -48,6 +49,7 @@ export const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   inputValueDeprecation: true,
   directiveArgumentsIsDeprecated: true,
   fieldArgumentsIsDeprecated: true,
+  typesIsOneOf: true,
 };
 
 export const NO_SUPPORTED_FEATURES: SupportedFeatures = {
@@ -56,12 +58,14 @@ export const NO_SUPPORTED_FEATURES: SupportedFeatures = {
   inputValueDeprecation: false,
   directiveArgumentsIsDeprecated: false,
   fieldArgumentsIsDeprecated: false,
+  typesIsOneOf: false,
 };
 
 /** Evaluates data from a {@link makeIntrospectSupportQuery} result to {@link SupportedFeatures} */
 export const toSupportedFeatures = (data: IntrospectSupportQueryData): SupportedFeatures => ({
   directiveIsRepeatable: _hasField(data.directive, 'isRepeatable'),
   specifiedByURL: _hasField(data.type, 'specifiedByURL'),
+  typesIsOneOf: _hasField(data.type, 'isOneOf'),
   inputValueDeprecation: _hasField(data.inputValue, 'isDeprecated'),
   directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.directive),
   fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.field),
@@ -339,6 +343,9 @@ const _makeSchemaFullTypeFragment = (support: SupportedFeatures): FragmentDefini
         kind: Kind.FIELD,
         name: { kind: Kind.NAME, value: 'description' },
       },
+      ...(support.typesIsOneOf
+        ? ([{ kind: Kind.FIELD, name: { kind: Kind.NAME, value: 'isOneOf' } }] as const)
+        : []),
       ...(support.specifiedByURL
         ? ([
             {

--- a/packages/internal/src/loaders/introspection.ts
+++ b/packages/internal/src/loaders/introspection.ts
@@ -16,7 +16,7 @@ export interface SupportedFeatures {
   inputValueDeprecation: boolean;
   directiveArgumentsIsDeprecated: boolean;
   fieldArgumentsIsDeprecated: boolean;
-  typesIsOneOf: boolean;
+  inputOneOf: boolean;
 }
 
 /** Data from a {@link makeIntrospectSupportQuery} result */
@@ -49,7 +49,7 @@ export const ALL_SUPPORTED_FEATURES: SupportedFeatures = {
   inputValueDeprecation: true,
   directiveArgumentsIsDeprecated: true,
   fieldArgumentsIsDeprecated: true,
-  typesIsOneOf: true,
+  inputOneOf: true,
 };
 
 export const NO_SUPPORTED_FEATURES: SupportedFeatures = {
@@ -58,14 +58,14 @@ export const NO_SUPPORTED_FEATURES: SupportedFeatures = {
   inputValueDeprecation: false,
   directiveArgumentsIsDeprecated: false,
   fieldArgumentsIsDeprecated: false,
-  typesIsOneOf: false,
+  inputOneOf: false,
 };
 
 /** Evaluates data from a {@link makeIntrospectSupportQuery} result to {@link SupportedFeatures} */
 export const toSupportedFeatures = (data: IntrospectSupportQueryData): SupportedFeatures => ({
   directiveIsRepeatable: _hasField(data.directive, 'isRepeatable'),
   specifiedByURL: _hasField(data.type, 'specifiedByURL'),
-  typesIsOneOf: _hasField(data.type, 'isOneOf'),
+  inputOneOf: _hasField(data.type, 'isOneOf'),
   inputValueDeprecation: _hasField(data.inputValue, 'isDeprecated'),
   directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.directive),
   fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.field),
@@ -343,7 +343,7 @@ const _makeSchemaFullTypeFragment = (support: SupportedFeatures): FragmentDefini
         kind: Kind.FIELD,
         name: { kind: Kind.NAME, value: 'description' },
       },
-      ...(support.typesIsOneOf
+      ...(support.inputOneOf
         ? ([{ kind: Kind.FIELD, name: { kind: Kind.NAME, value: 'isOneOf' } }] as const)
         : []),
       ...(support.specifiedByURL

--- a/packages/internal/src/loaders/query.ts
+++ b/packages/internal/src/loaders/query.ts
@@ -15,6 +15,7 @@ export interface SupportedFeatures {
   inputValueDeprecation: boolean;
   directiveArgumentsIsDeprecated: boolean;
   fieldArgumentsIsDeprecated: boolean;
+  typesIsOneOf: boolean;
 }
 
 /** Data from a {@link makeIntrospectSupportQuery} result */
@@ -48,6 +49,7 @@ export const toSupportedFeatures = (data: IntrospectSupportQueryData): Supported
   inputValueDeprecation: _hasField(data.inputValue, 'isDeprecated'),
   directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.directive),
   fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.field),
+  typesIsOneOf: _hasField(data.type, 'isOneOf'),
 });
 
 let _introspectionQuery: DocumentNode | undefined;

--- a/packages/internal/src/loaders/query.ts
+++ b/packages/internal/src/loaders/query.ts
@@ -15,7 +15,7 @@ export interface SupportedFeatures {
   inputValueDeprecation: boolean;
   directiveArgumentsIsDeprecated: boolean;
   fieldArgumentsIsDeprecated: boolean;
-  typesIsOneOf: boolean;
+  inputOneOf: boolean;
 }
 
 /** Data from a {@link makeIntrospectSupportQuery} result */
@@ -49,7 +49,7 @@ export const toSupportedFeatures = (data: IntrospectSupportQueryData): Supported
   inputValueDeprecation: _hasField(data.inputValue, 'isDeprecated'),
   directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.directive),
   fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.field),
-  typesIsOneOf: _hasField(data.type, 'isOneOf'),
+  inputOneOf: _hasField(data.type, 'isOneOf'),
 });
 
 let _introspectionQuery: DocumentNode | undefined;

--- a/src/__tests__/fixtures/simpleIntrospection.json
+++ b/src/__tests__/fixtures/simpleIntrospection.json
@@ -76,12 +76,9 @@
           {
             "name": "value_2",
             "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             }
           }
         ],

--- a/src/__tests__/fixtures/simpleIntrospection.json
+++ b/src/__tests__/fixtures/simpleIntrospection.json
@@ -56,6 +56,41 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "OneOfPayload",
+        "fields": null,
+        "isOneOf": true,
+        "inputFields": [
+          {
+            "name": "value_1",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "value_2",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "DefaultPayload",
         "fields": null,
         "inputFields": [

--- a/src/__tests__/fixtures/simpleIntrospection.ts
+++ b/src/__tests__/fixtures/simpleIntrospection.ts
@@ -1,639 +1,639 @@
 export type simpleIntrospection = {
-  name: 'simpleSchema',
+  name: 'simpleSchema';
   __schema: {
     queryType: {
-      name: 'Query',
-    },
+      name: 'Query';
+    };
     mutationType: {
-      name: 'Mutation',
-    },
+      name: 'Mutation';
+    };
     subscriptionType: {
-      name: 'Subscription',
-    },
+      name: 'Subscription';
+    };
     types: [
       {
-        kind: 'INPUT_OBJECT',
-        name: 'TodoPayload',
-        fields: null,
+        kind: 'INPUT_OBJECT';
+        name: 'TodoPayload';
+        fields: null;
         inputFields: [
           {
-            name: 'title',
+            name: 'title';
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            defaultValue: null,
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
           },
           {
-            name: 'description',
+            name: 'description';
             type: {
-              kind: 'NON_NULL',
+              kind: 'NON_NULL';
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'complete',
+            name: 'complete';
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
-            defaultValue: null,
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+            defaultValue: null;
           },
-        ],
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        interfaces: null;
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'INPUT_OBJECT',
-        name: 'DefaultPayload',
-        fields: null,
+        kind: 'INPUT_OBJECT';
+        name: 'DefaultPayload';
+        fields: null;
         inputFields: [
           {
-            name: 'value',
+            name: 'value';
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            defaultValue: 'DEFAULT',
-          }
-        ],
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: 'DEFAULT';
+          },
+        ];
+        interfaces: null;
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'OBJECT',
-        name: 'Query',
+        kind: 'OBJECT';
+        name: 'Query';
         fields: [
           {
-            name: 'todos',
-            args: [],
+            name: 'todos';
+            args: [];
             type: {
-              kind: 'LIST',
-              name: null,
+              kind: 'LIST';
+              name: null;
               ofType: {
-                kind: 'OBJECT',
-                name: 'Todo',
-                ofType: null,
-              },
-            },
+                kind: 'OBJECT';
+                name: 'Todo';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'test',
-            args: [],
+            name: 'test';
+            args: [];
             type: {
-              kind: 'UNION',
-              name: 'Search',
-              ofType: null,
-            },
+              kind: 'UNION';
+              name: 'Search';
+              ofType: null;
+            };
           },
           {
-            name: 'latestTodo',
-            args: [],
+            name: 'latestTodo';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'UNION',
-                name: 'LatestTodoResult',
-                ofType: null,
-              },
-            },
+                kind: 'UNION';
+                name: 'LatestTodoResult';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'itodo',
-            args: [],
+            name: 'itodo';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'INTERFACE',
-                name: 'ITodo',
-                ofType: null,
-              },
-            },
+                kind: 'INTERFACE';
+                name: 'ITodo';
+                ofType: null;
+              };
+            };
           },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        inputFields: null;
+        interfaces: [];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        name: 'LatestTodoResult',
-        kind: 'UNION',
-        args: [],
+        name: 'LatestTodoResult';
+        kind: 'UNION';
+        args: [];
         possibleTypes: [
           {
-            kind: 'OBJECT',
-            name: 'Todo',
-            ofType: null,
+            kind: 'OBJECT';
+            name: 'Todo';
+            ofType: null;
           },
           {
-            kind: 'OBJECT',
-            name: 'NoTodosError',
-            ofType: null,
+            kind: 'OBJECT';
+            name: 'NoTodosError';
+            ofType: null;
           },
-        ],
+        ];
       },
       {
-        kind: 'OBJECT',
-        name: 'NoTodosError',
-        interfaces: [],
+        kind: 'OBJECT';
+        name: 'NoTodosError';
+        interfaces: [];
         fields: [
           {
-            name: 'message',
-            args: [],
+            name: 'message';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
-        ],
+        ];
       },
       {
-        kind: 'OBJECT',
-        name: 'Todo',
+        kind: 'OBJECT';
+        name: 'Todo';
         fields: [
           {
-            name: 'id',
-            args: [],
+            name: 'id';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'text',
-            args: [],
+            name: 'text';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'complete',
-            args: [],
+            name: 'complete';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
           },
           {
-            name: 'test',
-            args: [],
+            name: 'test';
+            args: [];
             type: {
-              kind: 'ENUM',
-              name: 'test',
-              ofType: null,
-            },
+              kind: 'ENUM';
+              name: 'test';
+              ofType: null;
+            };
           },
           {
-            name: 'author',
-            args: [],
+            name: 'author';
+            args: [];
             type: {
-              kind: 'OBJECT',
-              name: 'Author',
-              ofType: null,
-            },
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        inputFields: null;
+        interfaces: [];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'SCALAR',
-        name: 'ID',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+        kind: 'SCALAR';
+        name: 'ID';
+        fields: null;
+        inputFields: null;
+        interfaces: null;
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'SCALAR',
-        name: 'String',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+        kind: 'SCALAR';
+        name: 'String';
+        fields: null;
+        inputFields: null;
+        interfaces: null;
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'SCALAR',
-        name: 'Boolean',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+        kind: 'SCALAR';
+        name: 'Boolean';
+        fields: null;
+        inputFields: null;
+        interfaces: null;
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'OBJECT',
-        name: 'Author',
+        kind: 'OBJECT';
+        name: 'Author';
         fields: [
           {
-            name: 'id',
-            args: [],
+            name: 'id';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'name',
-            args: [],
+            name: 'name';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'known',
-            args: [],
+            name: 'known';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        inputFields: null;
+        interfaces: [];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'OBJECT',
-        name: 'Mutation',
+        kind: 'OBJECT';
+        name: 'Mutation';
         fields: [
           {
-            name: 'updateTodo',
+            name: 'updateTodo';
             args: [
               {
-                name: 'id',
+                name: 'id';
                 type: {
-                  kind: 'NON_NULL',
-                  name: null,
+                  kind: 'NON_NULL';
+                  name: null;
                   ofType: {
-                    kind: 'SCALAR',
-                    name: 'ID',
-                    ofType: null,
-                  },
-                },
-                defaultValue: null,
+                    kind: 'SCALAR';
+                    name: 'ID';
+                    ofType: null;
+                  };
+                };
+                defaultValue: null;
               },
               {
-                name: 'input',
+                name: 'input';
                 type: {
-                  kind: 'NON_NULL',
-                  name: null,
+                  kind: 'NON_NULL';
+                  name: null;
                   ofType: {
-                    kind: 'INPUT_OBJECT',
-                    name: 'TodoPayload',
-                    ofType: null,
-                  },
-                },
-                defaultValue: null,
+                    kind: 'INPUT_OBJECT';
+                    name: 'TodoPayload';
+                    ofType: null;
+                  };
+                };
+                defaultValue: null;
               },
-            ],
+            ];
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
           },
           {
-            name: 'toggleTodo',
+            name: 'toggleTodo';
             args: [
               {
-                name: 'id',
+                name: 'id';
                 type: {
-                  kind: 'NON_NULL',
-                  name: null,
+                  kind: 'NON_NULL';
+                  name: null;
                   ofType: {
-                    kind: 'SCALAR',
-                    name: 'ID',
-                    ofType: null,
-                  },
-                },
+                    kind: 'SCALAR';
+                    name: 'ID';
+                    ofType: null;
+                  };
+                };
               },
-            ],
+            ];
             type: {
-              kind: 'OBJECT',
-              name: 'Todo',
-              ofType: null,
-            },
+              kind: 'OBJECT';
+              name: 'Todo';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        inputFields: null;
+        interfaces: [];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'OBJECT',
-        name: 'Subscription',
+        kind: 'OBJECT';
+        name: 'Subscription';
         fields: [
           {
-            name: 'newTodo',
-            args: [],
+            name: 'newTodo';
+            args: [];
             type: {
-              kind: 'OBJECT',
-              name: 'Todo',
-              ofType: null,
-            },
+              kind: 'OBJECT';
+              name: 'Todo';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        inputFields: null;
+        interfaces: [];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'ENUM',
-        name: 'test',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: [{ name: 'value' }, { name: 'more' }],
+        kind: 'ENUM';
+        name: 'test';
+        fields: null;
+        inputFields: null;
+        interfaces: null;
+        enumValues: [{ name: 'value' }, { name: 'more' }];
       },
       {
-        kind: 'INTERFACE',
-        name: 'ITodo',
+        kind: 'INTERFACE';
+        name: 'ITodo';
         fields: [
           {
-            name: 'id',
-            args: [],
+            name: 'id';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'text',
-            args: [],
+            name: 'text';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'complete',
-            args: [],
+            name: 'complete';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
           },
           {
-            name: 'author',
-            args: [],
+            name: 'author';
+            args: [];
             type: {
-              kind: 'OBJECT',
-              name: 'Author',
-              ofType: null,
-            },
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
+        ];
+        inputFields: null;
+        interfaces: null;
+        enumValues: null;
         possibleTypes: [
           {
-            kind: 'OBJECT',
-            name: 'BigTodo',
-            ofType: null,
+            kind: 'OBJECT';
+            name: 'BigTodo';
+            ofType: null;
           },
           {
-            kind: 'OBJECT',
-            name: 'SmallTodo',
-            ofType: null,
+            kind: 'OBJECT';
+            name: 'SmallTodo';
+            ofType: null;
           },
-        ],
+        ];
       },
       {
-        kind: 'OBJECT',
-        name: 'BigTodo',
+        kind: 'OBJECT';
+        name: 'BigTodo';
         fields: [
           {
-            name: 'id',
-            args: [],
+            name: 'id';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'text',
-            args: [],
+            name: 'text';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'complete',
-            args: [],
+            name: 'complete';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
           },
           {
-            name: 'author',
-            args: [],
+            name: 'author';
+            args: [];
             type: {
-              kind: 'OBJECT',
-              name: 'Author',
-              ofType: null,
-            },
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
           },
           {
-            name: 'wallOfText',
-            args: [],
+            name: 'wallOfText';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
+        ];
+        inputFields: null;
         interfaces: [
           {
-            kind: 'INTERFACE',
-            name: 'ITodo',
-            ofType: null,
+            kind: 'INTERFACE';
+            name: 'ITodo';
+            ofType: null;
           },
-        ],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'OBJECT',
-        name: 'SmallTodo',
+        kind: 'OBJECT';
+        name: 'SmallTodo';
         fields: [
           {
-            name: 'id',
-            args: [],
+            name: 'id';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'text',
-            args: [],
+            name: 'text';
+            args: [];
             type: {
-              kind: 'NON_NULL',
-              name: null,
+              kind: 'NON_NULL';
+              name: null;
               ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           },
           {
-            name: 'complete',
-            args: [],
+            name: 'complete';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'Boolean',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
           },
           {
-            name: 'author',
-            args: [],
+            name: 'author';
+            args: [];
             type: {
-              kind: 'OBJECT',
-              name: 'Author',
-              ofType: null,
-            },
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
           },
           {
-            name: 'maxLength',
-            args: [],
+            name: 'maxLength';
+            args: [];
             type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
-            },
+              kind: 'SCALAR';
+              name: 'Int';
+              ofType: null;
+            };
           },
-        ],
-        inputFields: null,
+        ];
+        inputFields: null;
         interfaces: [
           {
-            kind: 'INTERFACE',
-            name: 'ITodo',
-            ofType: null,
+            kind: 'INTERFACE';
+            name: 'ITodo';
+            ofType: null;
           },
-        ],
-        enumValues: null,
-        possibleTypes: null,
+        ];
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'SCALAR',
-        name: 'Int',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+        kind: 'SCALAR';
+        name: 'Int';
+        fields: null;
+        inputFields: null;
+        interfaces: null;
+        enumValues: null;
+        possibleTypes: null;
       },
       {
-        kind: 'UNION',
-        name: 'Search',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
+        kind: 'UNION';
+        name: 'Search';
+        fields: null;
+        inputFields: null;
+        interfaces: null;
+        enumValues: null;
         possibleTypes: [
           {
-            kind: 'OBJECT',
-            name: 'SmallTodo',
-            ofType: null,
+            kind: 'OBJECT';
+            name: 'SmallTodo';
+            ofType: null;
           },
           {
-            kind: 'OBJECT',
-            name: 'BigTodo',
-            ofType: null,
+            kind: 'OBJECT';
+            name: 'BigTodo';
+            ofType: null;
           },
-        ],
+        ];
       },
-    ],
-  },
+    ];
+  };
 };

--- a/src/__tests__/fixtures/simpleIntrospection.ts
+++ b/src/__tests__/fixtures/simpleIntrospection.ts
@@ -1,639 +1,639 @@
 export type simpleIntrospection = {
-  name: 'simpleSchema';
+  name: 'simpleSchema',
   __schema: {
     queryType: {
-      name: 'Query';
-    };
+      name: 'Query',
+    },
     mutationType: {
-      name: 'Mutation';
-    };
+      name: 'Mutation',
+    },
     subscriptionType: {
-      name: 'Subscription';
-    };
+      name: 'Subscription',
+    },
     types: [
       {
-        kind: 'INPUT_OBJECT';
-        name: 'TodoPayload';
-        fields: null;
+        kind: 'INPUT_OBJECT',
+        name: 'TodoPayload',
+        fields: null,
         inputFields: [
           {
-            name: 'title';
+            name: 'title',
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: null;
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            defaultValue: null,
           },
           {
-            name: 'description';
+            name: 'description',
             type: {
-              kind: 'NON_NULL';
+              kind: 'NON_NULL',
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'complete';
+            name: 'complete',
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
-            defaultValue: null;
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
+            defaultValue: null,
           },
-        ];
-        interfaces: null;
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'INPUT_OBJECT';
-        name: 'DefaultPayload';
-        fields: null;
+        kind: 'INPUT_OBJECT',
+        name: 'DefaultPayload',
+        fields: null,
         inputFields: [
           {
-            name: 'value';
+            name: 'value',
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: 'DEFAULT';
-          },
-        ];
-        interfaces: null;
-        enumValues: null;
-        possibleTypes: null;
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            defaultValue: 'DEFAULT',
+          }
+        ],
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'OBJECT';
-        name: 'Query';
+        kind: 'OBJECT',
+        name: 'Query',
         fields: [
           {
-            name: 'todos';
-            args: [];
+            name: 'todos',
+            args: [],
             type: {
-              kind: 'LIST';
-              name: null;
+              kind: 'LIST',
+              name: null,
               ofType: {
-                kind: 'OBJECT';
-                name: 'Todo';
-                ofType: null;
-              };
-            };
+                kind: 'OBJECT',
+                name: 'Todo',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'test';
-            args: [];
+            name: 'test',
+            args: [],
             type: {
-              kind: 'UNION';
-              name: 'Search';
-              ofType: null;
-            };
+              kind: 'UNION',
+              name: 'Search',
+              ofType: null,
+            },
           },
           {
-            name: 'latestTodo';
-            args: [];
+            name: 'latestTodo',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'UNION';
-                name: 'LatestTodoResult';
-                ofType: null;
-              };
-            };
+                kind: 'UNION',
+                name: 'LatestTodoResult',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'itodo';
-            args: [];
+            name: 'itodo',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'INTERFACE';
-                name: 'ITodo';
-                ofType: null;
-              };
-            };
+                kind: 'INTERFACE',
+                name: 'ITodo',
+                ofType: null,
+              },
+            },
           },
-        ];
-        inputFields: null;
-        interfaces: [];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        inputFields: null,
+        interfaces: [],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        name: 'LatestTodoResult';
-        kind: 'UNION';
-        args: [];
+        name: 'LatestTodoResult',
+        kind: 'UNION',
+        args: [],
         possibleTypes: [
           {
-            kind: 'OBJECT';
-            name: 'Todo';
-            ofType: null;
+            kind: 'OBJECT',
+            name: 'Todo',
+            ofType: null,
           },
           {
-            kind: 'OBJECT';
-            name: 'NoTodosError';
-            ofType: null;
+            kind: 'OBJECT',
+            name: 'NoTodosError',
+            ofType: null,
           },
-        ];
+        ],
       },
       {
-        kind: 'OBJECT';
-        name: 'NoTodosError';
-        interfaces: [];
+        kind: 'OBJECT',
+        name: 'NoTodosError',
+        interfaces: [],
         fields: [
           {
-            name: 'message';
-            args: [];
+            name: 'message',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
-        ];
+        ],
       },
       {
-        kind: 'OBJECT';
-        name: 'Todo';
+        kind: 'OBJECT',
+        name: 'Todo',
         fields: [
           {
-            name: 'id';
-            args: [];
+            name: 'id',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'ID',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'text';
-            args: [];
+            name: 'text',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'complete';
-            args: [];
+            name: 'complete',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
           },
           {
-            name: 'test';
-            args: [];
+            name: 'test',
+            args: [],
             type: {
-              kind: 'ENUM';
-              name: 'test';
-              ofType: null;
-            };
+              kind: 'ENUM',
+              name: 'test',
+              ofType: null,
+            },
           },
           {
-            name: 'author';
-            args: [];
+            name: 'author',
+            args: [],
             type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
+              kind: 'OBJECT',
+              name: 'Author',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
-        interfaces: [];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        inputFields: null,
+        interfaces: [],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'SCALAR';
-        name: 'ID';
-        fields: null;
-        inputFields: null;
-        interfaces: null;
-        enumValues: null;
-        possibleTypes: null;
+        kind: 'SCALAR',
+        name: 'ID',
+        fields: null,
+        inputFields: null,
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'SCALAR';
-        name: 'String';
-        fields: null;
-        inputFields: null;
-        interfaces: null;
-        enumValues: null;
-        possibleTypes: null;
+        kind: 'SCALAR',
+        name: 'String',
+        fields: null,
+        inputFields: null,
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'SCALAR';
-        name: 'Boolean';
-        fields: null;
-        inputFields: null;
-        interfaces: null;
-        enumValues: null;
-        possibleTypes: null;
+        kind: 'SCALAR',
+        name: 'Boolean',
+        fields: null,
+        inputFields: null,
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'OBJECT';
-        name: 'Author';
+        kind: 'OBJECT',
+        name: 'Author',
         fields: [
           {
-            name: 'id';
-            args: [];
+            name: 'id',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'ID',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'name';
-            args: [];
+            name: 'name',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'known';
-            args: [];
+            name: 'known',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
-        interfaces: [];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        inputFields: null,
+        interfaces: [],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'OBJECT';
-        name: 'Mutation';
+        kind: 'OBJECT',
+        name: 'Mutation',
         fields: [
           {
-            name: 'updateTodo';
+            name: 'updateTodo',
             args: [
               {
-                name: 'id';
+                name: 'id',
                 type: {
-                  kind: 'NON_NULL';
-                  name: null;
+                  kind: 'NON_NULL',
+                  name: null,
                   ofType: {
-                    kind: 'SCALAR';
-                    name: 'ID';
-                    ofType: null;
-                  };
-                };
-                defaultValue: null;
+                    kind: 'SCALAR',
+                    name: 'ID',
+                    ofType: null,
+                  },
+                },
+                defaultValue: null,
               },
               {
-                name: 'input';
+                name: 'input',
                 type: {
-                  kind: 'NON_NULL';
-                  name: null;
+                  kind: 'NON_NULL',
+                  name: null,
                   ofType: {
-                    kind: 'INPUT_OBJECT';
-                    name: 'TodoPayload';
-                    ofType: null;
-                  };
-                };
-                defaultValue: null;
+                    kind: 'INPUT_OBJECT',
+                    name: 'TodoPayload',
+                    ofType: null,
+                  },
+                },
+                defaultValue: null,
               },
-            ];
+            ],
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
           },
           {
-            name: 'toggleTodo';
+            name: 'toggleTodo',
             args: [
               {
-                name: 'id';
+                name: 'id',
                 type: {
-                  kind: 'NON_NULL';
-                  name: null;
+                  kind: 'NON_NULL',
+                  name: null,
                   ofType: {
-                    kind: 'SCALAR';
-                    name: 'ID';
-                    ofType: null;
-                  };
-                };
+                    kind: 'SCALAR',
+                    name: 'ID',
+                    ofType: null,
+                  },
+                },
               },
-            ];
+            ],
             type: {
-              kind: 'OBJECT';
-              name: 'Todo';
-              ofType: null;
-            };
+              kind: 'OBJECT',
+              name: 'Todo',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
-        interfaces: [];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        inputFields: null,
+        interfaces: [],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'OBJECT';
-        name: 'Subscription';
+        kind: 'OBJECT',
+        name: 'Subscription',
         fields: [
           {
-            name: 'newTodo';
-            args: [];
+            name: 'newTodo',
+            args: [],
             type: {
-              kind: 'OBJECT';
-              name: 'Todo';
-              ofType: null;
-            };
+              kind: 'OBJECT',
+              name: 'Todo',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
-        interfaces: [];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        inputFields: null,
+        interfaces: [],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'ENUM';
-        name: 'test';
-        fields: null;
-        inputFields: null;
-        interfaces: null;
-        enumValues: [{ name: 'value' }, { name: 'more' }];
+        kind: 'ENUM',
+        name: 'test',
+        fields: null,
+        inputFields: null,
+        interfaces: null,
+        enumValues: [{ name: 'value' }, { name: 'more' }],
       },
       {
-        kind: 'INTERFACE';
-        name: 'ITodo';
+        kind: 'INTERFACE',
+        name: 'ITodo',
         fields: [
           {
-            name: 'id';
-            args: [];
+            name: 'id',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'ID',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'text';
-            args: [];
+            name: 'text',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'complete';
-            args: [];
+            name: 'complete',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
           },
           {
-            name: 'author';
-            args: [];
+            name: 'author',
+            args: [],
             type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
+              kind: 'OBJECT',
+              name: 'Author',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
-        interfaces: null;
-        enumValues: null;
+        ],
+        inputFields: null,
+        interfaces: null,
+        enumValues: null,
         possibleTypes: [
           {
-            kind: 'OBJECT';
-            name: 'BigTodo';
-            ofType: null;
+            kind: 'OBJECT',
+            name: 'BigTodo',
+            ofType: null,
           },
           {
-            kind: 'OBJECT';
-            name: 'SmallTodo';
-            ofType: null;
+            kind: 'OBJECT',
+            name: 'SmallTodo',
+            ofType: null,
           },
-        ];
+        ],
       },
       {
-        kind: 'OBJECT';
-        name: 'BigTodo';
+        kind: 'OBJECT',
+        name: 'BigTodo',
         fields: [
           {
-            name: 'id';
-            args: [];
+            name: 'id',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'ID',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'text';
-            args: [];
+            name: 'text',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'complete';
-            args: [];
+            name: 'complete',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
           },
           {
-            name: 'author';
-            args: [];
+            name: 'author',
+            args: [],
             type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
+              kind: 'OBJECT',
+              name: 'Author',
+              ofType: null,
+            },
           },
           {
-            name: 'wallOfText';
-            args: [];
+            name: 'wallOfText',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'String',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
+        ],
+        inputFields: null,
         interfaces: [
           {
-            kind: 'INTERFACE';
-            name: 'ITodo';
-            ofType: null;
+            kind: 'INTERFACE',
+            name: 'ITodo',
+            ofType: null,
           },
-        ];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'OBJECT';
-        name: 'SmallTodo';
+        kind: 'OBJECT',
+        name: 'SmallTodo',
         fields: [
           {
-            name: 'id';
-            args: [];
+            name: 'id',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'ID',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'text';
-            args: [];
+            name: 'text',
+            args: [],
             type: {
-              kind: 'NON_NULL';
-              name: null;
+              kind: 'NON_NULL',
+              name: null,
               ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
           },
           {
-            name: 'complete';
-            args: [];
+            name: 'complete',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
+            },
           },
           {
-            name: 'author';
-            args: [];
+            name: 'author',
+            args: [],
             type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
+              kind: 'OBJECT',
+              name: 'Author',
+              ofType: null,
+            },
           },
           {
-            name: 'maxLength';
-            args: [];
+            name: 'maxLength',
+            args: [],
             type: {
-              kind: 'SCALAR';
-              name: 'Int';
-              ofType: null;
-            };
+              kind: 'SCALAR',
+              name: 'Int',
+              ofType: null,
+            },
           },
-        ];
-        inputFields: null;
+        ],
+        inputFields: null,
         interfaces: [
           {
-            kind: 'INTERFACE';
-            name: 'ITodo';
-            ofType: null;
+            kind: 'INTERFACE',
+            name: 'ITodo',
+            ofType: null,
           },
-        ];
-        enumValues: null;
-        possibleTypes: null;
+        ],
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'SCALAR';
-        name: 'Int';
-        fields: null;
-        inputFields: null;
-        interfaces: null;
-        enumValues: null;
-        possibleTypes: null;
+        kind: 'SCALAR',
+        name: 'Int',
+        fields: null,
+        inputFields: null,
+        interfaces: null,
+        enumValues: null,
+        possibleTypes: null,
       },
       {
-        kind: 'UNION';
-        name: 'Search';
-        fields: null;
-        inputFields: null;
-        interfaces: null;
-        enumValues: null;
+        kind: 'UNION',
+        name: 'Search',
+        fields: null,
+        inputFields: null,
+        interfaces: null,
+        enumValues: null,
         possibleTypes: [
           {
-            kind: 'OBJECT';
-            name: 'SmallTodo';
-            ofType: null;
+            kind: 'OBJECT',
+            name: 'SmallTodo',
+            ofType: null,
           },
           {
-            kind: 'OBJECT';
-            name: 'BigTodo';
-            ofType: null;
+            kind: 'OBJECT',
+            name: 'BigTodo',
+            ofType: null,
           },
-        ];
+        ],
       },
-    ];
-  };
+    ],
+  },
 };

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -1,95 +1,39 @@
-export type simpleSchema =
-  {
-    name: 'simpleSchema';
-    query: 'Query';
-    mutation: 'Mutation';
-    subscription: 'Subscription';
-    types: {
-      Author: {
-        kind: 'OBJECT';
-        name: 'Author';
-        fields: {
-          id: {
-            name: 'id';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
-          };
-          known: {
-            name: 'known';
-            type: {
+export type simpleSchema = {
+  name: 'simpleSchema';
+  query: 'Query';
+  mutation: 'Mutation';
+  subscription: 'Subscription';
+  types: {
+    Author: {
+      kind: 'OBJECT';
+      name: 'Author';
+      fields: {
+        id: {
+          name: 'id';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
               kind: 'SCALAR';
-              name: 'Boolean';
+              name: 'ID';
               ofType: null;
-            };
-          };
-          name: {
-            name: 'name';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
             };
           };
         };
-      };
-      BigTodo: {
-        kind: 'OBJECT';
-        name: 'BigTodo';
-        fields: {
-          author: {
-            name: 'author';
-            type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
+        known: {
+          name: 'known';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
           };
-          complete: {
-            name: 'complete';
-            type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
-          };
-          id: {
-            name: 'id';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
-          };
-          text: {
-            name: 'text';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-          };
-          wallOfText: {
-            name: 'wallOfText';
-            type: {
+        };
+        name: {
+          name: 'name';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
               kind: 'SCALAR';
               name: 'String';
               ofType: null;
@@ -97,387 +41,434 @@ export type simpleSchema =
           };
         };
       };
-      Boolean: unknown;
-      DefaultPayload: {
-        kind: 'INPUT_OBJECT';
-        name: 'DefaultPayload';
-        isOneOf: false;
-        inputFields: [
-          {
-            name: 'value';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: 'DEFAULT';
-          },
-        ];
-      };
-      ID: unknown;
-      ITodo: {
-        kind: 'INTERFACE';
-        name: 'ITodo';
-        fields: {
-          author: {
-            name: 'author';
-            type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
+    };
+    BigTodo: {
+      kind: 'OBJECT';
+      name: 'BigTodo';
+      fields: {
+        author: {
+          name: 'author';
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
           };
-          complete: {
-            name: 'complete';
-            type: {
+        };
+        complete: {
+          name: 'complete';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        };
+        id: {
+          name: 'id';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
               kind: 'SCALAR';
-              name: 'Boolean';
+              name: 'ID';
               ofType: null;
-            };
-          };
-          id: {
-            name: 'id';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
-          };
-          text: {
-            name: 'text';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
             };
           };
         };
-        possibleTypes:
-          | 'BigTodo'
-          | 'SmallTodo';
-      };
-      Int: unknown;
-      LatestTodoResult: {
-        kind: 'UNION';
-        name: 'LatestTodoResult';
-        fields: {};
-        possibleTypes:
-          | 'NoTodosError'
-          | 'Todo';
-      };
-      Mutation: {
-        kind: 'OBJECT';
-        name: 'Mutation';
-        fields: {
-          toggleTodo: {
-            name: 'toggleTodo';
-            type: {
-              kind: 'OBJECT';
-              name: 'Todo';
-              ofType: null;
-            };
-          };
-          updateTodo: {
-            name: 'updateTodo';
-            type: {
+        text: {
+          name: 'text';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
               kind: 'SCALAR';
-              name: 'Boolean';
+              name: 'String';
               ofType: null;
             };
           };
         };
-      };
-      NoTodosError: {
-        kind: 'OBJECT';
-        name: 'NoTodosError';
-        fields: {
-          message: {
-            name: 'message';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
+        wallOfText: {
+          name: 'wallOfText';
+          type: {
+            kind: 'SCALAR';
+            name: 'String';
+            ofType: null;
           };
         };
-      };
-      OneOfPayload: {
-        kind: 'INPUT_OBJECT';
-        name: 'OneOfPayload';
-        isOneOf: true;
-        inputFields: [
-          {
-            name: 'value_1';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: null;
-          },
-          {
-            name: 'value_2';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: null;
-          },
-        ];
-      };
-      Query: {
-        kind: 'OBJECT';
-        name: 'Query';
-        fields: {
-          itodo: {
-            name: 'itodo';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'INTERFACE';
-                name: 'ITodo';
-                ofType: null;
-              };
-            };
-          };
-          latestTodo: {
-            name: 'latestTodo';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'UNION';
-                name: 'LatestTodoResult';
-                ofType: null;
-              };
-            };
-          };
-          test: {
-            name: 'test';
-            type: {
-              kind: 'UNION';
-              name: 'Search';
-              ofType: null;
-            };
-          };
-          todos: {
-            name: 'todos';
-            type: {
-              kind: 'LIST';
-              name: never;
-              ofType: {
-                kind: 'OBJECT';
-                name: 'Todo';
-                ofType: null;
-              };
-            };
-          };
-        };
-      };
-      Search: {
-        kind: 'UNION';
-        name: 'Search';
-        fields: {};
-        possibleTypes:
-          | 'BigTodo'
-          | 'SmallTodo';
-      };
-      SmallTodo: {
-        kind: 'OBJECT';
-        name: 'SmallTodo';
-        fields: {
-          author: {
-            name: 'author';
-            type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
-          };
-          complete: {
-            name: 'complete';
-            type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
-          };
-          id: {
-            name: 'id';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
-          };
-          maxLength: {
-            name: 'maxLength';
-            type: {
-              kind: 'SCALAR';
-              name: 'Int';
-              ofType: null;
-            };
-          };
-          text: {
-            name: 'text';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-          };
-        };
-      };
-      String: unknown;
-      Subscription: {
-        kind: 'OBJECT';
-        name: 'Subscription';
-        fields: {
-          newTodo: {
-            name: 'newTodo';
-            type: {
-              kind: 'OBJECT';
-              name: 'Todo';
-              ofType: null;
-            };
-          };
-        };
-      };
-      Todo: {
-        kind: 'OBJECT';
-        name: 'Todo';
-        fields: {
-          author: {
-            name: 'author';
-            type: {
-              kind: 'OBJECT';
-              name: 'Author';
-              ofType: null;
-            };
-          };
-          complete: {
-            name: 'complete';
-            type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
-          };
-          id: {
-            name: 'id';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'ID';
-                ofType: null;
-              };
-            };
-          };
-          test: {
-            name: 'test';
-            type: {
-              kind: 'ENUM';
-              name: 'test';
-              ofType: null;
-            };
-          };
-          text: {
-            name: 'text';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-          };
-        };
-      };
-      TodoPayload: {
-        kind: 'INPUT_OBJECT';
-        name: 'TodoPayload';
-        isOneOf: false;
-        inputFields: [
-          {
-            name: 'title';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: null;
-          },
-          {
-            name: 'description';
-            type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
-            };
-            defaultValue: null;
-          },
-          {
-            name: 'complete';
-            type: {
-              kind: 'SCALAR';
-              name: 'Boolean';
-              ofType: null;
-            };
-            defaultValue: null;
-          },
-        ];
-      };
-      test: {
-        name: 'test';
-        enumValues:
-          | 'value'
-          | 'more';
       };
     };
+    Boolean: unknown;
+    DefaultPayload: {
+      kind: 'INPUT_OBJECT';
+      name: 'DefaultPayload';
+      isOneOf: false;
+      inputFields: [
+        {
+          name: 'value';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: 'DEFAULT';
+        },
+      ];
+    };
+    ID: unknown;
+    ITodo: {
+      kind: 'INTERFACE';
+      name: 'ITodo';
+      fields: {
+        author: {
+          name: 'author';
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        };
+        complete: {
+          name: 'complete';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        };
+        id: {
+          name: 'id';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        };
+        text: {
+          name: 'text';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        };
+      };
+      possibleTypes: 'BigTodo' | 'SmallTodo';
+    };
+    Int: unknown;
+    LatestTodoResult: {
+      kind: 'UNION';
+      name: 'LatestTodoResult';
+      fields: {};
+      possibleTypes: 'NoTodosError' | 'Todo';
+    };
+    Mutation: {
+      kind: 'OBJECT';
+      name: 'Mutation';
+      fields: {
+        toggleTodo: {
+          name: 'toggleTodo';
+          type: {
+            kind: 'OBJECT';
+            name: 'Todo';
+            ofType: null;
+          };
+        };
+        updateTodo: {
+          name: 'updateTodo';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        };
+      };
+    };
+    NoTodosError: {
+      kind: 'OBJECT';
+      name: 'NoTodosError';
+      fields: {
+        message: {
+          name: 'message';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        };
+      };
+    };
+    OneOfPayload: {
+      kind: 'INPUT_OBJECT';
+      name: 'OneOfPayload';
+      isOneOf: true;
+      inputFields: [
+        {
+          name: 'value_1';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: null;
+        },
+        {
+          name: 'value_2';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: null;
+        },
+      ];
+    };
+    Query: {
+      kind: 'OBJECT';
+      name: 'Query';
+      fields: {
+        itodo: {
+          name: 'itodo';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'INTERFACE';
+              name: 'ITodo';
+              ofType: null;
+            };
+          };
+        };
+        latestTodo: {
+          name: 'latestTodo';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'UNION';
+              name: 'LatestTodoResult';
+              ofType: null;
+            };
+          };
+        };
+        test: {
+          name: 'test';
+          type: {
+            kind: 'UNION';
+            name: 'Search';
+            ofType: null;
+          };
+        };
+        todos: {
+          name: 'todos';
+          type: {
+            kind: 'LIST';
+            name: never;
+            ofType: {
+              kind: 'OBJECT';
+              name: 'Todo';
+              ofType: null;
+            };
+          };
+        };
+      };
+    };
+    Search: {
+      kind: 'UNION';
+      name: 'Search';
+      fields: {};
+      possibleTypes: 'BigTodo' | 'SmallTodo';
+    };
+    SmallTodo: {
+      kind: 'OBJECT';
+      name: 'SmallTodo';
+      fields: {
+        author: {
+          name: 'author';
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        };
+        complete: {
+          name: 'complete';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        };
+        id: {
+          name: 'id';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        };
+        maxLength: {
+          name: 'maxLength';
+          type: {
+            kind: 'SCALAR';
+            name: 'Int';
+            ofType: null;
+          };
+        };
+        text: {
+          name: 'text';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        };
+      };
+    };
+    String: unknown;
+    Subscription: {
+      kind: 'OBJECT';
+      name: 'Subscription';
+      fields: {
+        newTodo: {
+          name: 'newTodo';
+          type: {
+            kind: 'OBJECT';
+            name: 'Todo';
+            ofType: null;
+          };
+        };
+      };
+    };
+    Todo: {
+      kind: 'OBJECT';
+      name: 'Todo';
+      fields: {
+        author: {
+          name: 'author';
+          type: {
+            kind: 'OBJECT';
+            name: 'Author';
+            ofType: null;
+          };
+        };
+        complete: {
+          name: 'complete';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+        };
+        id: {
+          name: 'id';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'ID';
+              ofType: null;
+            };
+          };
+        };
+        test: {
+          name: 'test';
+          type: {
+            kind: 'ENUM';
+            name: 'test';
+            ofType: null;
+          };
+        };
+        text: {
+          name: 'text';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+        };
+      };
+    };
+    TodoPayload: {
+      kind: 'INPUT_OBJECT';
+      name: 'TodoPayload';
+      isOneOf: false;
+      inputFields: [
+        {
+          name: 'title';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: null;
+        },
+        {
+          name: 'description';
+          type: {
+            kind: 'NON_NULL';
+            name: never;
+            ofType: {
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
+            };
+          };
+          defaultValue: null;
+        },
+        {
+          name: 'complete';
+          type: {
+            kind: 'SCALAR';
+            name: 'Boolean';
+            ofType: null;
+          };
+          defaultValue: null;
+        },
+      ];
+    };
+    test: {
+      name: 'test';
+      enumValues: 'value' | 'more';
+    };
   };
+};

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -1,39 +1,95 @@
-export type simpleSchema = {
-  name: 'simpleSchema';
-  query: 'Query';
-  mutation: 'Mutation';
-  subscription: 'Subscription';
-  types: {
-    Author: {
-      kind: 'OBJECT';
-      name: 'Author';
-      fields: {
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+export type simpleSchema =
+  {
+    name: 'simpleSchema';
+    query: 'Query';
+    mutation: 'Mutation';
+    subscription: 'Subscription';
+    types: {
+      Author: {
+        kind: 'OBJECT';
+        name: 'Author';
+        fields: {
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          known: {
+            name: 'known';
+            type: {
               kind: 'SCALAR';
-              name: 'ID';
+              name: 'Boolean';
               ofType: null;
             };
           };
-        };
-        known: {
-          name: 'known';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
+          name: {
+            name: 'name';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
           };
         };
-        name: {
-          name: 'name';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+      };
+      BigTodo: {
+        kind: 'OBJECT';
+        name: 'BigTodo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
+          };
+          complete: {
+            name: 'complete';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+          wallOfText: {
+            name: 'wallOfText';
+            type: {
               kind: 'SCALAR';
               name: 'String';
               ofType: null;
@@ -41,252 +97,279 @@ export type simpleSchema = {
           };
         };
       };
-    };
-    BigTodo: {
-      kind: 'OBJECT';
-      name: 'BigTodo';
-      fields: {
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
-              ofType: null;
+      Boolean: unknown;
+      DefaultPayload: {
+        kind: 'INPUT_OBJECT';
+        name: 'DefaultPayload';
+        isOneOf: false;
+        inputFields: [
+          {
+            name: 'value';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
             };
-          };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-        };
-        wallOfText: {
-          name: 'wallOfText';
-          type: {
-            kind: 'SCALAR';
-            name: 'String';
-            ofType: null;
-          };
-        };
+            defaultValue: 'DEFAULT';
+          },
+        ];
       };
-    };
-    Boolean: unknown;
-    DefaultPayload: {
-      kind: 'INPUT_OBJECT';
-      name: 'DefaultPayload';
-      isOneOf: false;
-      inputFields: [
-        {
-          name: 'value';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
+      ID: unknown;
+      ITodo: {
+        kind: 'INTERFACE';
+        name: 'ITodo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
               ofType: null;
             };
           };
-          defaultValue: 'DEFAULT';
-        },
-      ];
-    };
-    ID: unknown;
-    ITodo: {
-      kind: 'INTERFACE';
-      name: 'ITodo';
-      fields: {
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+          complete: {
+            name: 'complete';
+            type: {
               kind: 'SCALAR';
-              name: 'ID';
+              name: 'Boolean';
               ofType: null;
             };
           };
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
         };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+        possibleTypes:
+          | 'BigTodo'
+          | 'SmallTodo';
+      };
+      Int: unknown;
+      LatestTodoResult: {
+        kind: 'UNION';
+        name: 'LatestTodoResult';
+        fields: {};
+        possibleTypes:
+          | 'NoTodosError'
+          | 'Todo';
+      };
+      Mutation: {
+        kind: 'OBJECT';
+        name: 'Mutation';
+        fields: {
+          toggleTodo: {
+            name: 'toggleTodo';
+            type: {
+              kind: 'OBJECT';
+              name: 'Todo';
+              ofType: null;
+            };
+          };
+          updateTodo: {
+            name: 'updateTodo';
+            type: {
               kind: 'SCALAR';
-              name: 'String';
+              name: 'Boolean';
               ofType: null;
             };
           };
         };
       };
-      possibleTypes: 'BigTodo' | 'SmallTodo';
-    };
-    Int: unknown;
-    LatestTodoResult: {
-      kind: 'UNION';
-      name: 'LatestTodoResult';
-      fields: {};
-      possibleTypes: 'NoTodosError' | 'Todo';
-    };
-    Mutation: {
-      kind: 'OBJECT';
-      name: 'Mutation';
-      fields: {
-        toggleTodo: {
-          name: 'toggleTodo';
-          type: {
-            kind: 'OBJECT';
-            name: 'Todo';
-            ofType: null;
-          };
-        };
-        updateTodo: {
-          name: 'updateTodo';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-      };
-    };
-    NoTodosError: {
-      kind: 'OBJECT';
-      name: 'NoTodosError';
-      fields: {
-        message: {
-          name: 'message';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
+      NoTodosError: {
+        kind: 'OBJECT';
+        name: 'NoTodosError';
+        fields: {
+          message: {
+            name: 'message';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
             };
           };
         };
       };
-    };
-    OneOfPayload: {
-      kind: 'INPUT_OBJECT';
-      name: 'OneOfPayload';
-      isOneOf: true;
-      inputFields: [
-        {
-          name: 'value_1';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
+      OneOfPayload: {
+        kind: 'INPUT_OBJECT';
+        name: 'OneOfPayload';
+        isOneOf: true;
+        inputFields: [
+          {
+            name: 'value_1';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+          {
+            name: 'value_2';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+        ];
+      };
+      Query: {
+        kind: 'OBJECT';
+        name: 'Query';
+        fields: {
+          itodo: {
+            name: 'itodo';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'INTERFACE';
+                name: 'ITodo';
+                ofType: null;
+              };
             };
           };
-          defaultValue: null;
-        },
-        {
-          name: 'value_2';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
+          latestTodo: {
+            name: 'latestTodo';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'UNION';
+                name: 'LatestTodoResult';
+                ofType: null;
+              };
             };
           };
-          defaultValue: null;
-        },
-      ];
-    };
-    Query: {
-      kind: 'OBJECT';
-      name: 'Query';
-      fields: {
-        itodo: {
-          name: 'itodo';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'INTERFACE';
-              name: 'ITodo';
-              ofType: null;
-            };
-          };
-        };
-        latestTodo: {
-          name: 'latestTodo';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+          test: {
+            name: 'test';
+            type: {
               kind: 'UNION';
-              name: 'LatestTodoResult';
+              name: 'Search';
               ofType: null;
             };
           };
-        };
-        test: {
-          name: 'test';
-          type: {
-            kind: 'UNION';
-            name: 'Search';
-            ofType: null;
+          todos: {
+            name: 'todos';
+            type: {
+              kind: 'LIST';
+              name: never;
+              ofType: {
+                kind: 'OBJECT';
+                name: 'Todo';
+                ofType: null;
+              };
+            };
           };
         };
-        todos: {
-          name: 'todos';
-          type: {
-            kind: 'LIST';
-            name: never;
-            ofType: {
+      };
+      Search: {
+        kind: 'UNION';
+        name: 'Search';
+        fields: {};
+        possibleTypes:
+          | 'BigTodo'
+          | 'SmallTodo';
+      };
+      SmallTodo: {
+        kind: 'OBJECT';
+        name: 'SmallTodo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
+              ofType: null;
+            };
+          };
+          complete: {
+            name: 'complete';
+            type: {
+              kind: 'SCALAR';
+              name: 'Boolean';
+              ofType: null;
+            };
+          };
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
+            };
+          };
+          maxLength: {
+            name: 'maxLength';
+            type: {
+              kind: 'SCALAR';
+              name: 'Int';
+              ofType: null;
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+          };
+        };
+      };
+      String: unknown;
+      Subscription: {
+        kind: 'OBJECT';
+        name: 'Subscription';
+        fields: {
+          newTodo: {
+            name: 'newTodo';
+            type: {
               kind: 'OBJECT';
               name: 'Todo';
               ofType: null;
@@ -294,181 +377,107 @@ export type simpleSchema = {
           };
         };
       };
-    };
-    Search: {
-      kind: 'UNION';
-      name: 'Search';
-      fields: {};
-      possibleTypes: 'BigTodo' | 'SmallTodo';
-    };
-    SmallTodo: {
-      kind: 'OBJECT';
-      name: 'SmallTodo';
-      fields: {
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
+      Todo: {
+        kind: 'OBJECT';
+        name: 'Todo';
+        fields: {
+          author: {
+            name: 'author';
+            type: {
+              kind: 'OBJECT';
+              name: 'Author';
               ofType: null;
             };
           };
-        };
-        maxLength: {
-          name: 'maxLength';
-          type: {
-            kind: 'SCALAR';
-            name: 'Int';
-            ofType: null;
-          };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+          complete: {
+            name: 'complete';
+            type: {
               kind: 'SCALAR';
-              name: 'String';
+              name: 'Boolean';
               ofType: null;
             };
           };
-        };
-      };
-    };
-    String: unknown;
-    Subscription: {
-      kind: 'OBJECT';
-      name: 'Subscription';
-      fields: {
-        newTodo: {
-          name: 'newTodo';
-          type: {
-            kind: 'OBJECT';
-            name: 'Todo';
-            ofType: null;
-          };
-        };
-      };
-    };
-    Todo: {
-      kind: 'OBJECT';
-      name: 'Todo';
-      fields: {
-        author: {
-          name: 'author';
-          type: {
-            kind: 'OBJECT';
-            name: 'Author';
-            ofType: null;
-          };
-        };
-        complete: {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-        };
-        id: {
-          name: 'id';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'ID';
-              ofType: null;
+          id: {
+            name: 'id';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'ID';
+                ofType: null;
+              };
             };
           };
-        };
-        test: {
-          name: 'test';
-          type: {
-            kind: 'ENUM';
+          test: {
             name: 'test';
-            ofType: null;
-          };
-        };
-        text: {
-          name: 'text';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
+            type: {
+              kind: 'ENUM';
+              name: 'test';
               ofType: null;
+            };
+          };
+          text: {
+            name: 'text';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
             };
           };
         };
       };
-    };
-    TodoPayload: {
-      kind: 'INPUT_OBJECT';
-      name: 'TodoPayload';
-      isOneOf: false;
-      inputFields: [
-        {
-          name: 'title';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
+      TodoPayload: {
+        kind: 'INPUT_OBJECT';
+        name: 'TodoPayload';
+        isOneOf: false;
+        inputFields: [
+          {
+            name: 'title';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+          {
+            name: 'description';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+          {
+            name: 'complete';
+            type: {
               kind: 'SCALAR';
-              name: 'String';
+              name: 'Boolean';
               ofType: null;
             };
-          };
-          defaultValue: null;
-        },
-        {
-          name: 'description';
-          type: {
-            kind: 'NON_NULL';
-            name: never;
-            ofType: {
-              kind: 'SCALAR';
-              name: 'String';
-              ofType: null;
-            };
-          };
-          defaultValue: null;
-        },
-        {
-          name: 'complete';
-          type: {
-            kind: 'SCALAR';
-            name: 'Boolean';
-            ofType: null;
-          };
-          defaultValue: null;
-        },
-      ];
-    };
-    test: {
-      name: 'test';
-      enumValues: 'value' | 'more';
+            defaultValue: null;
+          },
+        ];
+      };
+      test: {
+        name: 'test';
+        enumValues:
+          | 'value'
+          | 'more';
+      };
     };
   };
-};

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -217,6 +217,39 @@ export type simpleSchema =
           };
         };
       };
+      OneOfPayload: {
+        kind: 'INPUT_OBJECT';
+        name: 'OneOfPayload';
+        isOneOf: true;
+        inputFields: [
+          {
+            name: 'value_1';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+          {
+            name: 'value_2';
+            type: {
+              kind: 'NON_NULL';
+              name: never;
+              ofType: {
+                kind: 'SCALAR';
+                name: 'String';
+                ofType: null;
+              };
+            };
+            defaultValue: null;
+          },
+        ];
+      };
       Query: {
         kind: 'OBJECT';
         name: 'Query';

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -101,6 +101,7 @@ export type simpleSchema =
       DefaultPayload: {
         kind: 'INPUT_OBJECT';
         name: 'DefaultPayload';
+        isOneOf: false;
         inputFields: [
           {
             name: 'value';
@@ -400,6 +401,7 @@ export type simpleSchema =
       TodoPayload: {
         kind: 'INPUT_OBJECT';
         name: 'TodoPayload';
+        isOneOf: false;
         inputFields: [
           {
             name: 'title';

--- a/src/__tests__/fixtures/simpleSchema.ts
+++ b/src/__tests__/fixtures/simpleSchema.ts
@@ -238,13 +238,9 @@ export type simpleSchema =
           {
             name: 'value_2';
             type: {
-              kind: 'NON_NULL';
-              name: never;
-              ofType: {
-                kind: 'SCALAR';
-                name: 'String';
-                ofType: null;
-              };
+              kind: 'SCALAR';
+              name: 'String';
+              ofType: null;
             };
             defaultValue: null;
           },

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -48,7 +48,8 @@ describe('getVariablesType', () => {
 
     expectTypeOf<variables>().toEqualTypeOf<{
       id: string;
-      input: { value_1: string } | { value_2: string };
+      // TODO: should we get rid of the leading empty object?
+      input: {} | { value_1: string } | { value_2: string };
     }>();
   });
 

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -36,6 +36,23 @@ describe('getVariablesType', () => {
     }>();
   });
 
+  it('works for one-of-objects', () => {
+    const query = `
+      mutation ($id: ID!, $input: OneOfPayload!) {
+        toggleTodo (id: $id input: $input) { id }
+      }
+    `;
+
+    type doc = parseDocument<typeof query>;
+    type variables = getVariablesType<doc, schema>;
+
+    expectTypeOf<variables>().toEqualTypeOf<{
+      id: string;
+      // TODO: should we get rid of the leading empty object?
+      input: {} | { value_1: string } | { value_2: string };
+    }>();
+  });
+
   it('allows optionals for default values', () => {
     const query = `
       mutation ($id: ID! = "default") {

--- a/src/__tests__/variables.test-d.ts
+++ b/src/__tests__/variables.test-d.ts
@@ -48,8 +48,7 @@ describe('getVariablesType', () => {
 
     expectTypeOf<variables>().toEqualTypeOf<{
       id: string;
-      // TODO: should we get rid of the leading empty object?
-      input: {} | { value_1: string } | { value_2: string };
+      input: { value_1: string } | { value_2: string };
     }>();
   });
 

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -65,6 +65,7 @@ interface IntrospectionEnumType {
 interface IntrospectionInputObjectType {
   readonly kind: 'INPUT_OBJECT';
   readonly name: string;
+  readonly isOneOf?: boolean;
   readonly inputFields: readonly any[] /*readonly IntrospectionInputValue[]*/;
 }
 
@@ -128,6 +129,7 @@ export type mapObject<T extends IntrospectionObjectType> = {
 export type mapInputObject<T extends IntrospectionInputObjectType> = {
   kind: 'INPUT_OBJECT';
   name: T['name'];
+  isOneOf: T['isOneOf'] extends boolean ? T['isOneOf'] : false;
   inputFields: [...T['inputFields']];
 };
 

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -3,35 +3,6 @@ import type { SchemaLike } from './introspection';
 import type { DocumentNodeLike } from './parser';
 import type { obj } from './utils';
 
-type GetInputObjectType<
-  InputField,
-  Introspection extends SchemaLike,
-  IgnoreNonNull,
-> = InputField extends {
-  name: any;
-  type: any;
-}
-  ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
-    ? {
-        [Name in InputField['name']]: unwrapTypeRec<
-          InputField['type'],
-          Introspection,
-          IgnoreNonNull extends true ? false : true
-        >;
-      }
-    : IgnoreNonNull extends true
-      ? {
-          [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, false>;
-        }
-      : {
-          [Name in InputField['name']]?: unwrapTypeRec<
-            InputField['type'],
-            Introspection,
-            true
-          > | null;
-        }
-  : {};
-
 type getInputObjectTypeRec<
   InputFields,
   Introspection extends SchemaLike,
@@ -40,7 +11,23 @@ type getInputObjectTypeRec<
   ? getInputObjectTypeRec<
       Rest,
       Introspection,
-      GetInputObjectType<InputField, Introspection, false> & InputObject
+      (InputField extends {
+        name: any;
+        type: any;
+      }
+        ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
+          ? {
+              [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, true>;
+            }
+          : {
+              [Name in InputField['name']]?: unwrapTypeRec<
+                InputField['type'],
+                Introspection,
+                true
+              > | null;
+            }
+        : {}) &
+        InputObject
     >
   : obj<InputObject>;
 
@@ -52,7 +39,27 @@ type getInputObjectTypeOneOfRec<
   ? getInputObjectTypeOneOfRec<
       Rest,
       Introspection,
-      GetInputObjectType<InputField, Introspection, true> | InputObject
+      | (InputField extends {
+          name: any;
+          type: any;
+        }
+          ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
+            ? {
+                [Name in InputField['name']]: unwrapTypeRec<
+                  InputField['type'],
+                  Introspection,
+                  false
+                >;
+              }
+            : {
+                [Name in InputField['name']]: unwrapTypeRec<
+                  InputField['type'],
+                  Introspection,
+                  false
+                >;
+              }
+          : {})
+      | InputObject
     >
   : obj<InputObject>;
 

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -43,25 +43,13 @@ type getInputObjectTypeOneOfRec<
           name: any;
           type: any;
         }
-          ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
-            ? {
-                [Name in InputField['name']]: unwrapTypeRec<
-                  InputField['type'],
-                  Introspection,
-                  false
-                >;
-              }
-            : {
-                [Name in InputField['name']]: unwrapTypeRec<
-                  InputField['type'],
-                  Introspection,
-                  false
-                >;
-              }
-          : {})
+          ? {
+              [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, false>;
+            }
+          : never)
       | InputObject
     >
-  : obj<InputObject>;
+  : InputObject;
 
 type unwrapTypeRec<TypeRef, Introspection extends SchemaLike, IsOptional> = TypeRef extends {
   kind: 'NON_NULL';

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -3,7 +3,11 @@ import type { SchemaLike } from './introspection';
 import type { DocumentNodeLike } from './parser';
 import type { obj } from './utils';
 
-type GetInputObjectType<InputField, Introspection extends SchemaLike> = InputField extends {
+type GetInputObjectType<
+  InputField,
+  Introspection extends SchemaLike,
+  IgnoreNonNull,
+> = InputField extends {
   name: any;
   type: any;
 }
@@ -11,13 +15,17 @@ type GetInputObjectType<InputField, Introspection extends SchemaLike> = InputFie
     ? {
         [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, true>;
       }
-    : {
-        [Name in InputField['name']]?: unwrapTypeRec<
-          InputField['type'],
-          Introspection,
-          true
-        > | null;
-      }
+    : IgnoreNonNull extends true
+      ? {
+          [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, false>;
+        }
+      : {
+          [Name in InputField['name']]?: unwrapTypeRec<
+            InputField['type'],
+            Introspection,
+            true
+          > | null;
+        }
   : {};
 
 type getInputObjectTypeRec<
@@ -28,7 +36,7 @@ type getInputObjectTypeRec<
   ? getInputObjectTypeRec<
       Rest,
       Introspection,
-      GetInputObjectType<InputField, Introspection> & InputObject
+      GetInputObjectType<InputField, Introspection, false> & InputObject
     >
   : obj<InputObject>;
 
@@ -40,7 +48,7 @@ type getInputObjectTypeOneOfRec<
   ? getInputObjectTypeOneOfRec<
       Rest,
       Introspection,
-      GetInputObjectType<InputField, Introspection> | InputObject
+      GetInputObjectType<InputField, Introspection, true> | InputObject
     >
   : obj<InputObject>;
 

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -23,24 +23,16 @@ type GetInputObjectType<InputField, Introspection extends SchemaLike> = InputFie
 type getInputObjectTypeRec<
   InputFields,
   Introspection extends SchemaLike,
+  IsOneOf extends boolean,
   InputObject = {},
 > = InputFields extends [infer InputField, ...infer Rest]
   ? getInputObjectTypeRec<
       Rest,
       Introspection,
-      GetInputObjectType<InputField, Introspection> & InputObject
-    >
-  : obj<InputObject>;
-
-type getInputObjectTypeOneOfRec<
-  InputFields,
-  Introspection extends SchemaLike,
-  InputObject = never,
-> = InputFields extends [infer InputField, ...infer Rest]
-  ? getInputObjectTypeOneOfRec<
-      Rest,
-      Introspection,
-      GetInputObjectType<InputField, Introspection> | InputObject
+      IsOneOf,
+      IsOneOf extends true
+        ? GetInputObjectType<InputField, Introspection> | InputObject
+        : GetInputObjectType<InputField, Introspection> & InputObject
     >
   : obj<InputObject>;
 
@@ -117,9 +109,11 @@ type getScalarType<
       inputFields: any;
       isOneOf?: any;
     }
-    ? Introspection['types'][TypeName]['isOneOf'] extends true
-      ? getInputObjectTypeOneOfRec<Introspection['types'][TypeName]['inputFields'], Introspection>
-      : getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
+    ? getInputObjectTypeRec<
+        Introspection['types'][TypeName]['inputFields'],
+        Introspection,
+        Introspection['types'][TypeName]['isOneOf'] extends true ? true : false
+      >
     : Introspection['types'][TypeName] extends { type: any }
       ? Introspection['types'][TypeName]['type']
       : Introspection['types'][TypeName]['enumValues']

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -23,16 +23,24 @@ type GetInputObjectType<InputField, Introspection extends SchemaLike> = InputFie
 type getInputObjectTypeRec<
   InputFields,
   Introspection extends SchemaLike,
-  IsOneOf extends boolean,
   InputObject = {},
 > = InputFields extends [infer InputField, ...infer Rest]
   ? getInputObjectTypeRec<
       Rest,
       Introspection,
-      IsOneOf,
-      IsOneOf extends true
-        ? GetInputObjectType<InputField, Introspection> | InputObject
-        : GetInputObjectType<InputField, Introspection> & InputObject
+      GetInputObjectType<InputField, Introspection> & InputObject
+    >
+  : obj<InputObject>;
+
+type getInputObjectTypeOneOfRec<
+  InputFields,
+  Introspection extends SchemaLike,
+  InputObject = never,
+> = InputFields extends [infer InputField, ...infer Rest]
+  ? getInputObjectTypeOneOfRec<
+      Rest,
+      Introspection,
+      GetInputObjectType<InputField, Introspection> | InputObject
     >
   : obj<InputObject>;
 
@@ -109,11 +117,9 @@ type getScalarType<
       inputFields: any;
       isOneOf?: any;
     }
-    ? getInputObjectTypeRec<
-        Introspection['types'][TypeName]['inputFields'],
-        Introspection,
-        Introspection['types'][TypeName]['isOneOf'] extends true ? true : false
-      >
+    ? Introspection['types'][TypeName]['isOneOf'] extends true
+      ? getInputObjectTypeOneOfRec<Introspection['types'][TypeName]['inputFields'], Introspection>
+      : getInputObjectTypeRec<Introspection['types'][TypeName]['inputFields'], Introspection>
     : Introspection['types'][TypeName] extends { type: any }
       ? Introspection['types'][TypeName]['type']
       : Introspection['types'][TypeName]['enumValues']

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -3,6 +3,23 @@ import type { SchemaLike } from './introspection';
 import type { DocumentNodeLike } from './parser';
 import type { obj } from './utils';
 
+type GetInputObjectType<InputField, Introspection extends SchemaLike> = InputField extends {
+  name: any;
+  type: any;
+}
+  ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
+    ? {
+        [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, true>;
+      }
+    : {
+        [Name in InputField['name']]?: unwrapTypeRec<
+          InputField['type'],
+          Introspection,
+          true
+        > | null;
+      }
+  : {};
+
 type getInputObjectTypeRec<
   InputFields,
   Introspection extends SchemaLike,
@@ -14,43 +31,8 @@ type getInputObjectTypeRec<
       Introspection,
       IsOneOf,
       IsOneOf extends true
-        ?
-            | (InputField extends { name: any; type: any }
-                ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
-                  ? {
-                      [Name in InputField['name']]: unwrapTypeRec<
-                        InputField['type'],
-                        Introspection,
-                        true
-                      >;
-                    }
-                  : {
-                      [Name in InputField['name']]?: unwrapTypeRec<
-                        InputField['type'],
-                        Introspection,
-                        true
-                      > | null;
-                    }
-                : {})
-            | InputObject
-        : (InputField extends { name: any; type: any }
-            ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
-              ? {
-                  [Name in InputField['name']]: unwrapTypeRec<
-                    InputField['type'],
-                    Introspection,
-                    true
-                  >;
-                }
-              : {
-                  [Name in InputField['name']]?: unwrapTypeRec<
-                    InputField['type'],
-                    Introspection,
-                    true
-                  > | null;
-                }
-            : {}) &
-            InputObject
+        ? GetInputObjectType<InputField, Introspection> | InputObject
+        : GetInputObjectType<InputField, Introspection> & InputObject
     >
   : obj<InputObject>;
 

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -13,7 +13,11 @@ type GetInputObjectType<
 }
   ? InputField extends { defaultValue?: undefined | null; type: { kind: 'NON_NULL' } }
     ? {
-        [Name in InputField['name']]: unwrapTypeRec<InputField['type'], Introspection, true>;
+        [Name in InputField['name']]: unwrapTypeRec<
+          InputField['type'],
+          Introspection,
+          IgnoreNonNull extends true ? false : true
+        >;
       }
     : IgnoreNonNull extends true
       ? {


### PR DESCRIPTION
## Summary

Adds support for https://github.com/graphql/graphql-spec/pull/825

When we encounter an input marked as `isOneOf: true` we need to create a type that is an _or_ of all the properties spelled out in said input-object.

- In the support-query we check whether `__Type` contains a `isOneOf`
- In the `Introspection` type we add `isOneOf` to the properties
- Add new branch in `variables.ts` that differentiates between `|` and `&`