### PR TITLE
feat(internal/cli): Search for plugin config in referenced tsconfig files too

### DIFF
--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -97,7 +97,18 @@ export const loadConfig = async (targetPath?: string): Promise<LoadConfigResult>
       };
     }
 
-    if (Array.isArray(tsconfig.extends)) {
+    if (Array.isArray(tsconfig.references)) {
+      for (const ref of tsconfig.references) {
+        let refPath = ref.path;
+        if (refPath) {
+          if (path.extname(refPath) !== '.json') refPath += '.json';
+          try {
+            const tsconfigPath = await resolveExtend(refPath, path.dirname(rootTsconfigPath));
+            if (tsconfigPath) return await load(tsconfigPath);
+          } catch (_error) {}
+        }
+      }
+    } else if (Array.isArray(tsconfig.extends)) {
       for (let extend of tsconfig.extends) {
         if (path.extname(extend) !== '.json') extend += '.json';
         try {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

Resolves #452 

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Adds support for project using multiple tsconfig files, all listed in `.references` field of the main tsconfig.json file. This is how most react vite projects are set up. For more info on the problem, see #452.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

Updated `load(targetPath)` function in `@gql.tada/internal/src/resolve.ts` to also search for plugin config in files listed in `tsconfig.references` field.