### PR TITLE
chore(cli): disable field-usage and colocated fragments for vue/svelte 

### DIFF
--- a/.changeset/happy-cheetahs-provide.md
+++ b/.changeset/happy-cheetahs-provide.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": minor
+---
+
+Add types for field-usage tracking and checking for co-located fragments

--- a/.changeset/happy-cheetahs-provide.md
+++ b/.changeset/happy-cheetahs-provide.md
@@ -1,5 +1,5 @@
 ---
-"@gql.tada/internal": minor
+"@gql.tada/internal": patch
 ---
 
 Add types for field-usage tracking and checking for co-located fragments

--- a/.changeset/thin-cats-tell.md
+++ b/.changeset/thin-cats-tell.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": minor
+---
+
+Disable field-usage tracking and the co-located fragment checking for vue/svelte

--- a/packages/cli-utils/src/commands/check/thread.ts
+++ b/packages/cli-utils/src/commands/check/thread.ts
@@ -40,7 +40,16 @@ async function* _runDiagnostics(
   };
 
   for (const sourceFile of sourceFiles) {
+    const isVueOrSvelte =
+      sourceFile.fileName.endsWith('.vue.ts') || sourceFile.fileName.endsWith('.svelte.ts');
     let filePath = sourceFile.fileName;
+    pluginInfo.config = {
+      ...pluginInfo.config,
+      shouldCheckForColocatedFragments: isVueOrSvelte
+        ? false
+        : pluginInfo.config.shouldCheckForColocatedFragments ?? false,
+      trackFieldUsage: isVueOrSvelte ? false : pluginInfo.config.trackFieldUsage ?? false,
+    };
     const diagnostics = getGraphQLDiagnostics(filePath, schemaRef, pluginInfo);
     const messages: DiagnosticMessage[] = [];
 

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -5,6 +5,8 @@ import type { SchemaOrigin } from './loaders';
 
 export interface BaseConfig {
   template?: string;
+  trackFieldUsage?: boolean;
+  shouldCheckForColocatedFragments?: boolean;
 }
 
 export interface SchemaConfig {


### PR DESCRIPTION
Resolves https://github.com/0no-co/gql.tada/issues/323

## Summary

The field-usage heuristics see the generated functions as two different scopes so the field-usage and co-located fragment tracking fails to report correctly, hence for now we disable this when analyzing svelte/vue.
