### PR TITLE
fix(cli-utils): Add `moduleResolution` override for `NodeNext`/`Node16`

### DIFF
--- a/.changeset/gold-balloons-count.md
+++ b/.changeset/gold-balloons-count.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Prevent `NodeNext` module resolution from being used over `Bundler` mode, since this is almost always a mistake.

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -64,6 +64,15 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
     getDefaultLibFilePath: ts.getDefaultLibFilePath(config.options),
     ...config.options,
   };
+
+  // NOTE: Using "NodeNext" instead of "Bundler" is almost always a mistake
+  if (
+    'Bundler' in ts.ModuleResolutionKind &&
+    options.moduleResolution === ts.ModuleResolutionKind.NodeNext
+  ) {
+    options.moduleResolution = ts.ModuleResolutionKind.Bundler;
+  }
+
   const host = createVirtualCompilerHost(system, options, ts);
 
   const factory: ProgramFactory = {

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -68,7 +68,8 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
   // NOTE: Using "NodeNext" instead of "Bundler" is almost always a mistake
   if (
     'Bundler' in ts.ModuleResolutionKind &&
-    options.moduleResolution === ts.ModuleResolutionKind.NodeNext
+    (options.moduleResolution === ts.ModuleResolutionKind.NodeNext ||
+      options.moduleResolution === ts.ModuleResolutionKind.Node16)
   ) {
     options.moduleResolution = ts.ModuleResolutionKind.Bundler;
   }


### PR DESCRIPTION
Related: https://github.com/0no-co/gql.tada/issues/347#issuecomment-2258746859

## Summary

Using `NodeNext`/`Node16` is almost always a mistake. This will disallow extension-less imports, and is almost always not preferred over `Bundler`. In practice, `NodeNext` is only the `Bundler` resolution with the added restriction, and if it's used and we get module resolution errors, this was likely a mistake. Overriding it is always safe since it's a super-set of `NodeNext`.

## Set of changes

- Override `moduleResolution` to `Bundler` if it's `NodeNext`/`Node16`
