### PR TITLE
Add doctor check for incompatible VSCode settings

### DIFF
--- a/packages/cli-utils/src/commands/doctor/helpers/vscode.ts
+++ b/packages/cli-utils/src/commands/doctor/helpers/vscode.ts
@@ -73,7 +73,7 @@ export const loadExtensionsList = async (): Promise<readonly string[]> => {
 };
 
 /** Load the global VSCode settings */
-export const loadGlobalSettings = async (): Promise<{ path: string; json: object } | undefined> => {
+export const loadGlobalSettings = async (): Promise<{ path: string; json: unknown } | undefined> => {
   if (!process.env.HOME) return undefined;
   const globalPath =
     process.platform === 'darwin'
@@ -88,9 +88,7 @@ export const loadGlobalSettings = async (): Promise<{ path: string; json: object
       : path.resolve(process.env.HOME, '.config', 'Code', 'User', 'settings.json');
   try {
     const globalJson = await jsonParse(globalPath);
-    if (globalJson && typeof globalJson === 'object') {
-      return { path: globalPath, json: globalJson };
-    }
+    return { path: globalPath, json: globalJson };
   } catch {}
   return undefined;
 };

--- a/packages/cli-utils/src/commands/doctor/runner.ts
+++ b/packages/cli-utils/src/commands/doctor/runner.ts
@@ -193,6 +193,25 @@ async function* runVSCodeChecks(): AsyncIterable<ComposeInput> {
       }
     }
 
+    // Check for incompatible VSCode settings
+    const locations = await vscode.loadSettings();
+    for (const location of Object.values(locations)) {
+      const settings = location.json as any;
+      if (settings.editor?.experimental?.preferTreeSitter?.typescript) {
+        if (!hasEndedTask) {
+          hasEndedTask = true;
+          yield logger.warningTask(Messages.CHECK_VSCODE);
+        }
+        yield logger.hintMessage(
+          `The ${logger.code(
+            '"editor.experimental.preferTreeSitter.typescript"'
+          )} VSCode setting can cause problems!\n` +
+            `When enabled it may interfere with extension functionality.\n` +
+            `You may disable the setting here: ${logger.code(location.path)}\n`
+        );
+      }
+    }
+
     const hasProblemExtension =
       userExtensions.includes('graphql.vscode-graphql') ||
       suggestedExtensions.includes('graphql.vscode-graphql');


### PR DESCRIPTION
Resolves #459

## Summary

Adds a new check to Doctor, to warn the user if they have a VSCode setting incompatible with the recommended VSCode extension.

## Set of changes

Added a check to the doctor cli command, to check both the global and workspace VSCode settings for the "editor.experimental.preferTreeSitter.typescript" setting.