### PR TITLE
refactor: expose type to allow type-infer from string

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -92,6 +92,27 @@ interface AbstractSetupCache {
 
 interface setupCache extends AbstractSetupCache {}
 
+type DocumentNodeFromQuery<
+  Schema extends SchemaLike,
+  Config extends AbstractConfig,
+  In extends string,
+  Fragments extends readonly FragmentShape[],
+> = setupCache[In] extends DocumentNodeLike
+  ? unknown extends setupCache['__cacheDisabled']
+    ? setupCache[In]
+    : getDocumentNode<
+        parseDocument<In>,
+        Schema,
+        getFragmentsOfDocuments<Fragments>,
+        Config['isMaskingDisabled']
+      >
+  : getDocumentNode<
+      parseDocument<In>,
+      Schema,
+      getFragmentsOfDocuments<Fragments>,
+      Config['isMaskingDisabled']
+    >;
+
 interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfig> {
   /** In "multi-schema" mode this identifies the schema.
    * @internal */
@@ -139,21 +160,7 @@ interface GraphQLTadaAPI<Schema extends SchemaLike, Config extends AbstractConfi
   <const In extends string, const Fragments extends readonly FragmentShape[]>(
     input: In,
     fragments?: Fragments
-  ): setupCache[In] extends DocumentNodeLike
-    ? unknown extends setupCache['__cacheDisabled']
-      ? setupCache[In]
-      : getDocumentNode<
-          parseDocument<In>,
-          Schema,
-          getFragmentsOfDocuments<Fragments>,
-          Config['isMaskingDisabled']
-        >
-    : getDocumentNode<
-        parseDocument<In>,
-        Schema,
-        getFragmentsOfDocuments<Fragments>,
-        Config['isMaskingDisabled']
-      >;
+  ): DocumentNodeFromQuery<Schema, Config, In, Fragments>;
 
   /** Function to validate the type of a given scalar or enum value.
    *
@@ -773,9 +780,12 @@ export { parse, graphql, readFragment, maskFragments, unsafe_readResult };
 export type {
   setupCache,
   setupSchema,
+  schemaOfSetup,
+  configOfSetup,
   parseDocument,
   AbstractSetupSchema,
   AbstractSetupCache,
+  DocumentNodeFromQuery,
   GraphQLTadaAPI,
   TadaDocumentNode,
   TadaPersistedDocumentNode,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Expose some TypeScript types so I can use this library for type purpose only.

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

Expose a few types to allow using the library for type purpose.

At the moment, in order to get the Variables or Result of a query, I need to do something like this

```typescript
const graphql = initGraphQLTada<...Setup>()

const document = graphql(`...my query`) // This executes something in the run time.

type variables = VariablesOf<typeof document>
```

Instead, I am looking for a way to get the wanted type without running `graphql`. e.g.

```
type variables = VariablesFromQuery(`...my query`) // This is a purely type based and no runtime involved.
```

The reason why I am blocked because type of `graphql()` function is declared in an interface, I am only access to the generic types of the interface but I can't access to the generic types of the function. i.e.

```
interface GraphQLTadaAPI<T> { // <<<< I can only access these generic types.
  <K extends string>(input: K): Q // <<<< I want to access to these generic types.
}
```

The PR demos what I believe can make it happen but if there are better ways or a prefer type to achieving this I am more than happy to contribute.

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
