### PR TITLE
passthrough query input string

### DIFF
--- a/.changeset/yellow-singers-push.md
+++ b/.changeset/yellow-singers-push.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+passthrough the query input string

--- a/src/api.ts
+++ b/src/api.ts
@@ -233,7 +233,7 @@ function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
       );
     }
 
-    return { kind: Kind.DOCUMENT, definitions };
+    return { kind: Kind.DOCUMENT, definitions, input };
   }
 
   graphql.scalar = function scalar(_schema: Schema, value: any) {
@@ -292,7 +292,9 @@ interface TadaDocumentNode<
   Decoration = void,
 > extends DocumentNode,
     DocumentDecoration<Result, Variables>,
-    makeDefinitionDecoration<Decoration> {}
+    makeDefinitionDecoration<Decoration> {
+  readonly input: string;
+}
 
 /** A utility type returning the `Result` type of typed GraphQL documents.
  *


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

We'd like to send the query string directly to our backend, not the "parsed graphql definition" (not sure the terminology). We have a hacky patch workaround for this, but it seems like something appropriate for other users of this lib as well.

example:
```ts
const query = graphql(`
  query MyThing {
    id
  }
`);

const res = await requestDataFromBackend(query.input);
```

Question: i'm not currenctly using fragments, but it probably also makes sense to passhrough them as well?

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- passthrough the query input string