### PR TITLE
Fix external scalars in turbo

### DIFF
--- a/.changeset/cyan-camels-listen.md
+++ b/.changeset/cyan-camels-listen.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Remove alias outside of current scope flag for the stringification of types, this adds support for external scalar files in the Tada setup file.

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -120,7 +120,6 @@ const BUILDER_FLAGS: ts.TypeFormatFlags =
   ts.TypeFormatFlags.InTypeAlias |
   ts.TypeFormatFlags.UseFullyQualifiedType |
   ts.TypeFormatFlags.GenerateNamesForShadowedTypeParams |
-  ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
   ts.TypeFormatFlags.AllowUniqueESSymbolType |
   ts.TypeFormatFlags.WriteTypeArgumentsOfSignature;
 


### PR DESCRIPTION
Resolves https://github.com/0no-co/gql.tada/issues/445

## Summary

This adds support for externally defined scalars, the addition of this flag means that we just copy over references and it's kind of a "trust me" on whether the import is present. This makes the output less clean as it will be littered with `import().type`, however this isn't a file that is meant to be read so...

The alternative solution would have been to analyze the setup file and copy over the imports into the generated cache file. This could have been tricky as the cache file is allowed to be on any level compared to the setup file and even an external package so I opted for this approach instead.
