### PR TITLE
fix: Handle trailing comments without newline characters

### DIFF
--- a/.changeset/calm-donuts-juggle.md
+++ b/.changeset/calm-donuts-juggle.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Fix in-type tokenizer to support trailing comments

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -66,4 +66,16 @@ describe('tokenize', () => {
     type expected = [{ kind: Token.Directive; name: 'test' }, { kind: Token.Directive; name: 'x' }];
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
+
+  it('skips trailing comments', () => {
+    type actual = tokenize<'@test   # test'>;
+    type expected = [{ kind: Token.Directive; name: 'test' }];
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
+
+  it('skips comments until a newline', () => {
+    type actual = tokenize<'@test   # test \n   @x'>;
+    type expected = [{ kind: Token.Directive; name: 'test' }, { kind: Token.Directive; name: 'x' }];
+    expectTypeOf<actual>().toEqualTypeOf<expected>();
+  });
 });

--- a/src/__tests__/tokenizer.test-d.ts
+++ b/src/__tests__/tokenizer.test-d.ts
@@ -67,15 +67,26 @@ describe('tokenize', () => {
     expectTypeOf<actual>().toEqualTypeOf<expected>();
   });
 
-  it('skips trailing comments', () => {
-    type actual = tokenize<'@test   # test'>;
-    type expected = [{ kind: Token.Directive; name: 'test' }];
-    expectTypeOf<actual>().toEqualTypeOf<expected>();
-  });
+  describe('comments', () => {
+    it('skips trailing comments', () => {
+      type actual = tokenize<'@test   # test'>;
+      type expected = [{ kind: Token.Directive; name: 'test' }];
+      expectTypeOf<actual>().toEqualTypeOf<expected>();
+    });
 
-  it('skips comments until a newline', () => {
-    type actual = tokenize<'@test   # test \n   @x'>;
-    type expected = [{ kind: Token.Directive; name: 'test' }, { kind: Token.Directive; name: 'x' }];
-    expectTypeOf<actual>().toEqualTypeOf<expected>();
+    it('skips chained trailing comments', () => {
+      type actual = tokenize<'@test   # test\n   # test2'>;
+      type expected = [{ kind: Token.Directive; name: 'test' }];
+      expectTypeOf<actual>().toEqualTypeOf<expected>();
+    });
+
+    it('skips comments until a newline', () => {
+      type actual = tokenize<'@test   # test \n   # test 2 \n  @x'>;
+      type expected = [
+        { kind: Token.Directive; name: 'test' },
+        { kind: Token.Directive; name: 'x' },
+      ];
+      expectTypeOf<actual>().toEqualTypeOf<expected>();
+    });
   });
 });

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -101,8 +101,8 @@ type tokenizeRec<State> =
     ? State['out']
     : State extends _state<infer In, infer Out>
     ? tokenizeRec<
-        In extends `#${infer In}` ? _state<skipIgnored<In>, Out>
-          : In extends `${ignored}${infer In}` ? _state<skipIgnored<In>, Out>
+        In extends `#${string}` ? _state<skipIgnored<In>, Out>
+          : In extends `${ignored}${string}` ? _state<skipIgnored<In>, Out>
           : In extends `...${infer In}` ? _state<In, [...Out, Token.Spread]>
           : In extends `!${infer In}` ? _state<In, [...Out, Token.Exclam]>
           : In extends `=${infer In}` ? _state<In, [...Out, Token.Equal]>

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -36,9 +36,11 @@ type letter =
 
 type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
   ? skipIgnored<In>
-  : In extends `${ignored}${infer In}`
-    ? skipIgnored<In>
-    : In;
+  : In extends `#${infer _}`
+    ? ''
+    : In extends `${ignored}${infer In}`
+      ? skipIgnored<In>
+      : In;
 
 type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
 
@@ -99,7 +101,7 @@ type tokenizeRec<State> =
     ? State['out']
     : State extends _state<infer In, infer Out>
     ? tokenizeRec<
-        In extends `#${string}\n${infer In}` ? _state<In, Out>
+        In extends `#${infer In}` ? _state<skipIgnored<In>, Out>
           : In extends `${ignored}${infer In}` ? _state<skipIgnored<In>, Out>
           : In extends `...${infer In}` ? _state<In, [...Out, Token.Spread]>
           : In extends `!${infer In}` ? _state<In, [...Out, Token.Exclam]>


### PR DESCRIPTION
Resolves #448

## Summary

We didn't handle trailing comments correctly. This specifically occurs when the trailing comment does not end in a newline character, which we enforced before, which caused no pattern in the tokenizer to match.
Instead, we now match comments until the end of the string as well.

This wasn't noticed before due to auto-formatting by prettier being quite common, and formatting in general being mostly expected.

Benchmarks are neutral when applying these changes.

## Set of changes

- Move comment handling to `skipIgnored`
- Add case to match comment matches until end of input
