### PR TITLE
fix: handle multiple tsconfig `extends` for resolving GraphQLSP plugin entry

### DIFF
--- a/.changeset/fluffy-seahorses-flow.md
+++ b/.changeset/fluffy-seahorses-flow.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/internal': patch
+---
+
+Update the tsconfig resolver to better handle an array of "extends" values in tsconfig.json files when trying to locate the GraphQLSP plugin entry. Before, if you were using an array for "extends", e.g. `"extends: ["./file1.json", "./file2.json"]`, the first file loaded that did not have a GraphQLSP plugin entry defined would throw an error and prevent subsequent files from being loaded and evaluated. The implemented change now allows for the resolver to continue iterating over `extends` values trying to locate a GraphQLSP plugin entry.

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -102,13 +102,13 @@ export const loadConfig = async (targetPath?: string): Promise<LoadConfigResult>
         if (path.extname(extend) !== '.json') extend += '.json';
         try {
           const tsconfigPath = await resolveExtend(extend, path.dirname(rootTsconfigPath));
-          if (tsconfigPath) return load(tsconfigPath);
+          if (tsconfigPath) return await load(tsconfigPath);
         } catch (_error) {}
       }
     } else if (tsconfig.extends) {
       try {
         const tsconfigPath = await resolveExtend(tsconfig.extends, path.dirname(rootTsconfigPath));
-        if (tsconfigPath) return load(tsconfigPath);
+        if (tsconfigPath) return await load(tsconfigPath);
       } catch (_error) {}
     }
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Given the following `tsconfig.json` setup:

```
// tsconfig.json
{
  "extends": ["./tsconfig.app.json", "./tsconfig.gql-tada.json"]
}

// tsconfig.app.json
{
  "compilerOptions": {
     // some options here
   }
}

// tsconfig.gql-tada.json
{
  "compilerOptions": {
    "plugins": [
      {
        "name": "gql.tada/ts-plugin",
        // schema config
      }
    ]
  }
}
```

I encounter the following error:
`Could not find a valid GraphQLSP plugin entry in: tsconfig.json`

The code in this PR fixes the issue for me, but there aren't unit tests specifically for this area of code so not sure of any adverse effects.

## Set of changes

The change was pretty straightforward in just modifying `return load(tsconfigPath)` to be `return await load(tsconfigPath)` so that exceptions thrown when trying to load nested tsconfig "extends" elements are caught (and swallowed) by the intended `catch(_error)` statements.

