### PR TITLE
fix(cli-utils): Create directories in CLI when writing to non-existent paths

### DIFF
--- a/.changeset/rotten-balloons-bow.md
+++ b/.changeset/rotten-balloons-bow.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Create target directories if they don't exist and the CLI is trying to write to them.

--- a/packages/cli-utils/src/commands/shared/utils.ts
+++ b/packages/cli-utils/src/commands/shared/utils.ts
@@ -51,11 +51,9 @@ export const writeOutput = async (target: WriteTarget, contents: string): Promis
     });
   }
 
-  if (typeof target === 'string') {
-    const targetDirectory = dirname(target);
-    if (!(await directoryExists(target))) {
-      await fs.mkdir(targetDirectory, { recursive: true });
-    }
+  const targetDirectory = dirname(typeof target !== 'string' ? await fs.realpath(target) : target);
+  if (!(await directoryExists(targetDirectory))) {
+    await fs.mkdir(targetDirectory, { recursive: true });
   }
 
   if (!(await fileExists(target))) {


### PR DESCRIPTION
Related to https://github.com/0no-co/GraphQLSP/issues/357

## Summary

Creates directories recursively if the CLI is trying to write to a directory that doesn't exist yet.

The symbolic link check is a bit scuffed, but basically just protects us against creating a directory at the leaf path, if a conflicting symlink exists and points to a directory, since this will most certainly cause an issue. Otherwise, at non-leaf paths the directory would be resolved normally anyway.

## Set of changes

- Add recursive `mkdir` if target doesn't exist
