### PR TITLE
feat(examples): use new plugin alias

### DIFF
--- a/.changeset/lemon-rice-arrive.md
+++ b/.changeset/lemon-rice-arrive.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": minor
+---
+
+Use gql.tada/ts-plugin alias for examples

--- a/examples/example-pokemon-api/package.json
+++ b/examples/example-pokemon-api/package.json
@@ -13,7 +13,6 @@
     "urql": "^4.0.7"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.12.9",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
     "@vitejs/plugin-react": "^4.2.1",

--- a/examples/example-pokemon-api/src/components/Attack.tsx
+++ b/examples/example-pokemon-api/src/components/Attack.tsx
@@ -1,0 +1,26 @@
+import { FragmentOf, graphql, readFragment } from '../graphql';
+
+export const AttackFragment = graphql(`
+  fragment AttackItem on Attack {
+    name
+    type
+    damage
+  }
+`);
+
+interface Props {
+  data: FragmentOf<typeof AttackFragment> | null;
+}
+
+export const Attack: React.FC<Props> = ({ data }) => {
+  const attack = readFragment(AttackFragment, data);
+  if (!attack) {
+    return null;
+  }
+
+  return (
+    <span>
+      {attack.name} ({attack.type}): {attack.damage} damage
+    </span>
+  );
+};

--- a/examples/example-pokemon-api/src/components/PokemonItem.tsx
+++ b/examples/example-pokemon-api/src/components/PokemonItem.tsx
@@ -1,17 +1,30 @@
 import { FragmentOf, graphql, readFragment } from '../graphql';
+import { Attack, AttackFragment } from './Attack';
 
-export const PokemonItemFragment = graphql(`
-  fragment PokemonItem on Pokemon {
-    id
-    name
-  }
-`);
+export const PokemonItemFragment = graphql(
+  `
+    fragment PokemonItem on Pokemon {
+      id
+      name
+      types
+      attacks @include(if: $includeAttacks) {
+        fast {
+          ...AttackItem
+        }
+        special {
+          ...AttackItem
+        }
+      }
+    }
+  `,
+  [AttackFragment]
+);
 
 interface Props {
   data: FragmentOf<typeof PokemonItemFragment> | null;
 }
 
-const PokemonItem = ({ data }: Props) => {
+const PokemonItem: React.FC<Props> = ({ data }) => {
   const pokemon = readFragment(PokemonItemFragment, data);
   if (!pokemon) {
     return null;
@@ -19,7 +32,31 @@ const PokemonItem = ({ data }: Props) => {
 
   return (
     <li>
-      {pokemon.name}
+      <strong>{pokemon.name}</strong> ({pokemon.types?.join(', ')})
+      {pokemon.attacks?.fast && (
+        <details>
+          <summary>Fast Attacks</summary>
+          <ul>
+            {pokemon.attacks.fast.map((attack, index) => (
+              <li>
+                <Attack data={attack} key={index} />
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+      {pokemon.attacks?.special && (
+        <details>
+          <summary>Special Attacks</summary>
+          <ul>
+            {pokemon.attacks.special.map((attack, index) => (
+              <li>
+                <Attack data={attack} key={index} />
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
     </li>
   );
 };

--- a/examples/example-pokemon-api/src/components/PokemonList.tsx
+++ b/examples/example-pokemon-api/src/components/PokemonList.tsx
@@ -1,50 +1,84 @@
 import { useQuery } from 'urql';
+import { useState } from 'react';
 import { graphql } from '../graphql';
-
 import { PokemonItem, PokemonItemFragment } from './PokemonItem';
 
-const PokemonsQuery = graphql(`
-  query Pokemons ($limit: Int = 10) {
-    pokemons(limit: $limit) {
-      id
-      ...PokemonItem
+const PokemonsQuery = graphql(
+  `
+    query Pokemons($limit: Int = 10, $includeAttacks: Boolean = true) {
+      pokemons(limit: $limit) {
+        id
+        ...PokemonItem
+      }
     }
-  }
-`, [PokemonItemFragment]);
+  `,
+  [PokemonItemFragment]
+);
 
 const PersistedQuery = graphql.persisted(
-  "sha256:fc073da8e9719deb51cdb258d7c35865708852c5ce9031a257588370d3cd42f3",
-  PokemonsQuery,
+  'sha256:73ed59135aef3618a4d63e8d22b603234af79820e9b5ce54c6b171c6f292ca5d',
+  PokemonsQuery
 );
 
 const PokemonList = () => {
-  const [result] = useQuery({ query: PersistedQuery });
+  const [limit, setLimit] = useState(10);
+  const [includeAttacks, setIncludeAttacks] = useState(false);
+  const [result] = useQuery({
+    query: PersistedQuery,
+    variables: {
+      limit,
+      includeAttacks,
+    },
+  });
 
   const { data, fetching, error } = result;
 
   if (error) {
     return (
       <>
-        <h3>Oh no!</h3>
+        <h1>Oh no!</h1>
         <pre>{error.message}</pre>
       </>
     );
   } else if (fetching || !data) {
-    return <h3>Loading...</h3>
+    return <p>Loading...</p>;
   }
 
   return (
-    <div>
+    <main>
+      <h1>Pokedex</h1>
+      <fieldset>
+        <legend>Query Settings</legend>
+        <div>
+          <label htmlFor="limit">Limit:</label>
+          <select id="limit" onChange={(e) => setLimit(parseInt(e.target.value))}>
+            {[10, 20, 50, 100].map((value) => (
+              <option key={value} selected={limit === value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="includeAttacks">Include Attacks:</label>
+          <input
+            id="includeAttacks"
+            type="checkbox"
+            checked={includeAttacks}
+            onChange={(e) => setIncludeAttacks(e.target.checked)}
+          />
+        </div>
+      </fieldset>
       {data.pokemons ? (
-        <ul>
+        <ol>
           {data.pokemons.map((pokemon, index) => (
             <PokemonItem data={pokemon} key={pokemon?.id || index} />
           ))}
-        </ul>
+        </ol>
       ) : (
-        <h3>Your Pokedex is empty.</h3>
+        <p>Your Pokedex is empty.</p>
       )}
-    </div>
+    </main>
   );
 };
 

--- a/examples/example-pokemon-api/tsconfig.json
+++ b/examples/example-pokemon-api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql",
         "tadaOutputLocation": "./src/graphql-env.d.ts"
       }

--- a/examples/example-pokemon-svelte/package.json
+++ b/examples/example-pokemon-svelte/package.json
@@ -12,7 +12,6 @@
     "svelte": "^4.0.5"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.12.9",
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
     "typescript": "^5.5.2",
     "vite": "^5.2.10"

--- a/examples/example-pokemon-svelte/tsconfig.json
+++ b/examples/example-pokemon-svelte/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql",
         "tadaOutputLocation": "./src/graphql-env.d.ts"
       }

--- a/examples/example-pokemon-vue/package.json
+++ b/examples/example-pokemon-vue/package.json
@@ -13,7 +13,6 @@
     "vue": "^3.4.25"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.12.9",
     "@vitejs/plugin-vue": "^5.0.4",
     "typescript": "^5.5.2",
     "vite": "^5.2.10",

--- a/examples/example-pokemon-vue/tsconfig.json
+++ b/examples/example-pokemon-vue/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@0no-co/graphqlsp",
+        "name": "gql.tada/ts-plugin",
         "schema": "./schema.graphql",
         "tadaOutputLocation": "./src/graphql-env.d.ts"
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
         specifier: ^4.0.7
         version: 4.0.7(graphql@16.8.1)(react@18.3.1)
     devDependencies:
-      '@0no-co/graphqlsp':
-        specifier: ^1.12.9
-        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.1
@@ -174,9 +171,6 @@ importers:
         specifier: ^4.0.5
         version: 4.2.15
     devDependencies:
-      '@0no-co/graphqlsp':
-        specifier: ^1.12.9
-        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
         version: 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))
@@ -205,9 +199,6 @@ importers:
         specifier: ^3.4.25
         version: 3.4.25(typescript@5.5.2)
     devDependencies:
-      '@0no-co/graphqlsp':
-        specifier: ^1.12.9
-        version: 1.12.9(graphql@16.8.1)(typescript@5.5.2)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.25(typescript@5.5.2))


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Thank you for making gql.tada! It feels like a breath of fresh air after many years of the good and trusted graphql-codegen. 🎉 

When browsing the source code (especially the examples) I was a little confused:

- The examples are not using the newish `gql-tada/ts-plugin` alias. Not sure if this is intended.
- The example for React contained the somewhat (I think) advanced concept Persisted Queries but no simple showcase of variables and directives.

Hence...

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- all examples: removes `@0no-co/graphqlsp` dependency and instead uses the new plugin alias
- example-pokemon-api: Make the example a little interactive with variables and a directive

I can update the Vue + Svelte Examples to match the React one if there is interest.

Thank you!