### PR TITLE
fix(internal): Use TypeScript's built-in file watcher for SDL loader

### DIFF
--- a/.changeset/silent-eyes-boil.md
+++ b/.changeset/silent-eyes-boil.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/internal": patch
+---
+
+Fix SDL-file schema watcher missing changed file events on macOS under certain write conditions.


### PR DESCRIPTION
Resolves #339

## Summary

**TODO**
- Test this on Linux and Windows
- Check default options of `ts.sys.watchFile` that TypeScript itself uses (as default options were broken out of the box on macOS)

This switches the SDL loader over to using `ts.sys.watchFile` in favour of other, similar file watchers that work around some issues. Generally, there are some conditions under which the built-in file watcher in Node fails. It's suspected that swap-writing in some editors breaks the file watcher, for example.

Instead of working around this ourselves, we can use TypeScript's implementation, which implements all known workarounds and approaches, including polling fallbacks.

## Set of changes

- Use `ts.sys.watchFile` in SDL file loader's watcher
