### PR TITLE
fix: Add missing type alias for `initGraphQLTada`

### DIFF
--- a/.changeset/empty-hairs-punch.md
+++ b/.changeset/empty-hairs-punch.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Update internal type signature of `initGraphQLTada<>()` function and include `initGraphQLTada<Setup>` alias type. This alias type makes it more intuitive to declare types the return type of `initGraphQLTada()`, since it mirrors the same name.

--- a/src/api.ts
+++ b/src/api.ts
@@ -259,6 +259,33 @@ type configOfSetup<Setup extends AbstractSetupSchema> = {
   isMaskingDisabled: Setup['disableMasking'] extends true ? true : false;
 };
 
+/** Utility to type-instantiate a `graphql` document function with.
+ *
+ * @remarks
+ * The `initGraphQLTada` type may be used to manually instantiate a type
+ * as returned by `initGraphQLTada<>()` with the same input type.
+ *
+ * @example
+ * ```
+ * import { initGraphQLTada } from 'gql.tada';
+ * import type { myIntrospection } from './myIntrospection';
+ *
+ * export const graphql: initGraphQLTada<{
+ *   introspection: typeof myIntrospection;
+ *   scalars: {
+ *     DateTime: string;
+ *     Json: any;
+ *   };
+ * }> = initGraphQLTada();
+ *
+ * const query = graphql(`{ __typename }`);
+ * ```
+ */
+export type initGraphQLTada<Setup extends AbstractSetupSchema> = GraphQLTadaAPI<
+  schemaOfSetup<Setup>,
+  configOfSetup<Setup>
+>;
+
 /** Setup function to create a typed `graphql` document function with.
  *
  * @remarks
@@ -285,7 +312,7 @@ type configOfSetup<Setup extends AbstractSetupSchema> = {
  * const query = graphql(`{ __typename }`);
  * ```
  */
-function initGraphQLTada<const Setup extends AbstractSetupSchema>() {
+export function initGraphQLTada<const Setup extends AbstractSetupSchema>(): initGraphQLTada<Setup> {
   type Schema = schemaOfSetup<Setup>;
   type Config = configOfSetup<Setup>;
 
@@ -709,12 +736,9 @@ function unsafe_readResult<
   return data as any;
 }
 
-const graphql: GraphQLTadaAPI<
-  schemaOfSetup<setupSchema>,
-  configOfSetup<setupSchema>
-> = initGraphQLTada();
+const graphql: initGraphQLTada<setupSchema> = initGraphQLTada();
 
-export { parse, graphql, readFragment, maskFragments, unsafe_readResult, initGraphQLTada };
+export { parse, graphql, readFragment, maskFragments, unsafe_readResult };
 
 export type {
   setupCache,


### PR DESCRIPTION
Resolves #376

## Summary

We can make it more obvious how to explicitly declare a type for the `initGraphQLTada<>()` return type. Currently, replicating it seems unintuitive due to the unexported type helpers that `GraphQLTadaAPI` requires.

Hence, we can create an overloading type alias called `initGraphQLTada<>` that evaluates to this type and is then reused by `graphql` and `initGraphQLTada<>()`'s return type to explicitly make the type clear.

## Set of changes

- Add `initGraphQLTada<>` type alias
