### PR TITLE
fix(cli-utils): When threading, transfer extra error properties to host

### DIFF
--- a/.changeset/late-cougars-act.md
+++ b/.changeset/late-cougars-act.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+When threading, transfer error properties to thread host.


### PR DESCRIPTION
## Summary

The default serializer/transferables logic doesn't transfer extra properties on Errors. It can correctly transfers stacktraces and the message of the original error, but doesn't transfers extras such as the `name` property.

When applied, this change adds an extra serialization step for errors that transfers extra properties over.

Without this logic, it wouldn't be possible for us to add special handling to errors by their type/name.

## Set of changes

- Add `extra` properties for errors to transfer on throws in thread
