### PR TITLE
fix(cli-utils): vue losing the graphql call due to missing sfc plugin

### DIFF
--- a/.changeset/silver-eels-rhyme.md
+++ b/.changeset/silver-eels-rhyme.md
@@ -3,4 +3,4 @@
 "gql.tada": patch
 ---
 
-Fix vue losing out on the SFC plugin due to our usage of `getBasePlugins`
+Fix Vue not transpiling to `.tsx` files properly due to missing SFC plugin

--- a/.changeset/silver-eels-rhyme.md
+++ b/.changeset/silver-eels-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@gql.tada/cli-utils": patch
+"gql.tada": patch
+---
+
+Fix vue losing out on the SFC plugin due to our usage of `getBasePlugins`


### PR DESCRIPTION
## Summary

It looks like another breaking change apart from the rename to `getBasePlugins` is that we stopped using `vue-sfc` by default which means that we lose out on variables declared in the global scope. This addresses that by pushing this to the plugins array again.

Currently seeing whether it would be safer to use `createVueLanguagePlugin` instead
