### PR TITLE
fix(cli-utils): Strip unmask directive during persisted-ops generation

### DIFF
--- a/.changeset/friendly-dolls-lick.md
+++ b/.changeset/friendly-dolls-lick.md
@@ -1,0 +1,5 @@
+---
+"@gql.tada/cli-utils": patch
+---
+
+Strip our internal `@_unmask` directive from fragment-definitions during persisted-operations generation


### PR DESCRIPTION
Resolves #387 

## Summary

This guarantees correctness as the API won't know about this directive, this will also need to happen on the LSP side of things.
