### PR TITLE
docs: Update `gql.tada` CLI/commands to refer to `gql-tada` instead

### DIFF
--- a/website/get-started/installation.md
+++ b/website/get-started/installation.md
@@ -380,7 +380,7 @@ check Vue and Svelte files, `gql.tada` won't have any output in
 these cases.
 
 However, while the TypeScript plugin may not support `.vue` and
-`.svelte` files, [the `gql.tada check` command does.](/get-started/workflows#running-diagnostics)
+`.svelte` files, [the `gql-tada check` command does.](/get-started/workflows#running-diagnostics)
 To enable support for either files, you'll need to install the
 corresponding support packages.
 

--- a/website/get-started/workflows.md
+++ b/website/get-started/workflows.md
@@ -8,7 +8,7 @@ description: How to use and adapt the CLI in your workflows
 ## <span data-step="1">1.</span> Setup
 
 <section>
-  Before getting started, the <code>gql.tada</code> CLI has
+  Before getting started, the <code>gql-tada</code> CLI has
   the <code>generate schema</code> and <code>doctor</code>
   commands to help with getting all set up.
 </section>
@@ -30,7 +30,7 @@ To introspect an API and download your schema, run the `generate schema`
 command while passing your API's URL.
 
 ```sh
-gql.tada generate schema 'http://api.test/graphql' --output './schema.graphql'
+gql-tada generate schema 'http://api.test/graphql' --output './schema.graphql'
 ```
 
 When no `--output` argument is passed, the command will attempt to
@@ -42,7 +42,7 @@ requires authentication headers, you may use this to pass in
 tokens or authorization headers.
 
 ```sh
-gql.tada generate schema 'http://api.test/graphql' --header "Authorization: $ENV_TOKEN"
+gql-tada generate schema 'http://api.test/graphql' --header "Authorization: $ENV_TOKEN"
 ```
 
 <a href="/reference/gql-tada-cli#generate-schema" class="button">
@@ -65,7 +65,7 @@ whether there are any issues in your configuration or with
 your setup, the `doctor` command exists.
 
 ```sh
-gql.tada doctor
+gql-tada doctor
 ```
 
 The `doctor` command runs through several environment checks,
@@ -104,11 +104,11 @@ the output typings file is necessary for `gql.tada` to infer types
 of GraphQL documents as it contains an introspection type of
 your schema.
 
-To generate the output typings file, use the `gql.tada` CLI's
+To generate the output typings file, use the `gql-tada` CLI's
 `generate turbo` command.
 
 ```sh
-gql.tada generate output
+gql-tada generate output
 ```
 
 The `generate output` command loads your schema, generates
@@ -177,7 +177,7 @@ diagnostics and gives us an idea of GraphQL-related issues across
 a whole workspace.
 
 ```sh
-gql.tada check
+gql-tada check
 ```
 
 The `check` command loads your schema then runs diagnostics
@@ -198,7 +198,7 @@ server API, which is specific to editor and IDE features.
 During other tasks, like when you run `tsc` or other TypeScript
 compiler tools, TypeScript plugins aren't loaded.
 
-The `gql.tada check` command exists to be a standalone
+The `gql-tada check` command exists to be a standalone
 version of GraphQL-related diagnostics instead and itself
 loads the TypeScript plugin's diagnostics code.
 :::
@@ -236,11 +236,11 @@ codebase grows.
 ### Turbo Mode
 
 To help with this and prevent performance issues,
-the `gql.tada` CLI has a `turbo` command that
+the `gql-tada` CLI has a `turbo` command that
 pre-processes types and outputs a type cache.
 
 ```sh
-gql.tada turbo
+gql-tada turbo
 ```
 
 The `turbo` command scans your codebase for GraphQL
@@ -295,11 +295,11 @@ can improve the Developer Experience on larger codebases.
 
 <section>
   For after we commit and push our work, we can set up our CI
-  environment with the <code>gql.tada</code> CLI commands we've
+  environment with the <code>gql-tada</code> CLI commands we've
   now seen to output files and run diagnostics.
 </section>
 
-Integrating the `gql.tada` CLI into your continuous integration
+Integrating the `gql-tada` CLI into your continuous integration
 pipeline takes just adding a few commands and should effectively
 replicate the errors you may see in an editor when using `gql.tada`.
 
@@ -307,8 +307,8 @@ At the very least, you'll likely want to run the `check` command in your
 CI environment.
 
 ```sh
-gql.tada generate output
-gql.tada check
+gql-tada generate output
+gql-tada check
 ```
 
 ::: details GitHub Actions Example
@@ -318,8 +318,8 @@ in your workflow's jobs.
 ```yaml
 - name: "gql.tada Checks"
   run: |
-    gql.tada generate output
-    gql.tada check
+    gql-tada generate output
+    gql-tada check
 ```
 
 On GitHub Actions, the `check` command will also integrate with GitHub's,
@@ -350,8 +350,8 @@ This may mean however that you want to keep these files up-to-date
 and check for them in your CI's checks as well.
 
 ```sh
-gql.tada generate-output
-gql.tada turbo
+gql-tada generate-output
+gql-tada turbo
 git diff --name-status --exit-code .
 ```
 
@@ -362,8 +362,8 @@ in your workflow's jobs.
 ```yaml
 - name: "gql.tada Checks"
   run: |
-    gql.tada generate output
-    gql.tada generate turbo
+    gql-tada generate output
+    gql-tada generate turbo
     git diff --name-status --exit-code .
 ```
 :::

--- a/website/guides/multiple-schemas.md
+++ b/website/guides/multiple-schemas.md
@@ -86,7 +86,7 @@ After you've updated your configuration you can use the `doctor`
 command to make sure everything's working properly.
 
 ```sh
-gql.tada doctor
+gql-tada doctor
 ```
 
 ## <span data-step="2">2.</span> Initializing `gql.tada` per schema
@@ -220,13 +220,13 @@ const query = graphql(`
 ### CLI Commands
 
 ```sh
-gql.tada check
-gql.tada generate output
-gql.tada generate turbo
-gql.tada generate persisted
+gql-tada check
+gql-tada generate output
+gql-tada generate turbo
+gql-tada generate persisted
 ```
 
-All of the `gql.tada` CLI's commands still work the exact same
+All of the `gql-tada` CLI commands still work the exact same
 when multiple schemas are set up.
 
 However, while all `generate` commands accept an `--output` argument when

--- a/website/guides/persisted-documents.md
+++ b/website/guides/persisted-documents.md
@@ -175,7 +175,7 @@ const persistedQuery = graphql.persisted(
 ## Generating Persisted Manifests
 
 <section>
-  To statically extract persisted documents, we can use the <code>gql.tada</code>
+  To statically extract persisted documents, we can use the <code>gql-tada</code>
   CLI's <code>generate persisted</code> command.
 </section>
 
@@ -187,7 +187,7 @@ To generate a persisted JSON manifest file, use the `gql.tada` CLI's
 `generate persisted` command.
 
 ```sh
-gql.tada generate persisted --output persisted.json
+gql-tada generate persisted --output persisted.json
 ```
 
 The `generate persisted` command scans your codebase for persisted

--- a/website/reference/config-format.md
+++ b/website/reference/config-format.md
@@ -68,7 +68,7 @@ Don't worry about setting up more than the required `schema` and `tadaOutputLoca
 
 All optional schema options are mostly used by the `gql.tada` CLI, which will tell you if you're missing
 any of the extra configuration options. Additionally, to validate your configuration, you can always
-run the [`gql.tada doctor` CLI command](/reference/gql-tada-cli#doctor).
+run the [`gql-tada doctor` CLI command](/reference/gql-tada-cli#doctor).
 :::
 
 ## Schema Options
@@ -259,18 +259,18 @@ we're always required to set up `gql.tada` manually using the
 ### `tadaTurboLocation`
 
 The `tadaOutputLocation` specifies the output path that the
-[`gql.tada turbo`](/reference/gql-tada-cli#turbo) command will write
+[`gql-tada turbo`](/reference/gql-tada-cli#turbo) command will write
 the type cache output file to.
 
 Type cache files are `.d.ts` files that cache `gql.tada`'s inferred types
-This means that when you run `gql.tada turbo` after making your changes,
+This means that when you run `gql-tada turbo` after making your changes,
 TypeScript will be able to start up and type check your GraphQL documents
 much more quickly than without the type cache.
 
 <a href="/reference/gql-tada-cli#turbo" class="button">
   <h4>CLI Reference</h4>
   <p>
-    Learn more about the <code>gql.tada turbo</code> command.
+    Learn more about the <code>gql-tada turbo</code> command.
   </p>
 </a>
 
@@ -279,8 +279,8 @@ much more quickly than without the type cache.
 ### `tadaPersistedLocation`
 
 The `tadaPersistedLocation` specifies the output path that the
-[`gql.tada generate persisted`](/reference/gql-tada-cli#generate-persisted)
-command will write the persisted JSON manifest file to.
+[`gql-tada generate persisted` command](/reference/gql-tada-cli#generate-persisted)
+will write the persisted JSON manifest file to.
 
 Persisted manifest files are `.json` files that contain all GraphQL
 documents referenced using a [`graphql.persisted` call](/reference/gql-tada-api#graphql-persisted).
@@ -298,7 +298,7 @@ be extracted into the manifest file at compile-time.
   <a href="/reference/gql-tada-cli#generate-persisted" class="button">
     <h4>CLI Reference</h4>
     <p>
-      Learn more about the <code>gql.tada generate persisted</code> command.
+      Learn more about the <code>gql-tada generate persisted</code> command.
     </p>
   </a>
 </div>
@@ -333,7 +333,7 @@ global features for the `gql.tada` CLI and the TypeScript plugin.
 By default, this option is enabled. When enabled, your usage of
 fields will be tracked as you consume data typed using a GraphQL document.
 
-The TypeScript plugin and the [`gql.tada check` command](/reference/gql-tada-cli#check)
+The TypeScript plugin and the [`gql-tada check` command](/reference/gql-tada-cli#check)
 will run a diagnostic that issues warnings when any fields in your selection
 sets aren't used in your TypeScript code.
 
@@ -398,7 +398,7 @@ or report the problematic code pattern to us in an issue.
 By default, this option is enabled. When enabled, your imports will be scanned
 for exported fragments.
 
-The TypeScript plugin and the [`gql.tada check` command](/reference/gql-tada-cli#check)
+The TypeScript plugin and the [`gql-tada check` command](/reference/gql-tada-cli#check)
 will issue warnings when you're missing imports to a GraphQL fragment exported by
 will run a diagnostic that issues warnings when any imports statements don't import
 a GraphQL fragment exported by another module.<br />

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -190,7 +190,7 @@ We must either pass the document as a generic type argument or as the second arg
 - `graphql.persisted<typeof document>("abc...")`
 - `graphql.persisted("abc...", document)`
 
-The TypeScript plugin and the [`gql.tada check` command](/reference/gql-tada-cli#check)
+The TypeScript plugin and the [`gql-tada check` command](/reference/gql-tada-cli#check)
 run a diagnostic which can check that the document is passed into `graphql.persisted()`
 correctly. Furthermore, the TypeScript plugin offers a code action to automatically update
 the `hash` argument to a SHA256-hash computed from the document.

--- a/website/reference/gql-tada-cli.md
+++ b/website/reference/gql-tada-cli.md
@@ -1,8 +1,8 @@
 ---
-title: gql.tada CLI
+title: gql-tada CLI
 ---
 
-# `gql.tada` CLI <Badge type="warning" text="beta" />
+# `gql-tada` CLI <Badge type="warning" text="beta" />
 
 ## Commands
 
@@ -10,14 +10,14 @@ title: gql.tada CLI
 
 > [!NOTE]
 >
-> The `gql.tada init` command is still a work in progress.
+> The `gql-tada init` command is still a work in progress.
 > If you run into any trouble, feel free to let us know what you’d like to see added or changed.
 
 | Option | Description                                                                                      |
 | ------ | ------------------------------------------------------------------------------------------------ |
 | `dir`  | A relative location from your current working directory where the project should be initialized. |
 
-The `init` command takes care of everything required to setup a `gql.tada`
+The `init` command takes care of everything required to setup a `gql-tada`
 project. The main tasks involved here are:
 
 - Locating the schema
@@ -30,15 +30,15 @@ You can run this command with your preferred package manager:
 ::: code-group
 
 ```sh [npm]
-npx gql.tada init ./my-project
+npx gql-tada init ./my-project
 ```
 
 ```sh [pnpm]
-pnpx gql.tada init ./my-project
+pnpx gql-tada init ./my-project
 ```
 
 ```sh [bun]
-bunx gql.tada init ./my-project
+bunx gql-tada init ./my-project
 ```
 
 :::
@@ -47,10 +47,10 @@ bunx gql.tada init ./my-project
 
 > [!NOTE]
 >
-> The `gql.tada doctor` command is still a work in progress.
+> The `gql-tada doctor` command is still a work in progress.
 > If you run into any trouble, feel free to let us know what you’d like to see added or changed.
 
-The `doctor` command will check for common mistakes in the `gql.tada`’s setup and configuration. It will check installed versions of packages, check the configuration, and check the schema.
+The `doctor` command will check for common mistakes in the `gql-tada`’s setup and configuration. It will check installed versions of packages, check the configuration, and check the schema.
 
 ### `check`
 
@@ -64,7 +64,7 @@ Usually, the TypeScript plugin will run inside your editor's TypeScript language
 and errors. However, these diagnostics aren't run when `tsc` or other TypeScript compiler processes are used, since those
 neither load plugins nor are part of the TypeScript language service API.
 
-The `gql.tada check` command exists to run these diagnostics in a standalone command, outside of editing the relevant
+The `gql-tada check` command exists to run these diagnostics in a standalone command, outside of editing the relevant
 files and reports these errors to the console.
 
 When this command is run inside a GitHub Action, [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) are used to annotate errors within the GitHub UI.
@@ -80,7 +80,7 @@ When this command is run inside a GitHub Action, [workflow commands](https://doc
 
 Oftentimes, an API may not be running in development, is maintained in a separate repository, or requires authorization headers, and specifying a URL in the `schema` configuration can slow down development.
 
-The `gql.tada generate-schema` command introspects a targeted GraphQL API by URL, a `.graphql` SDL
+The `gql-tada generate-schema` command introspects a targeted GraphQL API by URL, a `.graphql` SDL
 or introspection JSON file, and outputs a `.graphql` SDL file. Generating a `.graphql` SDL file is
 useful if we're trying to avoid adding a URL as the `schema` configuration option.
 
@@ -95,7 +95,7 @@ which can be overridden using the `--output` argument.
 | `--tsconfig,-c`           | Optionally, a `tsconfig.json` file to use instead of an automatically discovered one.         |
 | `--output,-o`             | Specify where to output the file to. (Default: The `tadaOutputLocation` configuration option) |
 
-The `gql.tada generate-output` command programmatically outputs the `gql.tada` output typings file.
+The `gql-tada generate-output` command programmatically outputs the `gql.tada` output typings file.
 It will load the schema from the specified `schema` configuration option first then write the typings file to the specified
 location.
 
@@ -133,7 +133,7 @@ When this command is run inside a GitHub Action, [workflow commands](https://doc
 | `--fail-on-warn,-w` | Triggers an error and a non-zero exit code if any warnings have been reported.                   |
 | `--output,-o`       | Specify where to output the file to. (Default: The `tadaPersistedLocation` configuration option) |
 
-The `gql.tada generate-persisted` command will scan your code for `graphql.persisted()` calls and generate
+The `gql-tada generate-persisted` command will scan your code for `graphql.persisted()` calls and generate
 a JSON manifest file containing a mapping of document IDs to the GraphQL document strings.
 These can then be used to register known and accepted documents (known as “persisted operations”) with your GraphQL API to lock down accepted documents that are allowed to be sent.
 


### PR DESCRIPTION
See #404 and similar reports

## Summary

On Windows, it's generally harder to execute commands such as `gql.tada` containing dots. Instead, we should consistently refer people to our `gql-tada` alias for the command. This PR also changes a couple of references from "the `gql.tada` CLI/commands" to "the `gql-tada` CLI/commands"

## Set of changes

- Replace all `gql.tada` CLI and command references with `gql-tada`
