### PR TITLE
fix(cli-utils): Fix regressed CLI exit codes on errors

### DIFF
--- a/.changeset/gentle-elephants-breathe.md
+++ b/.changeset/gentle-elephants-breathe.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Fix regression omitting the exit status code from the CLI. Failing commands will now correctly output exit code `1` instead of `0` again.

--- a/packages/cli-utils/src/term/write.ts
+++ b/packages/cli-utils/src/term/write.ts
@@ -82,7 +82,12 @@ async function* convertError(outputs: AsyncIterable<ComposeInput>): AsyncIterabl
   try {
     yield* outputs;
   } catch (error) {
-    yield !(error instanceof CLIError) ? ('' + error).trim() + '\n' : error;
+    if (error instanceof CLIError) {
+      process.exitCode = error.exit;
+      yield error;
+    } else {
+      yield ('' + error).trim();
+    }
   }
 
   yield '\n';


### PR DESCRIPTION
Resolves #326

## Summary

A prior regression meant that `process.exitCode` wasn't being set any longer.
This has now been fixed and errors now cause `process.exitCode` to be set correctly and as intended again.

## Set of changes

- Add missing `CLIError#exit` to `process.exitCode` copying
