### PR TITLE
fix: Protect against missing typename fields on base types

### DIFF
--- a/.changeset/three-jobs-boil.md
+++ b/.changeset/three-jobs-boil.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Add `__typename` narrowing of unmasked interface fragment spreads, which could otherwise lead to confusion. This usually is relevant when the parent selection set forgets to include a `__typename` selection.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -178,6 +178,19 @@ describe('graphql()', () => {
       }
     `);
 
+    // NOTE: BigTodo's fields shouldn't be included here
+    const nestedFragment = graphql(`
+      fragment Object on SmallTodo @_unmask {
+        maxLength
+        ... on ITodo {
+          id
+          ... on BigTodo {
+            wallOfText
+          }
+        }
+      }
+    `);
+
     expectTypeOf<FragmentOf<typeof objectFragment>>().toEqualTypeOf<{
       __typename: 'SmallTodo';
       id: string;
@@ -186,6 +199,11 @@ describe('graphql()', () => {
 
     expectTypeOf<FragmentOf<typeof standaloneFragment>>().toEqualTypeOf<{
       __typename: 'SmallTodo';
+      id: string;
+      maxLength: number | null;
+    }>();
+
+    expectTypeOf<FragmentOf<typeof nestedFragment>>().toEqualTypeOf<{
       id: string;
       maxLength: number | null;
     }>();

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -166,7 +166,25 @@ describe('graphql()', () => {
       [interfaceFragment]
     );
 
+    const standaloneFragment = graphql(`
+      fragment Object on SmallTodo @_unmask {
+        maxLength
+        ...Fields
+      }
+
+      fragment Fields on ITodo @_unmask {
+        __typename
+        id
+      }
+    `);
+
     expectTypeOf<FragmentOf<typeof objectFragment>>().toEqualTypeOf<{
+      __typename: 'SmallTodo';
+      id: string;
+      maxLength: number | null;
+    }>();
+
+    expectTypeOf<FragmentOf<typeof standaloneFragment>>().toEqualTypeOf<{
       __typename: 'SmallTodo';
       id: string;
       maxLength: number | null;

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -147,6 +147,32 @@ describe('graphql()', () => {
     }>();
   });
 
+  // See: https://github.com/0no-co/gql.tada/issues/365
+  it('should create a fragment type of unmasked interface fragments on object types', () => {
+    const interfaceFragment = graphql(`
+      fragment Fields on ITodo @_unmask {
+        __typename
+        id
+      }
+    `);
+
+    const objectFragment = graphql(
+      `
+        fragment Object on SmallTodo @_unmask {
+          maxLength
+          ...Fields
+        }
+      `,
+      [interfaceFragment]
+    );
+
+    expectTypeOf<FragmentOf<typeof objectFragment>>().toEqualTypeOf<{
+      __typename: 'SmallTodo';
+      id: string;
+      maxLength: number | null;
+    }>();
+  });
+
   it('should preserve object literal types for variables', () => {
     const mutation = graphql(`
       mutation ($input: TodoPayload!) {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -93,7 +93,10 @@ type getFragmentSelection<
   : Node extends { kind: Kind.FRAGMENT_SPREAD; name: any }
     ? Node['name']['value'] extends keyof Fragments
       ? Fragments[Node['name']['value']] extends { [$tada.ref]: any }
-        ? Fragments[Node['name']['value']][$tada.ref]
+        ? Type extends { kind: 'INTERFACE'; name: any }
+          ? /* This protects against various edge cases where users forget to select `__typename` (See `getSelection`) */
+            Fragments[Node['name']['value']][$tada.ref] & { __typename?: PossibleType }
+          : Fragments[Node['name']['value']][$tada.ref]
         : getPossibleTypeSelectionRec<
             Fragments[Node['name']['value']]['selectionSet']['selections'],
             PossibleType,


### PR DESCRIPTION
Follow-up to #102
Resolves #365

## Summary

The differentiation when going from a narrow to a wide type can still cause confusion when the `__typename` field isn't included on the concrete/base type i.e. on the fragment that includes the abstract interface type.

This PR adds another optional `__typename` field to add disambiguation and avoid any confusion caused by this.

## Set of changes

- Disambiguate fragment spreads automatically using `__typename?: PossibleType` field
