### PR TITLE
feat: Export print from graphql.web

### DIFF
--- a/.changeset/cyan-drinks-destroy.md
+++ b/.changeset/cyan-drinks-destroy.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Re-export the `print` function from [graphql.web](https://github.com/0no-co/graphql.web), used to stringify GraphQL documents.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import type { DocumentNode, DefinitionNode } from '@0no-co/graphql.web';
-import { Kind, parse as _parse, print } from '@0no-co/graphql.web';
+import { Kind, parse as _parse } from '@0no-co/graphql.web';
 
 import type {
   IntrospectionLikeInput,
@@ -738,7 +738,7 @@ function unsafe_readResult<
 
 const graphql: initGraphQLTada<setupSchema> = initGraphQLTada();
 
-export { parse, graphql, readFragment, maskFragments, unsafe_readResult, print };
+export { parse, graphql, readFragment, maskFragments, unsafe_readResult };
 
 export type {
   setupCache,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import type { DocumentNode, DefinitionNode } from '@0no-co/graphql.web';
-import { Kind, parse as _parse } from '@0no-co/graphql.web';
+import { Kind, parse as _parse, print } from '@0no-co/graphql.web';
 
 import type {
   IntrospectionLikeInput,
@@ -738,7 +738,7 @@ function unsafe_readResult<
 
 const graphql: initGraphQLTada<setupSchema> = initGraphQLTada();
 
-export { parse, graphql, readFragment, maskFragments, unsafe_readResult };
+export { parse, graphql, readFragment, maskFragments, unsafe_readResult, print };
 
 export type {
   setupCache,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
   parse,
+  print,
   graphql,
   readFragment,
   maskFragments,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 export {
   parse,
-  print,
   graphql,
   readFragment,
   maskFragments,
   unsafe_readResult,
   initGraphQLTada,
 } from './api';
+
+// A `print` function compatible with `parse` exported above
+export { print } from '@0no-co/graphql.web';
 
 export type {
   setupCache,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Re-export the minimal `print` function from [graphql.web](https://www.npmjs.com/package/@0no-co/graphql.web) for smaller bundle size.

## Set of changes

The `graphql` function exposed by gql.tada uses `graphql.web#parse` under-the-hood, which is a lightweight version of `graphql#parse`. I'm building a minimal graphql client, and to send a proper graphql query, the document needs (does it?) to be stringified. I'm using `graphql#print`, but using `graphql.web#print` produces a bundle 4kB smaller.

```console
# With import { print } from "graphql";
❯ du -sh /home/gautier/escape/dropping-zeus/.svelte-kit/output/client/_app/immutable
120K    /home/gautier/escape/dropping-zeus/.svelte-kit/output/client/_app/immutable

# With import { print } from "@0no-co/graphql.web";
❯ du -sh /home/gautier/escape/dropping-zeus/.svelte-kit/output/client/_app/immutable
116K    /home/gautier/escape/dropping-zeus/.svelte-kit/output/client/_app/immutable
```

The goal of this PR is to make this print function available with `import { print } from "gql.tada";` like `parse`.

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
