### PR TITLE
patch(cli-utils): Bump stack trace limit when TypeScript is used

### DIFF
--- a/.changeset/ten-owls-vanish.md
+++ b/.changeset/ten-owls-vanish.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Bump stack trace limit to 25 when TypeScript is used, which requires a larger stack depths to debug properly.

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -44,6 +44,13 @@ export interface ProgramFactory {
   build(): ProgramContainer;
 }
 
+/** Bumps the Error stack traces to a length of 100 for better debugging. */
+const bumpStackTraceLimit = () => {
+  if ('stackTraceLimit' in Error && Error.stackTraceLimit < 25) {
+    Error.stackTraceLimit = 25;
+  }
+};
+
 export const programFactory = (params: ProgramFactoryParams): ProgramFactory => {
   const vfsMap = new Map<string, string>();
   const virtualMap: VirtualMap = new Map();
@@ -154,6 +161,8 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
     },
 
     build() {
+      bumpStackTraceLimit();
+
       // NOTE: This is necessary for `@0no-co/graphqlsp/api` to use the right instance
       // of the typescript library
       init({ typescript: ts });

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -44,7 +44,7 @@ export interface ProgramFactory {
   build(): ProgramContainer;
 }
 
-/** Bumps the Error stack traces to a length of 100 for better debugging. */
+/** Bumps the Error stack traces to a length of 25 for better debugging. */
 const bumpStackTraceLimit = () => {
   if ('stackTraceLimit' in Error && Error.stackTraceLimit < 25) {
     Error.stackTraceLimit = 25;


### PR DESCRIPTION
## Summary

Increase stack trace limit to `25` when TypeScript is used, as the default of `10` isn't enough to properly debug issues in most (if not all) cases that TypeScript's type checker or program is involved in a crash.

## Set of changes

- Add `bumpStackTraceLimit` utility
