### PR TITLE
Add support for vitest workspace catalogs

### DIFF
--- a/.changeset/modern-walls-relax.md
+++ b/.changeset/modern-walls-relax.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': minor
+---
+
+Add support for pnpm workspace catalog version resolution to `gql-tada doctor`

--- a/packages/cli-utils/src/commands/doctor/helpers/__tests__/versions.test.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/__tests__/versions.test.ts
@@ -474,6 +474,252 @@ catalog:
     });
   });
 
+  describe('Bun catalog support', () => {
+    it('should resolve catalog reference from bun package.json workspaces', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      const bunPackageJson = JSON.stringify({
+        name: 'my-monorepo',
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: {
+            typescript: '^5.0.0',
+            react: '^18.0.0',
+          },
+        },
+      });
+
+      // Mock access to differentiate between pnpm and bun files
+      mockAccess.mockImplementation((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.endsWith('pnpm-workspace.yaml')) {
+          return Promise.reject(new Error('pnpm-workspace.yaml not found'));
+        } else if (pathStr.endsWith('package.json')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      // Mock readFile to return bun package.json content
+      mockReadFile.mockResolvedValue(bunPackageJson);
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+    });
+
+    it('should resolve named catalog reference from bun workspaces', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:build' },
+      };
+
+      const bunPackageJson = JSON.stringify({
+        name: 'my-monorepo',
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: {
+            react: '^18.0.0',
+          },
+          catalogs: {
+            build: {
+              typescript: '^5.1.0',
+              webpack: '^5.0.0',
+            },
+            testing: {
+              jest: '^29.0.0',
+            },
+          },
+        },
+      });
+
+      // Mock access to differentiate between pnpm and bun files
+      mockAccess.mockImplementation((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.endsWith('pnpm-workspace.yaml')) {
+          return Promise.reject(new Error('pnpm-workspace.yaml not found'));
+        } else if (pathStr.endsWith('package.json')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      // Mock readFile to return bun package.json content
+      mockReadFile.mockResolvedValue(bunPackageJson);
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.1.0');
+    });
+
+    it('should handle bun workspace traversal', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock nested directory structure
+      vi.spyOn(process, 'cwd').mockReturnValue('/test/project/packages/app');
+
+      const bunPackageJson = JSON.stringify({
+        name: 'my-monorepo',
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: {
+            typescript: '^5.0.0',
+          },
+        },
+      });
+
+      // Mock pnpm workspace files not found at any level
+      // Mock package.json files not found at nested levels but found at root
+      mockAccess
+        .mockRejectedValueOnce(new Error('pnpm-workspace.yaml not found'))
+        .mockRejectedValueOnce(new Error('package.json not found'))
+        .mockRejectedValueOnce(new Error('pnpm-workspace.yaml not found'))
+        .mockRejectedValueOnce(new Error('package.json not found'))
+        .mockRejectedValueOnce(new Error('pnpm-workspace.yaml not found'))
+        .mockResolvedValueOnce(undefined); // package.json found at root
+
+      // Mock bun package.json read calls
+      mockReadFile.mockResolvedValueOnce(bunPackageJson).mockResolvedValueOnce(bunPackageJson);
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+      expect(mockAccess).toHaveBeenCalledTimes(6);
+      expect(mockReadFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle bun package.json without workspaces', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock access to differentiate between pnpm and bun files
+      mockAccess.mockImplementation((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.endsWith('pnpm-workspace.yaml')) {
+          return Promise.reject(new Error('pnpm-workspace.yaml not found'));
+        } else if (pathStr.endsWith('package.json')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      // Mock regular package.json without workspaces
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          name: 'regular-package',
+          dependencies: {
+            react: '^18.0.0',
+          },
+        })
+      );
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Should fallback to TypeScript module resolution since no catalog was found
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(mockReadFile).toHaveBeenCalledTimes(2); // One read call during findBunWorkspaceRoot, another in loadBunWorkspaceCatalogs
+    });
+
+    it('should handle bun package.json with workspaces but no catalogs', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock access to differentiate between pnpm and bun files
+      mockAccess.mockImplementation((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.endsWith('pnpm-workspace.yaml')) {
+          return Promise.reject(new Error('pnpm-workspace.yaml not found'));
+        } else if (pathStr.endsWith('package.json')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      // Mock bun package.json with workspaces but no catalogs
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          name: 'my-monorepo',
+          workspaces: {
+            packages: ['packages/*'],
+            // No catalog or catalogs
+          },
+        })
+      );
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Should fallback to TypeScript module resolution since no catalogs were found
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(mockReadFile).toHaveBeenCalledTimes(2); // One read call during findBunWorkspaceRoot, another in loadBunWorkspaceCatalogs
+    });
+
+    it('should handle complex bun catalog configuration', async () => {
+      const meta: PackageJson = {
+        dependencies: { 'gql.tada': 'catalog:react18' },
+        devDependencies: {
+          typescript: 'catalog:',
+          '@types/node': 'catalog:dev',
+          '@0no-co/graphqlsp': 'catalog:graphql',
+        },
+      };
+
+      // Mock access to differentiate between pnpm and bun files
+      mockAccess.mockImplementation((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.endsWith('pnpm-workspace.yaml')) {
+          return Promise.reject(new Error('pnpm-workspace.yaml not found'));
+        } else if (pathStr.endsWith('package.json')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      const bunPackageJson = JSON.stringify({
+        name: 'my-monorepo',
+        workspaces: {
+          packages: ['packages/*', 'apps/*'],
+          catalog: {
+            typescript: '^5.0.0',
+            '@types/react': '^18.0.0',
+          },
+          catalogs: {
+            react18: {
+              'gql.tada': '^1.6.0',
+              react: '^18.0.0',
+              'react-dom': '^18.0.0',
+            },
+            dev: {
+              '@types/node': '^20.0.0',
+              vitest: '^1.0.0',
+            },
+            graphql: {
+              '@0no-co/graphqlsp': '^1.12.0',
+              graphql: '^16.0.0',
+            },
+          },
+        },
+      });
+
+      // Mock readFile to return bun package.json content
+      mockReadFile.mockResolvedValue(bunPackageJson);
+
+      const tsResult = await getTypeScriptVersion(meta);
+      const gqlTadaResult = await getGqlTadaVersion(meta);
+      const graphqlspResult = await getGraphQLSPVersion(meta);
+
+      expect(tsResult).toBe('^5.0.0');
+      expect(gqlTadaResult).toBe('^1.6.0');
+      expect(graphqlspResult).toBe('^1.12.0');
+    });
+  });
+
   describe('Edge cases', () => {
     it('should handle empty package.json', async () => {
       const meta: PackageJson = {};

--- a/packages/cli-utils/src/commands/doctor/helpers/__tests__/versions.test.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/__tests__/versions.test.ts
@@ -140,15 +140,19 @@ catalogs:
       expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
     });
 
-    it('should fallback to import resolution when no package.json entry', async () => {
-      const meta: PackageJson = {};
+    it(
+      'should fallback to import resolution when no package.json entry',
+      async () => {
+        const meta: PackageJson = {};
 
-      const result = await getTypeScriptVersion(meta);
+        const result = await getTypeScriptVersion(meta);
 
-      // Since TypeScript is available in the test environment, it will return the actual version
-      expect(result).toBeTruthy();
-      expect(typeof result).toBe('string');
-    });
+        // Since TypeScript is available in the test environment, it will return the actual version
+        expect(result).toBeTruthy();
+        expect(typeof result).toBe('string');
+      },
+      { timeout: 10_000 }
+    );
 
     it('should return null when package is not found', async () => {
       const meta: PackageJson = {};

--- a/packages/cli-utils/src/commands/doctor/helpers/__tests__/versions.test.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/__tests__/versions.test.ts
@@ -1,0 +1,548 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFile, access } from 'node:fs/promises';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+// Mock the fs promises module
+vi.mock('node:fs/promises');
+vi.mock('node:module');
+vi.mock('node:path');
+
+// Import the functions we want to test
+import {
+  readPackageJson,
+  getTypeScriptVersion,
+  getGraphQLSPVersion,
+  getGqlTadaVersion,
+  hasSvelteSupport,
+  hasVueSupport,
+  type PackageJson,
+} from '../versions';
+
+const mockReadFile = vi.mocked(readFile);
+const mockAccess = vi.mocked(access);
+const mockCreateRequire = vi.mocked(createRequire);
+
+describe('versions.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock process.cwd() to return a known path
+    vi.spyOn(process, 'cwd').mockReturnValue('/test/project');
+
+    // Mock path methods to normalize path separators for consistent testing
+    vi.mocked(path.join).mockImplementation((...args) => args.join('/'));
+    vi.mocked(path.resolve).mockImplementation((...args) => {
+      if (args.length === 1) return args[0];
+      return args[args.length - 1].startsWith('/') ? args[args.length - 1] : '/' + args.join('/');
+    });
+    vi.mocked(path.dirname).mockImplementation((p) => {
+      const parts = p.split('/');
+      return parts.slice(0, -1).join('/') || '/';
+    });
+    vi.mocked(path.parse).mockImplementation((p) => ({
+      root: '/',
+      dir: p.substring(0, p.lastIndexOf('/')),
+      base: p.substring(p.lastIndexOf('/') + 1),
+      ext: '',
+      name: p.substring(p.lastIndexOf('/') + 1),
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readPackageJson', () => {
+    it('should read and parse package.json', async () => {
+      const mockPackageJson = {
+        name: 'test-project',
+        dependencies: { 'gql.tada': '^1.0.0' },
+        devDependencies: { typescript: '^5.0.0' },
+      };
+
+      mockReadFile.mockResolvedValue(JSON.stringify(mockPackageJson));
+
+      const result = await readPackageJson();
+
+      expect(result).toEqual(mockPackageJson);
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.resolve('/test/project', 'package.json'),
+        'utf-8'
+      );
+    });
+
+    it('should throw error if package.json is invalid JSON', async () => {
+      mockReadFile.mockResolvedValue('invalid json');
+
+      await expect(readPackageJson()).rejects.toThrow();
+    });
+  });
+
+  describe('getTypeScriptVersion', () => {
+    it('should return version from devDependencies', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: '^5.0.0' },
+      };
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+    });
+
+    it('should return version from dependencies', async () => {
+      const meta: PackageJson = {
+        dependencies: { typescript: '^5.0.0' },
+      };
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+    });
+
+    it('should resolve catalog reference in devDependencies', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  typescript: "^5.0.0"
+  "@types/node": "^20.0.0"
+`);
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should resolve named catalog reference', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:dev' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalogs:
+  dev:
+    typescript: "^5.1.0"
+    "@types/node": "^20.0.0"
+`);
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.1.0');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should fallback to import resolution when no package.json entry', async () => {
+      const meta: PackageJson = {};
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Since TypeScript is available in the test environment, it will return the actual version
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+    });
+
+    it('should return null when package is not found', async () => {
+      const meta: PackageJson = {};
+
+      // Re-import the function to get the new mock
+      const { getTypeScriptVersion: getTypeScriptVersionWithError } = await import('../versions');
+
+      const result = await getTypeScriptVersionWithError(meta);
+
+      // Since TypeScript is available in the test environment, it will return the actual version
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+    });
+  });
+
+  describe('getGraphQLSPVersion', () => {
+    it('should return version from devDependencies', async () => {
+      const meta: PackageJson = {
+        devDependencies: { '@0no-co/graphqlsp': '^1.12.0' },
+      };
+
+      const result = await getGraphQLSPVersion(meta);
+
+      expect(result).toBe('^1.12.0');
+    });
+
+    it('should resolve catalog reference', async () => {
+      const meta: PackageJson = {
+        devDependencies: { '@0no-co/graphqlsp': 'catalog:' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  "@0no-co/graphqlsp": "^1.12.0"
+`);
+
+      const result = await getGraphQLSPVersion(meta);
+
+      expect(result).toBe('^1.12.0');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should fallback to createRequire resolution', async () => {
+      const meta: PackageJson = {};
+
+      const mockRequire = vi.fn().mockReturnValue({ version: '1.12.0' });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const result = await getGraphQLSPVersion(meta);
+
+      expect(result).toBe('1.12.0');
+      expect(mockCreateRequire).toHaveBeenCalled();
+      expect(mockRequire).toHaveBeenCalledWith('@0no-co/graphqlsp/package.json');
+    });
+
+    it('should return null when package is not found', async () => {
+      const meta: PackageJson = {};
+
+      const mockRequire = vi.fn().mockImplementation(() => {
+        throw new Error('Module not found');
+      });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const result = await getGraphQLSPVersion(meta);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getGqlTadaVersion', () => {
+    it('should return version from devDependencies', async () => {
+      const meta: PackageJson = {
+        devDependencies: { 'gql.tada': '^1.6.0' },
+      };
+
+      const result = await getGqlTadaVersion(meta);
+
+      expect(result).toBe('^1.6.0');
+    });
+
+    it('should return version from dependencies', async () => {
+      const meta: PackageJson = {
+        dependencies: { 'gql.tada': '^1.6.0' },
+      };
+
+      const result = await getGqlTadaVersion(meta);
+
+      expect(result).toBe('^1.6.0');
+    });
+
+    it('should resolve catalog reference', async () => {
+      const meta: PackageJson = {
+        dependencies: { 'gql.tada': 'catalog:' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  "gql.tada": "^1.6.0"
+`);
+
+      const result = await getGqlTadaVersion(meta);
+
+      expect(result).toBe('^1.6.0');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should fallback to createRequire resolution', async () => {
+      const meta: PackageJson = {};
+
+      const mockRequire = vi.fn().mockReturnValue({ version: '1.6.0' });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const result = await getGqlTadaVersion(meta);
+
+      expect(result).toBe('1.6.0');
+      expect(mockCreateRequire).toHaveBeenCalled();
+    });
+  });
+
+  describe('hasSvelteSupport', () => {
+    it('should return true when package is found in devDependencies', async () => {
+      const meta: PackageJson = {
+        devDependencies: { '@gql.tada/svelte-support': '^1.0.0' },
+      };
+
+      const result = await hasSvelteSupport(meta);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when package is found via catalog', async () => {
+      const meta: PackageJson = {
+        devDependencies: { '@gql.tada/svelte-support': 'catalog:' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  "@gql.tada/svelte-support": "^1.0.0"
+`);
+
+      const result = await hasSvelteSupport(meta);
+
+      expect(result).toBe(true);
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should return true when package is found via createRequire', async () => {
+      const meta: PackageJson = {};
+
+      const mockRequire = vi.fn().mockReturnValue({ version: '1.0.0' });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const result = await hasSvelteSupport(meta);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when package is not found', async () => {
+      const meta: PackageJson = {};
+
+      const mockRequire = vi.fn().mockImplementation(() => {
+        throw new Error('Module not found');
+      });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const result = await hasSvelteSupport(meta);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('hasVueSupport', () => {
+    it('should return true when package is found in devDependencies', async () => {
+      const meta: PackageJson = {
+        devDependencies: { '@gql.tada/vue-support': '^1.0.0' },
+      };
+
+      const result = await hasVueSupport(meta);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when package is found via catalog', async () => {
+      const meta: PackageJson = {
+        devDependencies: { '@gql.tada/vue-support': 'catalog:' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  "@gql.tada/vue-support": "^1.0.0"
+`);
+
+      const result = await hasVueSupport(meta);
+
+      expect(result).toBe(true);
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should return false when package is not found', async () => {
+      const meta: PackageJson = {};
+
+      const mockRequire = vi.fn().mockImplementation(() => {
+        throw new Error('Module not found');
+      });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const result = await hasVueSupport(meta);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('YAML parsing', () => {
+    it('should handle complex workspace catalog configuration', async () => {
+      const meta: PackageJson = {
+        dependencies: { 'gql.tada': 'catalog:react18' },
+        devDependencies: { typescript: 'catalog:', '@types/node': 'catalog:dev' },
+      };
+
+      // Mock workspace files - return workspace found at root level
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+# pnpm workspace catalog example
+packages:
+  - 'packages/*'
+  - 'apps/*'
+
+catalog:
+  typescript: "^5.0.0"
+  "@types/react": "^18.0.0"
+
+catalogs:
+  react18:
+    "gql.tada": "^1.6.0"
+    react: "^18.0.0"
+  
+  dev:
+    "@types/node": "^20.0.0"
+    vitest: "^1.0.0"
+`);
+
+      const tsResult = await getTypeScriptVersion(meta);
+      const gqlTadaResult = await getGqlTadaVersion(meta);
+
+      expect(tsResult).toBe('^5.0.0');
+      expect(gqlTadaResult).toBe('^1.6.0');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+      expect(mockReadFile).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml', 'utf-8');
+    });
+
+    it('should handle workspace without catalogs', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock no workspace file found
+      mockAccess.mockRejectedValue(new Error('File not found'));
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Since TypeScript is available in the test environment, it will return the actual version
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+    });
+
+    it('should handle invalid YAML gracefully', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock workspace files - access succeeds but read fails
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Since TypeScript is available in the test environment, it will return the actual version
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+    });
+
+    it('should handle workspace file traversal', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock nested directory structure
+      vi.spyOn(process, 'cwd').mockReturnValue('/test/project/packages/app');
+
+      // Mock workspace files - first calls fail, then succeed at parent level
+      mockAccess
+        .mockRejectedValueOnce(new Error('File not found'))
+        .mockRejectedValueOnce(new Error('File not found'))
+        .mockResolvedValue(undefined);
+
+      mockReadFile.mockResolvedValue(`
+catalog:
+  typescript: "^5.0.0"
+`);
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+      expect(mockAccess).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty package.json', async () => {
+      const meta: PackageJson = {};
+
+      // Mock all fallbacks to fail
+      const mockRequire = vi.fn().mockImplementation(() => {
+        throw new Error('Module not found');
+      });
+      mockCreateRequire.mockReturnValue(mockRequire as any);
+
+      const tsResult = await getTypeScriptVersion(meta);
+      const gqlResult = await getGqlTadaVersion(meta);
+      const graphqlspResult = await getGraphQLSPVersion(meta);
+
+      // TypeScript fallback will succeed since it's available in test environment
+      // Others should fail and return null
+      expect(tsResult).toBeTruthy();
+      expect(typeof tsResult).toBe('string');
+      expect([gqlResult, graphqlspResult]).toEqual([null, null]);
+    });
+
+    it('should handle catalog reference without package in catalog', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:' },
+      };
+
+      // Mock workspace files - catalog exists but doesn't have the package
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  "some-other-package": "^1.0.0"
+`);
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Since TypeScript is available in the test environment, it will return the actual version
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+    });
+
+    it('should handle malformed catalog reference', async () => {
+      const meta: PackageJson = {
+        devDependencies: { typescript: 'catalog:nonexistent' },
+      };
+
+      // Mock workspace files - catalog exists but doesn't have the named catalog
+      mockAccess.mockResolvedValue(undefined);
+      mockReadFile.mockResolvedValue(`
+catalog:
+  typescript: "^5.0.0"
+catalogs:
+  dev:
+    typescript: "^5.1.0"
+`);
+
+      const result = await getTypeScriptVersion(meta);
+
+      // Since TypeScript is available in the test environment, it will return the actual version
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(mockAccess).toHaveBeenCalledWith('/test/project/pnpm-workspace.yaml');
+    });
+
+    it('should prefer devDependencies over dependencies', async () => {
+      const meta: PackageJson = {
+        dependencies: { typescript: '^4.0.0' },
+        devDependencies: { typescript: '^5.0.0' },
+      };
+
+      const result = await getTypeScriptVersion(meta);
+
+      expect(result).toBe('^5.0.0');
+    });
+  });
+});

--- a/packages/cli-utils/src/commands/doctor/helpers/versions.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/versions.ts
@@ -25,7 +25,7 @@ const parseYaml = (content: string): PnpmWorkspaceConfig => {
     if (!trimmed || trimmed.startsWith('#')) continue;
 
     if (trimmed.endsWith(':') && !trimmed.includes(' ')) {
-      const key = trimmed.slice(0, -1);
+      const key = trimmed.slice(0, -1).replace(/['"]/g, '');
       if (key === 'packages') {
         currentSection = 'packages';
         result.packages = [];
@@ -45,7 +45,7 @@ const parseYaml = (content: string): PnpmWorkspaceConfig => {
       }
     } else if (trimmed.includes(':')) {
       const colonIndex = trimmed.indexOf(':');
-      const key = trimmed.slice(0, colonIndex).trim();
+      const key = trimmed.slice(0, colonIndex).trim().replace(/['"]/g, '');
       const value = trimmed
         .slice(colonIndex + 1)
         .trim()

--- a/packages/cli-utils/src/commands/doctor/helpers/versions.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/versions.ts
@@ -8,6 +8,166 @@ export interface PackageJson {
   devDependencies?: Record<string, string>;
 }
 
+export interface PnpmWorkspaceConfig {
+  packages?: string[];
+  catalog?: Record<string, string>;
+  catalogs?: Record<string, Record<string, string>>;
+}
+
+const parseYaml = (content: string): PnpmWorkspaceConfig => {
+  const lines = content.split('\n');
+  const result: PnpmWorkspaceConfig = {};
+  let currentSection: string | null = null;
+  let currentCatalog: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    if (trimmed.endsWith(':') && !trimmed.includes(' ')) {
+      const key = trimmed.slice(0, -1);
+      if (key === 'packages') {
+        currentSection = 'packages';
+        result.packages = [];
+      } else if (key === 'catalog') {
+        currentSection = 'catalog';
+        result.catalog = {};
+      } else if (key === 'catalogs') {
+        currentSection = 'catalogs';
+        result.catalogs = {};
+      } else if (currentSection === 'catalogs') {
+        currentCatalog = key;
+        result.catalogs![key] = {};
+      }
+    } else if (trimmed.startsWith('- ')) {
+      if (currentSection === 'packages') {
+        result.packages!.push(trimmed.slice(2).replace(/['"]/g, ''));
+      }
+    } else if (trimmed.includes(':')) {
+      const colonIndex = trimmed.indexOf(':');
+      const key = trimmed.slice(0, colonIndex).trim();
+      const value = trimmed
+        .slice(colonIndex + 1)
+        .trim()
+        .replace(/['"]/g, '');
+
+      if (currentSection === 'catalog') {
+        result.catalog![key] = value;
+      } else if (currentSection === 'catalogs' && currentCatalog) {
+        result.catalogs![currentCatalog][key] = value;
+      }
+    }
+  }
+
+  return result;
+};
+
+const findPnpmWorkspaceroot = async (startPath: string = process.cwd()): Promise<string | null> => {
+  let currentPath = startPath;
+  const root = path.parse(currentPath).root;
+
+  while (currentPath !== root) {
+    const workspaceFile = path.join(currentPath, 'pnpm-workspace.yaml');
+    try {
+      await fs.access(workspaceFile);
+      return currentPath;
+    } catch {
+      // File doesn't exist, continue searching
+    }
+    currentPath = path.dirname(currentPath);
+  }
+
+  return null;
+};
+
+const loadWorkspaceCatalogs = async (): Promise<PnpmWorkspaceConfig | null> => {
+  const workspaceRoot = await findPnpmWorkspaceroot();
+  if (!workspaceRoot) return null;
+
+  try {
+    const workspaceFile = path.join(workspaceRoot, 'pnpm-workspace.yaml');
+    const content = await fs.readFile(workspaceFile, 'utf-8');
+    return parseYaml(content);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * This attempts to resolve a catalog version from a catalog reference.
+ * If the reference starts with 'catalog:', it extracts the catalog name.
+ * If the catalog name is 'default' or empty, it returns null to indicate
+ * that the default catalog should be used.
+ * If the catalog name is anything else, it returns the catalog name.
+ */
+const resolvePnpmCatalogVersion = (catalogRef: string): string | null => {
+  if (!catalogRef.startsWith('catalog:')) return null;
+
+  const catalogName = catalogRef.slice(8); // Remove 'catalog:' prefix
+
+  if (!catalogName || catalogName === 'default') {
+    // Default catalog
+    return null; // Will be resolved by package name lookup
+  }
+
+  // Named catalog
+  return catalogName;
+};
+
+const getVersionFromPnpmCatalog = (
+  packageName: string,
+  catalogName: string | null,
+  catalogs: PnpmWorkspaceConfig
+): string | null => {
+  if (catalogName) {
+    // Named catalog
+    return catalogs.catalogs?.[catalogName]?.[packageName] || null;
+  } else {
+    // Default catalog
+    return catalogs.catalog?.[packageName] || null;
+  }
+};
+
+// Enhanced version checking with catalog support
+const getPackageVersion = async (
+  packageName: string,
+  meta: PackageJson
+): Promise<string | null> => {
+  // Check devDependencies first
+  const devVersion = meta.devDependencies?.[packageName];
+  if (devVersion) {
+    if (devVersion.startsWith('catalog:')) {
+      // Resolve catalog reference
+      const catalogs = await loadWorkspaceCatalogs();
+      if (catalogs) {
+        const catalogName = resolvePnpmCatalogVersion(devVersion);
+        const resolvedVersion = getVersionFromPnpmCatalog(packageName, catalogName, catalogs);
+        if (resolvedVersion) return resolvedVersion;
+      }
+    } else {
+      return devVersion;
+    }
+  }
+
+  // Check dependencies
+  const depVersion = meta.dependencies?.[packageName];
+  if (depVersion) {
+    if (depVersion.startsWith('catalog:')) {
+      // Resolve catalog reference
+      const catalogs = await loadWorkspaceCatalogs();
+      if (catalogs) {
+        const catalogName = resolvePnpmCatalogVersion(depVersion);
+        const resolvedVersion = getVersionFromPnpmCatalog(packageName, catalogName, catalogs);
+        if (resolvedVersion) return resolvedVersion;
+      }
+    } else {
+      return depVersion;
+    }
+  }
+
+  return null;
+};
+
 export const readPackageJson = async (): Promise<PackageJson> => {
   const packageJsonPath = path.resolve(process.cwd(), 'package.json');
   const file = path.resolve(packageJsonPath);
@@ -16,11 +176,12 @@ export const readPackageJson = async (): Promise<PackageJson> => {
 
 export const getTypeScriptVersion = async (meta: PackageJson): Promise<string | null> => {
   const pkg = 'typescript';
-  if (meta.devDependencies?.[pkg]) {
-    return meta.devDependencies[pkg];
-  } else if (meta.dependencies?.[pkg]) {
-    return meta.dependencies[pkg];
-  }
+
+  // Try to get version with catalog support
+  const catalogVersion = await getPackageVersion(pkg, meta);
+  if (catalogVersion) return catalogVersion;
+
+  // Fallback to direct resolution
   try {
     return (await import(pkg)).version || null;
   } catch (_error) {
@@ -30,11 +191,12 @@ export const getTypeScriptVersion = async (meta: PackageJson): Promise<string | 
 
 export const getGraphQLSPVersion = async (meta: PackageJson): Promise<string | null> => {
   const pkg = '@0no-co/graphqlsp';
-  if (meta.devDependencies?.[pkg]) {
-    return meta.devDependencies[pkg];
-  } else if (meta.dependencies?.[pkg]) {
-    return meta.dependencies[pkg];
-  }
+
+  // Try to get version with catalog support
+  const catalogVersion = await getPackageVersion(pkg, meta);
+  if (catalogVersion) return catalogVersion;
+
+  // Fallback to direct resolution
   try {
     // NOTE: Resolved from current folder, since it's a child dependency
     return createRequire(__dirname)(`${pkg}/package.json`)?.version || null;
@@ -45,11 +207,12 @@ export const getGraphQLSPVersion = async (meta: PackageJson): Promise<string | n
 
 export const getGqlTadaVersion = async (meta: PackageJson): Promise<string | null> => {
   const pkg = 'gql.tada';
-  if (meta.devDependencies?.[pkg]) {
-    return meta.devDependencies[pkg];
-  } else if (meta.dependencies?.[pkg]) {
-    return meta.dependencies[pkg];
-  }
+
+  // Try to get version with catalog support
+  const catalogVersion = await getPackageVersion(pkg, meta);
+  if (catalogVersion) return catalogVersion;
+
+  // Fallback to direct resolution
   try {
     // NOTE: Resolved from working directory, since it's a parent dependency
     return createRequire(process.cwd())(`${pkg}/package.json`)?.version || null;
@@ -58,30 +221,25 @@ export const getGqlTadaVersion = async (meta: PackageJson): Promise<string | nul
   }
 };
 
-export const hasSvelteSupport = async (meta: PackageJson): Promise<boolean> => {
-  const pkg = '@gql.tada/svelte-support';
-  const isInstalled = !!meta.devDependencies?.[pkg] || !!meta.devDependencies?.[pkg];
-  if (isInstalled) {
-    return true;
-  }
+// Enhanced support checking with catalog support
+const hasPackageSupport = async (packageName: string, meta: PackageJson): Promise<boolean> => {
+  // Check if package is listed in dependencies with catalog support
+  const catalogVersion = await getPackageVersion(packageName, meta);
+  if (catalogVersion) return true;
+
+  // Fallback to direct resolution
   try {
     // NOTE: Resolved from current folder, since it's a child dependency
-    return !!createRequire(__dirname)(`${pkg}/package.json`)?.version;
+    return !!createRequire(__dirname)(`${packageName}/package.json`)?.version;
   } catch (_error) {
     return false;
   }
 };
 
+export const hasSvelteSupport = async (meta: PackageJson): Promise<boolean> => {
+  return hasPackageSupport('@gql.tada/svelte-support', meta);
+};
+
 export const hasVueSupport = async (meta: PackageJson): Promise<boolean> => {
-  const pkg = '@gql.tada/vue-support';
-  const isInstalled = !!meta.devDependencies?.[pkg] || !!meta.devDependencies?.[pkg];
-  if (isInstalled) {
-    return true;
-  }
-  try {
-    // NOTE: Resolved from current folder, since it's a child dependency
-    return !!createRequire(__dirname)(`${pkg}/package.json`)?.version;
-  } catch (_error) {
-    return false;
-  }
+  return hasPackageSupport('@gql.tada/vue-support', meta);
 };


### PR DESCRIPTION
Resolves https://github.com/0no-co/gql.tada/issues/446

## Summary

This adds support for `pnpm workspace catalog`, this basically entails that a version can be specified as `catalog:` which forces us to look it up in the `pnpm-workspace.yaml` file.

I am working on tests but I forgot how tedious it is to make these things work on Windows devices 😅 Yikes to the test timeout in CI, this is due to the async import of typescript just taking long. 
