### PR TITLE
fix: Remove redundant `never` default from `readFragment` with explicit generic

### DIFF
--- a/.changeset/hip-sheep-provide.md
+++ b/.changeset/hip-sheep-provide.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Remove redundant `never` default on `readFragment<Document>()` signature (explicit generic passed)

--- a/src/api.ts
+++ b/src/api.ts
@@ -533,55 +533,55 @@ function readFragment<
 ): T extends resultOrFragmentOf<Document> ? ResultOf<Document> : T;
 
 // Reading arrays of fragments with required generic
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly resultOrFragmentOf<Document>[]
 ): readonly ResultOf<Document>[];
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | null)[]
 ): readonly (ResultOf<Document> | null)[];
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | undefined)[]
 ): readonly (ResultOf<Document> | undefined)[];
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | null | undefined)[]
 ): readonly (ResultOf<Document> | null | undefined)[];
 // Reading arrays of fragments with required generic with optional `{}` type
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | {})[]
 ): readonly (ResultOf<Document> | {})[];
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | null | {})[]
 ): readonly (ResultOf<Document> | null | {})[];
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | undefined | {})[]
 ): readonly (ResultOf<Document> | undefined | {})[];
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: readonly (resultOrFragmentOf<Document> | null | undefined | {})[]
 ): readonly (ResultOf<Document> | null | undefined | {})[];
 // Reading fragments with required generic
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document>
 ): ResultOf<Document>;
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | null
 ): ResultOf<Document> | null;
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | undefined
 ): ResultOf<Document> | undefined;
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | null | undefined
 ): ResultOf<Document> | null | undefined;
 // Reading fragments with required generic with optional `{}` type
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | {}
 ): ResultOf<Document> | {};
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | null | {}
 ): ResultOf<Document> | null | {};
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | undefined | {}
 ): ResultOf<Document> | undefined | {};
-function readFragment<const Document extends FragmentShape = never>(
+function readFragment<const Document extends FragmentShape>(
   fragment: resultOrFragmentOf<Document> | null | undefined | {}
 ): ResultOf<Document> | null | undefined | {};
 


### PR DESCRIPTION
## Summary

All `readFragment<Document>(data)` calls receive explicit generics. However, they contained a `= never` default, which was entirely redundant.

**Side-note:** Any `readFragment<Document>({})` are always valid. Unknown data is now accepted. This is unfortunate, but not fixeable without a second generic, which isn't possible in TS.

## Set of changes

- Remove `= never` from `readFragment` overloads with explicit `Document` generics
