### PR TITLE
docs: Fix anchor link to VSCode setup section

### DIFF
--- a/website/get-started/installation.md
+++ b/website/get-started/installation.md
@@ -64,7 +64,7 @@ auto-completions, and type hovers for GraphQL.
 
 > [!NOTE] VSCode Setup
 > There may be extra steps you should take when you're using VSCode.
-> [Read about these steps in the "VSCode Setup" section below.](#vscode-settings-and-plugins)
+> [Read about these steps in the "VSCode Setup" section below.](#vscode-setup)
 
 > [!NOTE] Prior to TypeScript 5.5
 > There are extra steps you must take when your TypeScript version is older than 5.5.


### PR DESCRIPTION
## Summary

Fix incorrect anchor link in documentation that points to the VSCode setup section. The current link uses `#vscode-settings-and-plugins` while the correct anchor should be `#vscode-setup`.

On the installation guide [here](https://gql-tada.0no.co/get-started/installation#prior-to-typescript-5-5) :
![image](https://github.com/user-attachments/assets/7559f981-d0b6-4c39-9b9d-14a52b262e20)
The Read about link doesn't redirect you to any section.

## Set of changes
- Updates anchor link in the VSCode setup notice box to correctly point to the intended section
- Noteworthy file : `website/get-started/installation.md`
- No breaking changes

### Before:
```html
<a href="#vscode-settings-and-plugins">Read about these steps in the "VSCode Setup" section below.</a>
```
### After: 
```html
<a href="#vscode-setup">Read about these steps in the "VSCode Setup" section below.</a>
```