### PR TITLE
fix: Add missing setter to `loc` property

### DIFF
--- a/.changeset/forty-paws-yawn.md
+++ b/.changeset/forty-paws-yawn.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Add missing setter to `loc` property

--- a/src/api.ts
+++ b/src/api.ts
@@ -339,6 +339,7 @@ export function initGraphQLTada<const Setup extends AbstractSetupSchema>(): init
       );
     }
 
+    let loc: Location | undefined;
     return {
       kind: Kind.DOCUMENT,
       definitions,
@@ -346,7 +347,7 @@ export function initGraphQLTada<const Setup extends AbstractSetupSchema>(): init
         // NOTE: This is only meant for graphql-tag compatibility. When fragment documents
         // are interpolated into other documents, graphql-tag blindly reads `document.loc`
         // without checking whether it's `undefined`.
-        if (isFragment) {
+        if (!loc && isFragment) {
           const body = input + concatLocSources(fragments || []);
           return {
             start: 0,
@@ -358,6 +359,10 @@ export function initGraphQLTada<const Setup extends AbstractSetupSchema>(): init
             },
           };
         }
+        return loc;
+      },
+      set loc(_loc: Location) {
+        loc = _loc;
       },
     } satisfies DocumentNode;
   }


### PR DESCRIPTION
Resolves #398

## Set of changes

- Add missing setter (`set loc`) to document nodes output by `graphql`