### PR TITLE
patch(cli-utils): Add fallbacks for version checks to `doctor` command

### DIFF
--- a/.changeset/curvy-mirrors-warn.md
+++ b/.changeset/curvy-mirrors-warn.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Add fallback version checks to `doctor` command.

--- a/packages/cli-utils/src/commands/doctor/helpers/versions.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/versions.ts
@@ -1,0 +1,59 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface PackageJson {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+export const readPackageJson = async (): Promise<PackageJson> => {
+  const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+  const file = path.resolve(packageJsonPath);
+  return JSON.parse(await fs.readFile(file, 'utf-8'));
+};
+
+export const getTypeScriptVersion = async (meta: PackageJson): Promise<string | null> => {
+  const pkg = 'typescript';
+  if (meta.devDependencies?.[pkg]) {
+    return meta.devDependencies[pkg];
+  } else if (meta.dependencies?.[pkg]) {
+    return meta.dependencies[pkg];
+  }
+  try {
+    return (await import(pkg)).version || null;
+  } catch (_error) {
+    return null;
+  }
+};
+
+export const getGraphQLSPVersion = async (meta: PackageJson): Promise<string | null> => {
+  const pkg = '@0no-co/graphqlsp';
+  if (meta.devDependencies?.[pkg]) {
+    return meta.devDependencies[pkg];
+  } else if (meta.dependencies?.[pkg]) {
+    return meta.dependencies[pkg];
+  }
+  try {
+    // NOTE: Resolved from current folder, since it's a child dependency
+    return createRequire(__dirname)(`${pkg}/package.json`)?.version || null;
+  } catch (_error) {
+    return null;
+  }
+};
+
+export const getGqlTadaVersion = async (meta: PackageJson): Promise<string | null> => {
+  const pkg = 'gql.tada';
+  if (meta.devDependencies?.[pkg]) {
+    return meta.devDependencies[pkg];
+  } else if (meta.dependencies?.[pkg]) {
+    return meta.dependencies[pkg];
+  }
+  try {
+    // NOTE: Resolved from working directory, since it's a parent dependency
+    return createRequire(process.cwd())(`${pkg}/package.json`)?.version || null;
+  } catch (_error) {
+    return null;
+  }
+};

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -7,6 +7,7 @@ import { loadRef, loadConfig, parseConfig } from '@gql.tada/internal';
 import type { ComposeInput } from '../../term';
 import { MINIMUM_VERSIONS, semverComply } from '../../utils/semver';
 import { findGraphQLConfig } from './helpers/graphqlConfig';
+import * as versions from './helpers/versions';
 import * as vscode from './helpers/vscode';
 import * as logger from './logger';
 
@@ -38,16 +39,10 @@ export async function* run(): AsyncIterable<ComposeInput> {
   await delay();
 
   // Check TypeScript version
-  const cwd = process.cwd();
-  const packageJsonPath = path.resolve(cwd, 'package.json');
-  let packageJsonContents: {
-    dependencies: Record<string, string>;
-    devDependencies: Record<string, string>;
-  };
-
+  let packageJson: versions.PackageJson;
   try {
-    const file = path.resolve(packageJsonPath);
-    packageJsonContents = JSON.parse(await fs.readFile(file, 'utf-8'));
+    // packageJson = await versions.readPackageJson();
+    packageJson = {};
   } catch (_error) {
     yield logger.failedTask(Messages.CHECK_TS_VERSION);
     throw logger.errorMessage(
@@ -56,19 +51,14 @@ export async function* run(): AsyncIterable<ComposeInput> {
     );
   }
 
-  const deps = Object.entries({
-    ...packageJsonContents.dependencies,
-    ...packageJsonContents.devDependencies,
-  });
-
-  const typeScriptVersion = deps.find((x) => x[0] === 'typescript');
+  const typeScriptVersion = await versions.getTypeScriptVersion(packageJson);
   if (!typeScriptVersion) {
     yield logger.failedTask(Messages.CHECK_TS_VERSION);
     throw logger.errorMessage(
       `A version of ${logger.code('typescript')} was not found in your dependencies.\n` +
         logger.hint(`Is ${logger.code('typescript')} installed in this package?`)
     );
-  } else if (!semverComply(typeScriptVersion[1], MINIMUM_VERSIONS.typescript)) {
+  } else if (!semverComply(typeScriptVersion, MINIMUM_VERSIONS.typescript)) {
     // TypeScript version lower than v4.1 which is when they introduced template lits
     yield logger.failedTask(Messages.CHECK_TS_VERSION);
     throw logger.errorMessage(
@@ -84,18 +74,18 @@ export async function* run(): AsyncIterable<ComposeInput> {
   await delay();
 
   const supportsEmbeddedLsp = semverComply(
-    typeScriptVersion[1],
+    typeScriptVersion,
     MINIMUM_VERSIONS.typescript_embed_lsp
   );
   if (!supportsEmbeddedLsp) {
-    const gqlspVersion = deps.find((x) => x[0] === '@0no-co/graphqlsp');
+    const gqlspVersion = await versions.getGraphQLSPVersion(packageJson);
     if (!gqlspVersion) {
       yield logger.failedTask(Messages.CHECK_DEPENDENCIES);
       throw logger.errorMessage(
         `A version of ${logger.code('@0no-co/graphqlsp')} was not found in your dependencies.\n` +
           logger.hint(`Is ${logger.code('@0no-co/graphqlsp')} installed?`)
       );
-    } else if (!semverComply(gqlspVersion[1], MINIMUM_VERSIONS.lsp)) {
+    } else if (!semverComply(gqlspVersion, MINIMUM_VERSIONS.lsp)) {
       yield logger.failedTask(Messages.CHECK_DEPENDENCIES);
       throw logger.errorMessage(
         `The version of ${logger.code(
@@ -108,14 +98,14 @@ export async function* run(): AsyncIterable<ComposeInput> {
     }
   }
 
-  const gqlTadaVersion = deps.find((x) => x[0] === 'gql.tada');
+  const gqlTadaVersion = await versions.getGqlTadaVersion(packageJson);
   if (!gqlTadaVersion) {
     yield logger.failedTask(Messages.CHECK_DEPENDENCIES);
     throw logger.errorMessage(
       `A version of ${logger.code('gql.tada')} was not found in your dependencies.\n` +
         logger.hint(`Is ${logger.code('gql.tada')} installed?`)
     );
-  } else if (!semverComply(gqlTadaVersion[1], '1.0.0')) {
+  } else if (!semverComply(gqlTadaVersion, '1.0.0')) {
     yield logger.failedTask(Messages.CHECK_DEPENDENCIES);
     throw logger.errorMessage(
       `The version of ${logger.code('gql.tada')} in your dependencies is out of date.\n` +

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import type { GraphQLSPConfig, LoadConfigResult } from '@gql.tada/internal';


### PR DESCRIPTION
See: #357

## Summary

While it's correct that we'd want users to install `gql.tada` locally in packages, depending on where the command is run, the local `package.json` may not contain all dependencies. This lifts this limitation and basically makes sure of the basics:
- `typescript` should be available via a direct `import()` since it's a direct dependency of the CLI (via peer)
- `@0no-co/graphqlsp` should be available via a direct `require()` from the package since it's a direct dependency of the CLI (via peer)
- `gql.tada` should be available via a `require()` from the working directory, since it must be present to start up the CLI

This should generally allow us to be a little more lenient in the `doctor` checks.

## Set of changes

- Add `helpers/versions` to doctor for version checking
