### PR TITLE
fix(internal): Allow determine GraphQL support from introspection result

### DIFF
--- a/.changeset/nervous-pumpkins-prove.md
+++ b/.changeset/nervous-pumpkins-prove.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Derive supported GraphQL features from introspection result, when the introspection support query fails. This works around issues for APIs that block `__type` unintentionally, but do allow for `__schema` introspection.

--- a/packages/internal/src/loaders/introspection.ts
+++ b/packages/internal/src/loaders/introspection.ts
@@ -1,3 +1,4 @@
+import type { IntrospectionQuery } from 'graphql';
 import { GraphQLID, GraphQLObjectType, GraphQLSchema, executeSync } from 'graphql';
 import { Kind, OperationTypeNode } from '@0no-co/graphql.web';
 
@@ -70,6 +71,25 @@ export const toSupportedFeatures = (data: IntrospectSupportQueryData): Supported
   directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.directive),
   fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(data.field),
 });
+
+export const introspectionToSupportedFeatures = (data: IntrospectionQuery): SupportedFeatures => {
+  const directive = data.__schema.types.find((type) => type.name === '__Directive') as any;
+  const type = data.__schema.types.find((type) => type.name === '__Type') as any;
+  const inputValue = data.__schema.types.find((type) => type.name === '__InputValue') as any;
+  const field = data.__schema.types.find((type) => type.name === '__Field') as any;
+  if (directive && type && inputValue && field) {
+    return {
+      directiveIsRepeatable: _hasField(directive, 'isRepeatable'),
+      specifiedByURL: _hasField(type, 'specifiedByURL'),
+      inputOneOf: _hasField(type, 'isOneOf'),
+      inputValueDeprecation: _hasField(inputValue, 'isDeprecated'),
+      directiveArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(directive),
+      fieldArgumentsIsDeprecated: _supportsDeprecatedArgumentsArg(field),
+    };
+  } else {
+    return NO_SUPPORTED_FEATURES;
+  }
+};
 
 let _localSupport: SupportedFeatures | undefined;
 


### PR DESCRIPTION
Resolves #316

## Summary

This allows GraphQL support to be determined from an introspection result. This is a suboptimal path as we potentially do two introspections on a first introspection request. However, this isn't much different from what we did before, which included running assuming full support then falling back to no support of features.

## Set of changes

- Add deriving support from full introspection result to URL loader
