### PR TITLE
fix: Add type narrowing to `readFragment`

### DIFF
--- a/.changeset/ten-taxis-shop.md
+++ b/.changeset/ten-taxis-shop.md
@@ -1,0 +1,5 @@
+---
+"gql.tada": patch
+---
+
+Allow `readFragment(doc, data)` to narrow output's `__typename`s by the input type.

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -580,6 +580,30 @@ describe('readFragment', () => {
     expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<document>>();
   });
 
+  it('unmasks fragments of interfaces while narrowing types using input', () => {
+    type fragment = parseDocument<`
+      fragment Fields on ITodo {
+        id
+        ... on BigTodo {
+          wallOfText
+        }
+        ... on SmallTodo {
+          maxLength
+        }
+      }
+    `>;
+
+    type document = getDocumentNode<fragment, schema>;
+
+    const data: FragmentOf<document> & { __typename?: 'SmallTodo' } = {} as any;
+    const result = readFragment({} as document, data);
+    expectTypeOf<typeof result>().toEqualTypeOf<{
+      __typename?: 'SmallTodo';
+      id: unknown;
+      maxLength: unknown;
+    }>();
+  });
+
   it('unmasks fragments of interfaces with optional spreads', () => {
     type fragment = parseDocument<`
       fragment Fields on ITodo {

--- a/src/api.ts
+++ b/src/api.ts
@@ -453,7 +453,7 @@ type resultOfT<Document extends FragmentShape, T = unknown> = Document extends D
   infer Result,
   any
 >
-  ? T extends { __typename?: string }
+  ? '__typename' extends keyof T
     ? Result extends { __typename?: T['__typename'] }
       ? Result
       : never

--- a/src/api.ts
+++ b/src/api.ts
@@ -449,6 +449,17 @@ type FragmentOf<Document extends FragmentShape> = makeFragmentRef<Document>;
 
 type resultOrFragmentOf<Document extends FragmentShape> = FragmentOf<Document> | ResultOf<Document>;
 
+type resultOfT<Document extends FragmentShape, T = unknown> = Document extends DocumentDecoration<
+  infer Result,
+  any
+>
+  ? T extends { __typename?: string }
+    ? Result extends { __typename?: T['__typename'] }
+      ? Result
+      : never
+    : Result
+  : never;
+
 type resultOfFragmentsRec<
   Fragments extends readonly any[],
   Result = {},
@@ -513,24 +524,23 @@ type fragmentRefsOfFragmentsRec<
  */
 function readFragment<const Document extends FragmentShape = never>(
   _document: Document,
-  fragment: resultOrFragmentOf<Document>
-): ResultOf<Document>;
-// Reading fragments where input data is an array and nullable
+  fragment: never
+): resultOfT<Document>;
+
 function readFragment<
   const Document extends FragmentShape,
   const T extends resultOrFragmentOf<Document> | null | undefined | {},
 >(
   _document: Document,
   fragments: readonly T[]
-): readonly (T extends resultOrFragmentOf<Document> ? ResultOf<Document> : T)[];
-// Reading fragments where input data is nullable
+): readonly (T extends resultOrFragmentOf<Document> ? resultOfT<Document, T> : T)[];
 function readFragment<
   const Document extends FragmentShape,
   const T extends resultOrFragmentOf<Document> | null | undefined | {},
 >(
   _document: Document,
   fragment: T
-): T extends resultOrFragmentOf<Document> ? ResultOf<Document> : T;
+): T extends resultOrFragmentOf<Document> ? resultOfT<Document, T> : T;
 
 // Reading arrays of fragments with required generic
 function readFragment<const Document extends FragmentShape>(


### PR DESCRIPTION
## Summary

When an input with a `__typename` property is passed to `readFragment`, we can narrow the output type by this input property

## Set of changes

- Add `resultOfT` helper that, similarly to `narrowTypename` in `selection.ts` narrows the output type of `readFragment`
