### PR TITLE
fix: Improve type output for narrowed interfaces (intersect members of unions instead)

### DIFF
--- a/.changeset/wild-tables-serve.md
+++ b/.changeset/wild-tables-serve.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Improve type output readability for interfaces with narrowed types

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -227,7 +227,9 @@ type getPossibleTypeSelectionRec<
               >
           : SelectionAcc
     >
-  : obj<SelectionAcc['fields']> & SelectionAcc['rest'];
+  : SelectionAcc['rest'] extends infer T
+    ? obj<SelectionAcc['fields'] & T>
+    : never;
 
 type getOperationSelectionType<
   Definition,

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -12,6 +12,8 @@ type ObjectLikeType = {
   fields: { [key: string]: any };
 };
 
+type narrowTypename<T, Typename> = T extends { __typename?: Typename } ? T : never;
+
 type unwrapTypeRec<
   Type,
   SelectionSet,
@@ -95,7 +97,7 @@ type getFragmentSelection<
       ? Fragments[Node['name']['value']] extends { [$tada.ref]: any }
         ? Type extends { kind: 'INTERFACE'; name: any }
           ? /* This protects against various edge cases where users forget to select `__typename` (See `getSelection`) */
-            Fragments[Node['name']['value']][$tada.ref] & { __typename?: PossibleType }
+            narrowTypename<Fragments[Node['name']['value']][$tada.ref], PossibleType>
           : Fragments[Node['name']['value']][$tada.ref]
         : getPossibleTypeSelectionRec<
             Fragments[Node['name']['value']]['selectionSet']['selections'],


### PR DESCRIPTION
## Summary

I noticed that the types on interfaces and unions could become quite complex and the type output wasn't nice to read.

Instead of asking TypeScript to narrow using an intersection, we can instead manually narrow any union, since they're expanded in `extends` types.

**Note:** I'm not 100% sure what the type performance impact of this change might be, but the benchmarks indicate that it's negligible.

Follow-up to #368
But issue is also visible before the above PR was merged. It was just rarer

## Set of changes

- Expand union types before intersecting
