### PR TITLE
fix(cli-utils): Fix regression causing `turbo` command to reuse the `turbo` cache itself

### DIFF
--- a/.changeset/mighty-dots-applaud.md
+++ b/.changeset/mighty-dots-applaud.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix `turbo` command's cache disabling override not being effective. This was a regression that meant the cached outputs would be reused during the next run of the `turbo` command.

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -22,11 +22,14 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   // NOTE: We add our override declaration here before loading all files
   // This sets `__cacheDisabled` on the turbo cache, which disables the cache temporarily
   // If we don't disable the cache then we couldn't regenerate it from inferred types
-  factory.addSourceFile({
-    fileId: '__gql-tada-override__.d.ts',
-    sourceText: DECLARATION_OVERRIDE,
-    scriptKind: ts.ScriptKind.TS,
-  });
+  factory.addSourceFile(
+    {
+      fileId: '__gql-tada-override__.d.ts',
+      sourceText: DECLARATION_OVERRIDE,
+      scriptKind: ts.ScriptKind.TS,
+    },
+    true
+  );
 
   const externalFiles = factory.createExternalFiles();
   if (externalFiles.length) {

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -22,14 +22,11 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   // NOTE: We add our override declaration here before loading all files
   // This sets `__cacheDisabled` on the turbo cache, which disables the cache temporarily
   // If we don't disable the cache then we couldn't regenerate it from inferred types
-  factory.addSourceFile(
-    {
-      fileId: '__gql-tada-override__.d.ts',
-      sourceText: DECLARATION_OVERRIDE,
-      scriptKind: ts.ScriptKind.TS,
-    },
-    true
-  );
+  factory.addSourceFile({
+    fileId: '__gql-tada-override__.d.ts',
+    sourceText: DECLARATION_OVERRIDE,
+    scriptKind: ts.ScriptKind.TS,
+  });
 
   const externalFiles = factory.createExternalFiles();
   if (externalFiles.length) {

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -36,7 +36,7 @@ export interface ProgramFactory {
   createSourceFile(params: SourceFileParams, scriptKind?: ts.ScriptKind): ts.SourceFile;
   createExternalFiles(exts?: readonly VirtualExtension[]): readonly ts.SourceFile[];
 
-  addSourceFile(file: SourceFileParams | ts.SourceFile, addRootName?: boolean): this;
+  addSourceFile(file: SourceFileParams | ts.SourceFile): this;
   addMappedFile(file: SourceFileParams | ts.SourceFile, params: MappedFileParams): this;
 
   addVirtualFiles(files: readonly ts.SourceFile[]): Promise<this>;
@@ -126,11 +126,11 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
       return files;
     },
 
-    addSourceFile(input, addRootName) {
+    addSourceFile(input) {
       const sourceFile =
         'fileName' in input ? input : factory.createSourceFile(input, ts.ScriptKind.TSX);
       host.updateFile(sourceFile);
-      if (addRootName) rootNames.add(sourceFile.fileName);
+      rootNames.add(sourceFile.fileName);
       return factory;
     },
 
@@ -154,13 +154,10 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
         const virtualCode = await transform(sourceFile);
         if (virtualCode) {
           factory
-            .addSourceFile(
-              {
-                fileId: virtualFileId,
-                sourceText: virtualCode.snapshot,
-              },
-              /*addRootName*/ true
-            )
+            .addSourceFile({
+              fileId: virtualFileId,
+              sourceText: virtualCode.snapshot,
+            })
             .addMappedFile(sourceFile, {
               mappings: virtualCode.mappings,
               fileId: virtualFileId,


### PR DESCRIPTION
Resolves #406

## Summary

Due to a misuse of our own `addSourceFile` method's second argument, we regressed and the `turbo` command wasn't disabling the cached turbo file anymore.
This meant that any subsequent run of the `turbo` command would use the last run's type cache, which wasn't intentional.

To combat this the argument has been removed entirely, as we don't use it ourselves.

## Set of changes

- Remove `addRootNames` argument and instead always register a root name for `addSourceFile` calls
