### PR TITLE
docs: Update for 1.8.0 changes (TypeScript 5.5)

### DIFF
--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -472,6 +472,7 @@
 :root .VPContent .column {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  padding: 0.5rem 0;
   gap: 16px;
 }
 

--- a/website/get-started/index.md
+++ b/website/get-started/index.md
@@ -6,166 +6,37 @@ next: false
 
 # Introduction
 
-The `gql.tada` project aims to improve the experience of writing and using GraphQL
-with TypeScript on the client-side by providing more feedback when writing GraphQL,
-and reducing friction between TypeScript and GraphQL.
-
-`gql.tada` as a project was started to answer the question:
-“Why can’t we teach TypeScript to understand the GraphQL query language?”
+`gql.tada` aims to tie GraphQL and TypeScript closer together and minimize friction,
+by improving the experience of writing and using GraphQL with more editor feedback,
+automatically derived types, and additional built-in tools that don't get in your
+way.
 
 Once `gql.tada` is set up, we write our GraphQL queries in pure TypeScript,
-our queries automatically infer their types, and our editor introspects our
-GraphQL schema and provides immediate feedback, auto-completion, diagnostics,
-and GraphQL type hints.<br />
-This all happens on-the-fly in TypeScript.
+queries automatically infer their types, and editors provide immediate feedback,
+auto-completion, diagnostics, and GraphQL type hints.<br />
+All on-the-fly in TypeScript with as few setup steps as possible.
 
-<a href="/get-started/installation" class="button">
-  <h3>Installation</h3>
-  <p>Learn how to get started with <code>gql.tada</code> 🪄</p>
-</a>
+<div class="column">
+  <a class="button" href="./installation">
+    <h2>Installation</h2>
+    <p>How to install and set up <code>gql.tada</code></p>
+  </a>
+  <a class="button" href="./writing-graphql">
+    <h2>Writing GraphQL</h2>
+    <p>How to use <code>gql.tada</code> and write GraphQL documents with it.</p>
+  </a>
+  <a class="button" href="./workflows">
+    <h2>Essential Workflows</h2>
+    <p>Common patterns and how to use the CLI</p>
+  </a>
+  <a class="button" href="../guides/fragment-colocation">
+    <h2>Fragment Colocation</h2>
+    <p>How to effectively use fragment co-location patterns in your codebase</p>
+  </a>
+</div>
 
 ### A demo in 128 seconds
 
 <video controls autoplay loop muted>
   <source src="https://gql-tada-demo-video.pages.dev/demo.mp4" type="video/mp4" />
 </video>
-
-## How does it work?
-
-The project currently contains two installable modules:
-
-- `gql.tada`, the package providing typings and the runtime API as a library,
-- `@0no-co/graphqlsp`, a TypeScript Language Service plugin for editor feedback and integration.
-
-As you start your editor, `@0no-co/graphqlsp` is started as a TypeScript Language Service
-plugin, which allows it to integrate with the same process that provides your editor
-with type hints, diagnostics, and auto-completions; the TypeScript language server
-process.
-
-During this time, `@0no-co/graphqlsp` will retrieve your GraphQL schema, find GraphQL
-documents and provide added diagnostics and features using your schema information.
-It will also output an introspection file for `gql.tada` to use.
-
-The GraphQL documents, written with `gql.tada` will be parsed — all inside TypeScript
-typings — and are combined with the introspection information that `@0no-co/graphqlsp`
-provides to create typings for GraphQL result and variables types.
-
-This means, all we see in our code is the plain GraphQL documents with no annotations or distractions:
-
-```ts twoslash
-// @filename: graphql-env.d.ts
-export type introspection = {
-  "__schema": {
-    "queryType": {
-      "name": "Query"
-    },
-    "mutationType": null,
-    "subscriptionType": null,
-    "types": [
-      {
-        "kind": "OBJECT",
-        "name": "Query",
-        "fields": [
-          {
-            "name": "hello",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "args": []
-          },
-          {
-            "name": "world",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "SCALAR",
-        "name": "String"
-      }
-    ],
-    "directives": []
-  }
-};
-
-import * as gqlTada from 'gql.tada';
-
-declare module 'gql.tada' {
-  interface setupSchema {
-    introspection: introspection
-  }
-}
-
-// @filename: index.ts
-import './graphql-env.d.ts';
-// ---cut---
-import { graphql } from 'gql.tada';
-
-const fragment = graphql(`
-  fragment HelloWorld on Query {
-    hello
-    world
-  }
-`);
-
-const query = graphql(`
-  query HelloQuery {
-    hello
-    ...HelloWorld
-  }
-`, [fragment]);
-```
-
-## How does it compare to other solutions?
-
-Typically, when integrating client-side GraphQL code with TypeScript, other solutions
-will generate typings files for GraphQL documents.
-
-This means that you’ll need to run a persistent and separate process that watches your
-TypeScript files, and generates more auto-generated TypeScript files containing your
-GraphQL types.
-
-This leads to the additional friction of having additional generated files around and
-causing the TypeScript process to having to watch your files, error on changes, picking
-up the newly generated files, and updating the checks. In other words, these tools cause
-a “split” between what TypeScript sees, what you see, and what the code generator sees.
-
-`gql.tada` instead takes the approach of generating the typings fully in TypeScript to
-eliminate this “split experience”, reducing friction. All while writing actual GraphQL
-queries, rather than an object-syntax, which is only an approximation of GraphQL queries.
-
-## Which GraphQL query language features are supported?
-
-`gql.tada` supports the entire GraphQL query language syntax, and aims to support all
-type features that are relevant to GraphQL clients that support typed GraphQL documents
-(via `TypedDocumentNode`s).
-
-Currently, the list of supported features is:
-
-- Mapping selection sets mapping to object-like types to TypeScript object types
-- Grouping type mappings of possible types for interfaces and unions
-- `@defer`, `@skip`, and `@include` directives switching fields and fragments to be optional
-- resolving inline fragment and fragment spreads in documents
-- inferring the type of `__typename` fields
-- resolving types of custom scalars from a configuration
-
-## Next steps
-
-<div class="column">
-    <a class="button" href="./installation">
-        <h2>Installation</h2>
-        <p>How to install and set up <code>gql.tada</code></p>
-    </a>
-    <a class="button" href="./writing-graphql">
-        <h2>Writing GraphQL</h2>
-        <p>How to use <code>gql.tada</code> and write GraphQL documents with it.</p>
-    </a>
-</div>

--- a/website/get-started/installation.md
+++ b/website/get-started/installation.md
@@ -62,24 +62,13 @@ language server. This is the main configuration for both the TypeScript plugin a
 Setting up `gql.tada/ts-plugin` will start up a [“TypeScript Language Service Plugin”](https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin#whats-a-language-service-plugin) when TypeScript is analyzing a file in our IDE or editor. This provides editor hints, such as diagnostics,
 auto-completions, and type hovers for GraphQL.
 
-> [!NOTE]
-> If you’re using VSCode, you may also want to update your `.vscode/settings.json` file to prompt you
-> [to use the workspace version of TypeScript](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript).
-> Otherwise, the TypeScript plugin won’t work!
->
-> ::: code-group
->
-> ```js [.vscode/settings.json] {2-3}
-> {
->   "typescript.tsdk": "node_modules/typescript/lib",
->   "typescript.enablePromptUseWorkspaceTsdk": true
-> }
-> ```
->
-> :::
->
-> To enable syntax highlighting for GraphQL, you can install the official
-> [“GraphQL: Syntax Highlighting” VSCode extension.](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax)
+> [!NOTE] VSCode Setup
+> There may be extra steps you should take when you're using VSCode.
+> [Read about these steps in the "VSCode Setup" section below.](#vscode-settings-and-plugins)
+
+> [!NOTE] Prior to TypeScript 5.5
+> There are extra steps you must take when your TypeScript version is older than 5.5.
+> [Read about these steps in the "Prior to TypeScript 5.5" section below.](#prior-to-typescript-5-5)
 
 ## <span data-step="2">Step 2 —</span> Configuring a schema
 
@@ -293,3 +282,86 @@ export { readFragment } from 'gql.tada';
 
 When using these scalars, they’ll now be mapped to the types in the `scalars` object type.
 
+---
+
+## Extra Steps
+
+A few extra steps may be necessary to install and use `gql.tada`.
+These are called out, as needed, in the above sections, so you'll only
+need to follow these steps depending on your workspace and setup.
+
+### Prior to TypeScript 5.5
+
+If you're using a TypeScript version that's **older** than [TypeScript 5.5](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/)
+you will have to set up the TypeScript plugin differently.
+
+Instead, of using `gql.tada/ts-plugin`, with older versions of TypeScript we'll
+install `@0no-co/graphqlsp` directly. This is a package that contains the TypeScript
+plugin that `gql.tada/ts-plugin` uses and aliases.
+
+::: code-group
+
+```sh [npm]
+npm install --save-dev @0no-co/graphqlsp
+```
+
+```sh [pnpm]
+pnpm add --save-dev @0no-co/graphqlsp
+```
+
+```sh [yarn]
+yarn add --dev @0no-co/graphqlsp
+```
+
+```sh [bun]
+bun add --dev @0no-co/graphqlsp
+```
+
+:::
+
+Once `@0no-co/graphqlsp` is installed as a direct dependency, we'll update the `tsconfig.json`
+to use it.
+
+::: code-group
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "strict": true,
+    "plugins": [
+      {
+        "name": "gql.tada/ts-plugin", // [!code --]
+        "name": "@0no-co/graphqlsp", // [!code ++]
+        "schema": "./schema.graphql",
+        "tadaOutputLocation": "./src/graphql-env.d.ts"
+      }
+    ]
+  }
+}
+```
+:::
+
+### VSCode Setup
+
+As shown above, `gql.tada` has a TypeScript plugin to provide
+editor hints, such as diagnostics, auto-completions, and type hovers
+for GraphQL. This plugin will load up when your workspace's
+TypeScript installation is used by your editor's TypeScript server.
+
+However, VSCode won't by default load up your workspace's TypeScript
+installation and may instead load up a global installation, which
+prevents the plugin from being loaded up.
+
+To resolve this, you should create a `.vscode/settings.json` file to prompt you
+[to use the workspace version of TypeScript](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript).
+
+::: code-group
+```js [.vscode/settings.json] {2-3}
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}
+```
+:::
+
+To enable syntax highlighting for GraphQL, you can install the official
+[“GraphQL: Syntax Highlighting” VSCode extension.](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax)

--- a/website/get-started/installation.md
+++ b/website/get-started/installation.md
@@ -5,45 +5,42 @@ description: How to get set up and ready
 
 # Installation
 
-The `gql.tada` package provides typings and the runtime API as a library,
-while `@0no-co/graphqlsp` integrates with the TypeScript language server
-to integrate with an IDE or editor.
-
-On this page, we’ll go through the steps to get everything set up properly.
+We’ll go through the steps to get `gql.tada` set up properly.
 A quick demo of what this looks like can be found [in an example project in the `gql.tada`
 repository.](https://github.com/0no-co/gql.tada/blob/main/examples/example-pokemon-api/)
 
+With `gql.tada`, you'll mainly interact with three different parts of the library:
+- the library code you import from the `gql.tada` package
+- the TypeScript plugin, `gql.tada/ts-plugin`
+- and the `gql.tada` CLI
+
 ## <span data-step="1">Step 1 —</span> Installing packages
 
-We’ll start by installing `gql.tada` as a dependency, and `@0no-co/graphqlsp` as
-a dev-dependency using out project’s package manager.
+We’ll start by installing `gql.tada` as a dependency.
 
 ::: code-group
 
 ```sh [npm]
 npm install gql.tada
-npm install --save-dev @0no-co/graphqlsp
 ```
 
 ```sh [pnpm]
 pnpm add gql.tada
-pnpm add --save-dev @0no-co/graphqlsp
 ```
 
 ```sh [yarn]
 yarn add gql.tada
-yarn add --dev @0no-co/graphqlsp
 ```
 
 ```sh [bun]
 bun add gql.tada
-bun add --dev @0no-co/graphqlsp
 ```
 
 :::
 
-Next, we’ll have to add `@0no-co/graphqlsp` as a plugin to our TypeScript
-configuration.
+Next, we’ll add the TypeScrpt plugin to our `tsconfig.json` to set it up in TypeScript’s
+language server. This is the main configuration for both the TypeScript plugin and the
+`gql.tada` CLI at the same time.
 
 ::: code-group
 ```json [tsconfig.json]
@@ -52,7 +49,7 @@ configuration.
     "strict": true,
     "plugins": [ // [!code ++]
       { // [!code ++]
-        "name": "@0no-co/graphqlsp", // [!code ++]
+        "name": "gql.tada/ts-plugin", // [!code ++]
         "schema": "./schema.graphql", // [!code ++]
         "tadaOutputLocation": "./src/graphql-env.d.ts" // [!code ++]
       } // [!code ++]
@@ -62,16 +59,13 @@ configuration.
 ```
 :::
 
-This will start up a [“TypeScript Language Service Plugin”](https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin#whats-a-language-service-plugin) which runs when TypeScript is analyzing a file
-in our IDE or editor.
-
-`gql.tada` on its own won’t provide you with editor hints, diagnostics, or errors, so `@0no-co/graphqlsp` is crucial
-in providing you feedback and help when writing GraphQL documents.
+Setting up `gql.tada/ts-plugin` will start up a [“TypeScript Language Service Plugin”](https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin#whats-a-language-service-plugin) when TypeScript is analyzing a file in our IDE or editor. This provides editor hints, such as diagnostics,
+auto-completions, and type hovers for GraphQL.
 
 > [!NOTE]
 > If you’re using VSCode, you may also want to update your `.vscode/settings.json` file to prompt you
 > [to use the workspace version of TypeScript](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript).
-> Otherwise, the `@0no-co/graphqlsp` plugin won’t work!
+> Otherwise, the TypeScript plugin won’t work!
 >
 > ::: code-group
 >
@@ -89,20 +83,22 @@ in providing you feedback and help when writing GraphQL documents.
 
 ## <span data-step="2">Step 2 —</span> Configuring a schema
 
-`@0no-co/graphqlsp` needs to have a GraphQL API’s schema to function correctly.
-The schema provides it with the types, fields, and description information of a GraphQL API.
+We’ll need to set up a GraphQL schema for `gql.tada` to function correctly.
+Without a schema, no typings and no editor hints will be available, since the
+schema provides the GraphQL types, fields, and description information of
+your GraphQL API.
 
-We can set `@0no-co/graphqlsp` up with our schema in our `tsconfig.json` file.
-In the plugin options we’ll update the `schema` key.
+To add a GraphQL schema to `gql.tada`, we'll be the `tsconfig.json`'s plugin
+section we've just added and modify the `schema` option.
 
 ::: code-group
-```json twoslash [tsconfig.json] {6-7}
+```json twoslash [tsconfig.json] {6}
 {
   "compilerOptions": {
     "plugins": [
       {
 // @annotate: Configure your schema here
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql",
         "tadaOutputLocation": "./src/graphql-env.d.ts"
       }
@@ -124,7 +120,7 @@ The `schema` option currently allows for three different formats to load a schem
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql"
       }
     ]
@@ -137,7 +133,7 @@ The `schema` option currently allows for three different formats to load a schem
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./introspection.json"
       }
     ]
@@ -150,7 +146,7 @@ The `schema` option currently allows for three different formats to load a schem
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "http://localhost:4321/graphql"
       }
     ]
@@ -163,7 +159,7 @@ The `schema` option currently allows for three different formats to load a schem
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": {
           "url": "http://localhost:4321/graphql",
           "headers": {
@@ -179,21 +175,20 @@ The `schema` option currently allows for three different formats to load a schem
 
 ## <span data-step="3">Step 3 —</span> Configuring typings
 
-Afterwards, `@0no-co/graphqlsp` is ready to also output a typings file for `gql.tada`.
-The latter needs a **type** of an introspected GraphQL schema to infer types of
-GraphQL documents automatically.
-
-This is configured by providing an output location to `@0no-co/graphqlsp` in our `tsconfig.json` file.
-In the plugin options we’ll update the `tadaOutputLocation` key.
+We're now ready to let `gql.tada` output a typings file.
+This file is generated on the fly by the TypeScript plugin,
+and can [also be generated using the CLI](/get-started/workflows#generating-the-output-file).
+Where this file will be saved to is configured in the `tsconfig.json` file as
+well using the `tadaOutputLocation` option.
 
 ::: code-group
-```json twoslash [tsconfig.json] {6-7}
+```json twoslash [tsconfig.json] {7}
 {
   "compilerOptions": {
     "plugins": [
       {
-// @annotate: Configure your schema here
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
+// @annotate: Configure the output typings file location here
         "schema": "./schema.graphql",
         "tadaOutputLocation": "./src/graphql-env.d.ts"
       }
@@ -203,10 +198,12 @@ In the plugin options we’ll update the `tadaOutputLocation` key.
 ```
 :::
 
-The `tadaOutputLocation` path can either be a `.ts` file, a `.d.ts` file, or
-a folder, in which case a `introspection.d.ts` file will be created.
+Depeding on the `tadaOutputLocation`'s configured file extension, there's
+[two separate formats](/reference/config-format#tadaoutputlocation) this
+file can be saved in. For most cases the `.d.ts` format is recommended
+for best performance however.
 
-Once we start up our editor, `@0no-co/graphqlsp` will run and will create
+Once we start up our editor, the TypeScript plugin will run and create
 the output file. In this example, we’ve created a `src/graphql-env.d.ts` file.
 When opening this file we should see code that looks like the following:
 
@@ -226,22 +223,20 @@ declare module 'gql.tada' {
 ```
 :::
 
-This file declares our schema’s introspection data in `gql.tada`. After this file
-is created by `@0no-co/graphqlsp` automatically, `gql.tada` is set up project-wide
-and is **ready to be used.**
+The typings file is a representation of an introspected GraphQL schema
+and allows types to be inferred for GraphQL documents in the
+TypeScript type system. After this file is created by automatically,
+`gql.tada` is set up project-wide and is **ready to be used.**
 
 ### Initializing `gql.tada` manually
 
-Above, we let `@0no-co/graphqlsp` generate a `src/graphql-env.d.ts` file, which sets
-`gql.tada` up project-wide for us.
+With the prior instructions, we can import `graphql()` from `gql.tada` directly
+and start writing GraphQL documents, but this default setup limits what we can do.
+In a full setup, we want to customize scalars or pass further type configuration to
+`gql.tada`.
 
-This allows us to import `graphql()` from `gql.tada` directly, but it limits what we
-can do, since we can’t customize any scalars, or further configuration
-for `gql.tada`. This setup also fails if we have multiple schemas (for example, in a monorepo),
-since the declaration in `graphql-env.d.ts` sets a schema up project-wide.
-
-To work around this, we’ll create a file that uses the introspection data manually with the
-`initGraphQLTada()` function to create our own `graphql()` function:
+To customize `gql.tada`, we’ll create a file that imports the output typings manually
+and uses the `initGraphQLTada()` function to create our own `graphql()` function:
 
 :::code-group
 ```ts twoslash [src/graphql.ts] {4-6}
@@ -257,11 +252,11 @@ export { readFragment } from 'gql.tada';
 ```
 :::
 
-Instead of declaring our schema project-wide, we now have created a `graphql` function
-that specifically uses the introspection inside the `graphql-env.d.ts` file that
-`@0no-co/graphqlsp` outputs for us.
+This setup is also necessary if we're setting up [multiple schemas](/guides/multiple-schemas)
+(for example, in a monorepo), since we'd have multiple output typings files if we're trying
+to use `gql.tada` for multiple GraphQL schemas.
 
-Instead of importing `graphql` from `gql.tada`, we should now import it from our
+Instead of importing `graphql()` from `gql.tada`, we should now import it from our
 custom `src/graphql.ts` file.
 
 ### Customizing scalar types
@@ -297,3 +292,4 @@ export { readFragment } from 'gql.tada';
 :::
 
 When using these scalars, they’ll now be mapped to the types in the `scalars` object type.
+

--- a/website/get-started/workflows.md
+++ b/website/get-started/workflows.md
@@ -48,8 +48,8 @@ use your configuration's `schema` setting, provided it's a file path.
 Since you've run through the steps on the [Installation
 page](/get-started/installation), you may have seen that there
 are several moving parts to `gql.tada`, including needing
-an output file to be generated and relying on the `@0no-co/graphqlsp`
-TypeScript plugin to display diagnostics.
+an output file to be generated and relying on the TypeScript
+plugin to display diagnostics.
 
 To prevent any of these parts working improperly, and to detect
 whether there are any issues in your configuration or with
@@ -76,7 +76,7 @@ you get started or when onboarding a new team member onto
   and <code>check</code> commands.
 </section>
 
-Usually while editing your code, the `@0no-co/graphqlsp` plugin
+Usually while editing your code, the TypeScript plugin
 takes care of several things automatically:
 - it generates the output typings file
 - it provides type hints and suggestions
@@ -105,7 +105,7 @@ gql.tada generate output
 The `generate output` command loads your schema, generates
 introspection output and finally saves the output typings file.
 
-Just like the `@0no-co/graphqlsp` plugin, the command will
+Just like the TypeScript plugin, the command will
 use the `tadaOutputLocation` setting to determine where to
 write the output file to, and will load your schema
 using the `schema` setting:
@@ -116,7 +116,7 @@ using the `schema` setting:
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql"
         "tadaOutputLocation": "./src/graphql-env.d.ts"
       }
@@ -160,9 +160,12 @@ that you'll always be in a state to run type checks.
 
 ### Running diagnostics
 
-All diagnostics that the `@0no-co/graphqlsp` runs, can also
-be run using the CLI's `check` command. This is also useful to
-run to get an idea of any issues across the entire codebase.
+The TypeScript plugin runs several checks on your code, providing
+diagnostics releant to your GraphQL schema right in your editor.
+But to run `gql.tada`'s diagnostics as a standalone process we can
+use the CLI's `check` command instead. The command runs all
+diagnostics and gives us an idea of GraphQL-related issues across
+a whole workspace.
 
 ```sh
 gql.tada check
@@ -181,19 +184,18 @@ don't exist on your schema, or you pass invalid arguments
 to a field an error will be displayed.
 
 ::: info Why doesn't `tsc` show me diagnostics?
-TypeScript plugins are specific to the TypeScript language
-service, and during other tasks, like in `tsc` or in other
-tools that integrate with TypeScript, no plugins are loaded
-or executed.
+TypeScript plugins are hook into the TypeScript language
+server API, which is specific to editor and IDE features.
+During other tasks, like when you run `tsc` or other TypeScript
+compiler tools, TypeScript plugins aren't loaded.
 
-The diagnostics that are displayed in your editor by
-`@0no-co/graphqlsp`, are specific to the `tsserver` and
-to editors, and the `gql.tada check` command has been created
-to get the same diagnostics outside of editors.
+The `gql.tada check` command exists to be a standalone
+version of GraphQL-related diagnostics instead and itself
+loads the TypeScript plugin's diagnostics code.
 :::
 
-Some diagnostics are specific to `gql.tada`, specifically
-there's two settings you can change in your configuration:
+Two diagnostics that feature in `gql.tada` output opinionated
+warnings that may not be relevant to your codebase:
 
 - [`trackFieldUsage`](/reference/config-format#trackfieldusage)
 - [`shouldCheckForColocatedFragments`](/reference/config-format#shouldcheckforcolocatedfragments)
@@ -247,7 +249,7 @@ setting:
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql"
         "tadaOutputLocation": "./src/graphql-env.d.ts",
         "tadaTurboLocation": "./src/graphql-cache.d.ts" // [!code ++]

--- a/website/guides/fragment-colocation.md
+++ b/website/guides/fragment-colocation.md
@@ -356,6 +356,32 @@ and hidden.
 > We recommend you not to disable Fragment Masking unless you absolutely have to,
 > to enforce fragment composition safety.
 
+::: details Disabling Fragment Masking globally
+While fragment masking is the default, you can also switch it off globally, which
+is equivalent to adding `@_unmask` to every fragment.
+
+We don't necessarily recommend starting out with this, since it makes it harder to
+switch and migrate to fragment masking incrementally, if you decide to do so in the
+future.
+
+However, if this isn't a concern to you, you can pass a `disableMasking` flag
+to the `initGraphQLTada` call:
+
+```ts twoslash [src/graphql.ts]
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from './graphql/graphql-env.d.ts';
+
+// ---cut-before---
+export const graphql = initGraphQLTada<{
+  disableMasking: true; // [!code ++]
+  introspection: introspection;
+  scalars: {
+    DateTime: string;
+  };
+}>();
+```
+:::
+
 ### Import Diagnostic
 
 Fragment colocation and masking helps us manage large amounts of GraphQL documents

--- a/website/guides/fragment-colocation.md
+++ b/website/guides/fragment-colocation.md
@@ -326,13 +326,6 @@ export const PokemonTypes = (props: {
 ```
 :::
 
-> [!TIP]
-> This is the default behaviour in `gql.tada`, and happens unless you add `@_unmask`
-> to a fragment.
->
-> However, by default, we recommend you not to disable Fragment Masking unless you
-> absolutely have to, to enforce fragment composition.
-
 Inside the inferred TypeScript types, when fragment masking _isn’t disabled_ using
 `@_unmask`, then `gql.tada` will infer masked types. In TypeScript, the type that
 `FragmentOf<>` returns may look like the following:
@@ -350,3 +343,54 @@ type maskedPokemonTypes = {
   };
 };
 ```
+
+The `$tada.fragmentRefs` property above is just a stand-in for the fragment that we've
+used in our GraphQL document and all selections inside that fragment are not present
+and hidden.
+
+> [!TIP] Why is this the default behaviour?
+> This is the default behaviour in `gql.tada`, and happens unless you add `@_unmask`
+> to a fragment. Not only is this a great pattern to prevent mistakes, it also improves
+> TypeScript's inference performance!
+>
+> We recommend you not to disable Fragment Masking unless you absolutely have to,
+> to enforce fragment composition safety.
+
+### Import Diagnostic
+
+Fragment colocation and masking helps us manage large amounts of GraphQL documents
+when creating and composing queries, while keeping data usage isolated and minimal,
+right next to our UI components.
+However, a common mistake with this method is that sometimes we may forget to import
+and use a fragment.
+
+To prevent us from leaving out fragments, the TypeScript plugin has a diagnostic
+called `shouldCheckForColocatedFragments`. This diagnostic will issue a warning
+if any imports in your documents don't include an exported fragment.
+
+::: code-group
+```tsx twoslash {4} [Without importing a fragment]
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+// @filename: ./src/PokemonsList.tsx
+// ---cut---
+// @warn: GraphQLSP: Unused co-located fragment definition(s)
+
+import { PokemonItem } from './PokemonItem';
+```
+
+```tsx twoslash {4} [With importing a fragment]
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+// @filename: ./src/PokemonsList.tsx
+// ---cut---
+import { PokemonItem, PokemonItemFragment } from './PokemonItem';
+```
+:::
+
+This ties together the last loose end for the fragment colocation and masking
+patterns.
+
+<a href="/reference/config-format#shouldcheckforcolocatedfragments" class="button">
+  Learn more about this diagnostic
+</a>

--- a/website/guides/multiple-schemas.md
+++ b/website/guides/multiple-schemas.md
@@ -50,7 +50,7 @@ all schema options onto a `schemas[]` array.
   "compilerOptions": {
     "plugins": [
       { // [!code focus:15]
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schemas": [
           {
             "name": "pokemon",
@@ -246,7 +246,7 @@ to configure their output file paths in your schema options instead.
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schemas": [
           {
             "name": "pokemon",

--- a/website/guides/persisted-documents.md
+++ b/website/guides/persisted-documents.md
@@ -154,15 +154,16 @@ IDs for documents don't necessarily have to be human-readable, and often
 need to change when the document changes.
 
 Since it's tedious to manually generate hashes for a GraphQL document and
-to keep track of when it changes, `@0no-co/graphqlsp` has to mechanisms to
-deal with hashed document IDs:
+to keep track of when it changes, the TypeScript plugin has to mechanisms to
+help us with hashed document IDs:
 
-- provides a **code action** that generates a SHA256 hash of your document
-- warns you if this SHA256 hash needs to be updated
+- it provides a **code action** that generates a SHA256 hash of your document
+- a **diagnostic** warns you if this SHA256 hash needs to be updated
 
-The code action will be offered once you have defined a `graphql.persisted()`
-call and when activated, it will replace the current document ID passed to the
-call. In our example above, we'd end up with the following code after:
+The code action will be reported to your editor once you have defined
+a `graphql.persisted()` call. When activated, it will replace the current
+document ID passed to the call with a new hash.
+In our example above, we'd end up with the following code after:
 
 ```ts
 const persistedQuery = graphql.persisted(
@@ -203,7 +204,7 @@ the `tadaPersistedLocation` setting:
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql"
         "tadaOutputLocation": "./src/graphql-env.d.ts",
         "tadaPersistedLocation": "./persisted.json" // [!code ++]

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -190,13 +190,21 @@ We must either pass the document as a generic type argument or as the second arg
 - `graphql.persisted<typeof document>("abc...")`
 - `graphql.persisted("abc...", document)`
 
-`@0no-co/graphqlsp` will then check that the document is available and offer a code action to automatically update the hash to a SHA256-hash of the document.
+The TypeScript plugin and the [`gql.tada check` command](/reference/gql-tada-cli#check)
+run a diagnostic which can check that the document is passed into `graphql.persisted()`
+correctly. Furthermore, the TypeScript plugin offers a code action to automatically update
+the `hash` argument to a SHA256-hash computed from the document.
 
-This is useful to implement and extract persisted operations using the CLI. Additionally, when the document is passed as a generic — as long as our GraphQL cache supports this — it can be fully omitted during runtime from the client-side bundle.
+This is useful to implement and extract persisted operations using the CLI. Additionally,
+when the document is passed as a generic — as long as our GraphQL cache supports this — it
+can be fully omitted during runtime from the client-side bundle.
 
-> [!NOTE]
-> When you use the generic API, passing the document by type using `graphql.persisted<typeof document>("...")`, your runtime code won’t see any `definitions` on the AST.
-> This may cause problems with GraphQL clients (especially normalised caches) that rely on the AST to be available, since the full document will transpile away.
+> [!WARNING] Client Compatibility
+> When passing a document by type as a generic to `graphql.persisted<typeof document>("...")`, your runtime code
+> won’t see any `definitions` on the AST.
+>
+> This may cause problems with GraphQL clients (especially normalized caches) that rely on the AST to be available,
+> since the full document will be transpile away.
 > For such clients, you may want to preserve the document by passing it as a second argument instead.
 
 #### Example

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -60,9 +60,12 @@ The `doctor` command will check for common mistakes in the `gql.tada`’s setup 
 | `--fail-on-warn,-w` | Triggers an error and a non-zero exit code if any warnings have been reported (default: `false`). |
 | `--level,-l`        | The minimum severity of diagnostics to display: `info`, `warn` or `error` (default: `info`).      |
 
-Usually, `@0no-co/graphqlsp` runs as a TypeScript language server plugin to report warnings and errors. However, these diagnostics don’t show up when `tsc` is run.
+Usually, the TypeScript plugin will run inside your editor's TypeScript language server process and will report warnings
+and errors. However, these diagnostics aren't run when `tsc` or other TypeScript compiler processes are used, since those
+neither load plugins nor are part of the TypeScript language service API.
 
-The `gql.tada check` command exists to run these diagnostics in a standalone command, outside of editing the relevant files and reports these errors to the console.
+The `gql.tada check` command exists to run these diagnostics in a standalone command, outside of editing the relevant
+files and reports these errors to the console.
 
 When this command is run inside a GitHub Action, [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) are used to annotate errors within the GitHub UI.
 
@@ -92,7 +95,9 @@ which can be overridden using the `--output` argument.
 | `--tsconfig,-c`           | Optionally, a `tsconfig.json` file to use instead of an automatically discovered one.         |
 | `--output,-o`             | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option) |
 
-The `gql.tada generate-output` command mimics the behavior of `@0no-co/graphqlsp`, outputting the `gql.tada` output file manually. It will load the schema from the specified `schema` configuration option and write the output file.
+The `gql.tada generate-output` command programmatically outputs the `gql.tada` output typings file.
+It will load the schema from the specified `schema` configuration option first then write the typings file to the specified
+location.
 
 The output file will be written to the location specified by the `tadaOutputLocation` configuration
 option, which can be overridden using the `--output` argument.


### PR DESCRIPTION
- Change references to `@0no-co/graphqlsp` to `gql.tada/ts-plugin`
- Add sections for alternative setup instructions to Installation page
  - Separate section for VSCode
  - New section for `@0no-co/graphqlsp` in TypeScript <5.5
- Simplify all references to GraphQLSP by referring to it as the "TypeScript plugin"
- Rephrase a couple of outdated terms ("`introspection` file" to "typings output file")
- Rephrase several sections to make it easier to understand the TypeScript plugin / type system relationship

This will still need some updates to the `Introduction` page.
Currenty, I'm thinking that we may want to split the "How it works" section out, and remove the support section (maybe supplementing the latter with some additions to "Writing GraphQL")

The introduction page could generally maybe be a bit more engaging or interactive.