### PR TITLE
fix(cli-utils): Fix modules not being resolved correctly with pnpm-installed `gql.tada`

### DIFF
--- a/.changeset/new-clouds-argue.md
+++ b/.changeset/new-clouds-argue.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Fix modules not being resolved correctly when using `turbo` with `pnpm`-installed `gql.tada`

--- a/packages/cli-utils/src/ts/vendor/typescript-vfs.ts
+++ b/packages/cli-utils/src/ts/vendor/typescript-vfs.ts
@@ -385,6 +385,10 @@ export function createFSBackedSystem(
     name: 'fs-vfs',
     root,
     args: [],
+    realpath: (directory) => {
+      if (nodeSys.realpath) return nodeSys.realpath(directory);
+      return directory;
+    },
     createDirectory: () => notImplemented('createDirectory'),
     // TODO: could make a real file tree
     directoryExists: (directory) => {


### PR DESCRIPTION
Resolves #289

## Summary

The missing `system.realpath` method causes other file resolution processes to fail. Namely, this causes module resolution to act incorrectly with `pnpm`-installed dependencies and hence fails quite quickly since `gql.tada` depends on `@0no-co/graphql.web`

## Set of changes

- Add missing `realpath` method to `createFSBackedSystem`
