### PR TITLE
fix(gql.tada): Fix recursive optional fragment types causing exponential complexity

### DIFF
--- a/.changeset/hungry-needles-rule.md
+++ b/.changeset/hungry-needles-rule.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Fix `@defer`, `@skip`, and `@include` optional fragments causing types to become exponentially more complex to evaluate, causing a recursive type error. Instead, merging field types and sub-selections from fragments is now separated, as needed.

--- a/src/__tests__/selection.test-d.ts
+++ b/src/__tests__/selection.test-d.ts
@@ -4,6 +4,7 @@ import type { simpleSchema } from './fixtures/simpleSchema';
 import type { parseDocument } from '../parser';
 import type { mapIntrospection, addIntrospectionScalars } from '../introspection';
 import type { getDocumentType } from '../selection';
+import type { obj } from '../utils';
 
 import type {
   $tada,
@@ -149,19 +150,13 @@ test('infers optional fragment for @defer', () => {
     }
   `>;
 
-  type actual = getDocumentType<query, schema>;
+  type actual = obj<
+    (getDocumentType<query, schema>['todos'] extends infer U | null ? U : never)[number]
+  >;
 
-  type expected = {
-    todos: Array<
-      | {
-          id: string;
-        }
-      | {}
-      | null
-    > | null;
-  };
+  type expected = { id: string } | {};
 
-  expectTypeOf<expected>().toEqualTypeOf<actual>();
+  expectTypeOf<actual>().toMatchTypeOf<expected>();
 });
 
 test('infers optional inline fragment for @defer', () => {
@@ -489,7 +484,7 @@ test('creates a type for a given fragment with optional inline spread', () => {
     }
   `>;
 
-  type actual = getDocumentType<fragment, schema>;
+  type actual = obj<getDocumentType<fragment, schema>>;
 
   type expected =
     | {}


### PR DESCRIPTION
## Summary

Patterns that require a `T | {}` optionality being merged into selections are causing exponential complexity. This is because all fields in a selection are merged using the `obj` utility. However, `T | {}` causes `2^n` complexity in evaluating and flattening types in TypeScript.

This is because for each `A & (B | {})` merge two variants are created, `(A & B) | (A & {})`. For each subsequent addition (e.g. `A & (B | {}) & (C | {})`) the complexity doubles (`(A & B) | (A & C) | (A & B & C) | A`. This can quickly cause a recursion complexity error in TypeScript once we reach the limit of 16 variants.

This fix addresses this by limiting the flattening of fields to just the fields and not optional sub-selections.

This fix however does have a few problems:
- We can probably add a shortcut for fragment masks, since those are represented by a single field consistently
- This can maybe still occur with unions/interfaces that create multiple different variants of types
- The implementation of this fix makes `getPossibleTypeSelectionRec` just slightly too hard to follow for my taste
- The output type shape quality is sometimes now compromised on

As such, **post-merge**, we're not planning to release this fix as another stable release straightaway and are still looking for improvements.

## Set of changes

- Update tests for new output type shapes
- Separate field flattening from "non-flatteneable" types
