### PR TITLE
Fix external scalars

### DIFF
--- a/.changeset/gentle-carpets-sing.md
+++ b/.changeset/gentle-carpets-sing.md
@@ -2,4 +2,6 @@
 '@gql.tada/cli-utils': patch
 ---
 
-Revert https://github.com/0no-co/gql.tada/pull/461 as it was leading to full paths in the turbo-output
+Fix external scalars in the `graphql` definition files,
+we will collect the imports and rewrite them into the 
+cached file.

--- a/.changeset/gentle-carpets-sing.md
+++ b/.changeset/gentle-carpets-sing.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Revert https://github.com/0no-co/gql.tada/pull/461 as it was leading to full paths in the turbo-output

--- a/examples/example-pokemon-api/src/Test.ts
+++ b/examples/example-pokemon-api/src/Test.ts
@@ -1,0 +1,1 @@
+export type Test = Record<string, any>;

--- a/examples/example-pokemon-api/src/components/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/components/graphql-cache.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { TadaDocumentNode, $tada } from 'gql.tada';
+import { initGraphQLTada } from 'gql.tada';
+import type { Test } from '../Test';
+
+declare module 'gql.tada' {
+ interface setupCache {
+    "\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n":
+      TadaDocumentNode<{ id: string; name: string; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>;
+    "\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n":
+      TadaDocumentNode<{ pokemons: ({ id: string; [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; } | null)[] | null; }, { limit?: number | null | undefined; }, void>;
+  }
+}

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { TadaDocumentNode, $tada } from 'gql.tada';
+import { initGraphQLTada } from 'gql.tada';
+import type { Test } from './Test';
+
+declare module 'gql.tada' {
+ interface setupCache {
+    "\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n":
+      TadaDocumentNode<{ id: string; name: Test; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>;
+    "\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n":
+      TadaDocumentNode<{ pokemons: ({ id: string; [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; } | null)[] | null; }, { limit?: number | null | undefined; }, void>;
+  }
+}

--- a/examples/example-pokemon-api/src/graphql.ts
+++ b/examples/example-pokemon-api/src/graphql.ts
@@ -1,8 +1,13 @@
 import { initGraphQLTada } from 'gql.tada';
 import type { introspection } from './graphql-env.d.ts';
+import type { Test } from './Test';
 
 export const graphql = initGraphQLTada<{
   introspection: introspection;
+  // Add any additional types or configurations here
+  scalars: {
+    Test: Test;
+  };
 }>();
 
 export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';

--- a/examples/example-pokemon-api/tsconfig.json
+++ b/examples/example-pokemon-api/tsconfig.json
@@ -4,7 +4,8 @@
       {
         "name": "@0no-co/graphqlsp",
         "schema": "./schema.graphql",
-        "tadaOutputLocation": "./src/graphql-env.d.ts"
+        "tadaOutputLocation": "./src/graphql-env.d.ts",
+        "tadaTurboLocation": "./src/components/graphql-cache.d.ts"
       }
     ],
     "noEmit": true,

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -6,7 +6,7 @@ import { loadConfig, parseConfig } from '@gql.tada/internal';
 import type { TTY, ComposeInput } from '../../term';
 import type { WriteTarget } from '../shared';
 import { writeOutput } from '../shared';
-import type { TurboDocument } from './types';
+import type { TurboDocument, GraphQLSourceFile } from './types';
 import * as logger from './logger';
 
 const PREAMBLE_IGNORE = ['/* eslint-disable */', '/* prettier-ignore */'].join('\n') + '\n';
@@ -33,51 +33,10 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
   } catch (error) {
     throw logger.externalError('Failed to load configuration.', error);
   }
-
-  const generator = runTurbo({
-    rootPath: configResult.rootPath,
-    configPath: configResult.configPath,
-    pluginConfig,
-  });
-
-  const documents: TurboDocument[] = [];
-  let warnings = 0;
-  let totalFileCount = 0;
-  let fileCount = 0;
-
-  try {
-    if (tty.isInteractive) yield logger.runningTurbo();
-
-    for await (const signal of generator) {
-      if (signal.kind === 'EXTERNAL_WARNING') {
-        yield logger.experimentMessage(
-          `${logger.code('.vue')} and ${logger.code('.svelte')} file support is experimental.`
-        );
-      } else if (signal.kind === 'FILE_COUNT') {
-        totalFileCount = signal.fileCount;
-      } else {
-        fileCount++;
-        documents.push(...signal.documents);
-        warnings += signal.warnings.length;
-        if (signal.warnings.length) {
-          let buffer = logger.warningFile(signal.filePath);
-          for (const warning of signal.warnings) {
-            buffer += logger.warningMessage(warning);
-            logger.warningGithub(warning);
-          }
-          yield buffer + '\n';
-        }
-      }
-
-      if (tty.isInteractive) yield logger.runningTurbo(fileCount, totalFileCount);
-    }
-  } catch (error) {
-    throw logger.externalError('Could not build cache', error);
-  }
-
   const projectPath = path.dirname(configResult.configPath);
+
+  let destination: WriteTarget;
   if ('schema' in pluginConfig) {
-    let destination: WriteTarget;
     if (!opts.output && tty.pipeTo) {
       destination = tty.pipeTo;
     } else if (opts.output) {
@@ -104,15 +63,60 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
       throw logger.errorMessage(
         'No output path was specified to write the output file to.\n' +
           logger.hint(
-            `You have to either set ${logger.code(
-              '"tadaTurboLocation"'
-            )} in your configuration,\n` +
+            `You have to either set ${logger.code('"tadaTurboLocation"')} in your configuration,\n` +
               `pass an ${logger.code('--output')} argument to this command,\n` +
               'or pipe this command to an output file.'
           )
       );
     }
+  }
 
+  const generator = runTurbo({
+    rootPath: configResult.rootPath,
+    configPath: configResult.configPath,
+    pluginConfig,
+    turboOutputPath: typeof destination! === 'string' ? destination : undefined,
+  });
+
+  const documents: TurboDocument[] = [];
+  let graphqlSources: GraphQLSourceFile[] = [];
+  let warnings = 0;
+  let totalFileCount = 0;
+  let fileCount = 0;
+
+  try {
+    if (tty.isInteractive) yield logger.runningTurbo();
+
+    for await (const signal of generator) {
+      if (signal.kind === 'EXTERNAL_WARNING') {
+        yield logger.experimentMessage(
+          `${logger.code('.vue')} and ${logger.code('.svelte')} file support is experimental.`
+        );
+      } else if (signal.kind === 'FILE_COUNT') {
+        totalFileCount = signal.fileCount;
+      } else if (signal.kind === 'GRAPHQL_SOURCES') {
+        graphqlSources = signal.sources;
+      } else {
+        fileCount++;
+        documents.push(...signal.documents);
+        warnings += signal.warnings.length;
+        if (signal.warnings.length) {
+          let buffer = logger.warningFile(signal.filePath);
+          for (const warning of signal.warnings) {
+            buffer += logger.warningMessage(warning);
+            logger.warningGithub(warning);
+          }
+          yield buffer + '\n';
+        }
+      }
+
+      if (tty.isInteractive) yield logger.runningTurbo(fileCount, totalFileCount);
+    }
+  } catch (error) {
+    throw logger.externalError('Could not build cache', error);
+  }
+
+  if ('schema' in pluginConfig) {
     if (warnings && opts.failOnWarn) {
       throw logger.warningSummary(warnings);
     }
@@ -120,8 +124,8 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
     try {
       const cache: Record<string, string> = {};
       for (const item of documents) cache[item.argumentKey] = item.documentType;
-      const contents = createCacheContents(cache);
-      await writeOutput(destination, contents);
+      const contents = createCacheContents(cache, graphqlSources, destination!);
+      await writeOutput(destination!, contents);
     } catch (error) {
       throw logger.externalError('Something went wrong while writing the type cache file', error);
     }
@@ -160,8 +164,9 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
             documentCount[name]++;
           }
         }
-        const contents = createCacheContents(cache);
-        await writeOutput(path.resolve(projectPath, tadaTurboLocation), contents);
+        const destination = path.resolve(projectPath, tadaTurboLocation);
+        const contents = createCacheContents(cache, graphqlSources, destination);
+        await writeOutput(destination, contents);
       } catch (error) {
         throw logger.externalError(
           `Something went wrong while writing the '${name}' schema's type cache file.`,
@@ -178,15 +183,49 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
   }
 }
 
-function createCacheContents(cache: Record<string, string>): string {
+function createCacheContents(
+  cache: Record<string, string>,
+  graphqlSources: GraphQLSourceFile[],
+  turboDestination: WriteTarget
+): string {
   let output = '';
   for (const key in cache) {
     if (output) output += '\n';
     output += `    ${key}:\n      ${cache[key]};`;
   }
+
+  let imports = "import type { TadaDocumentNode, $tada } from 'gql.tada';\n";
+
+  const isFilePath =
+    typeof turboDestination === 'string' ||
+    (turboDestination &&
+      typeof turboDestination === 'object' &&
+      'toString' in turboDestination &&
+      !('writable' in turboDestination));
+
+  const addedImports = new Set<string>();
+  for (const source of graphqlSources) {
+    for (const importInfo of source.imports) {
+      if (isFilePath) {
+        const turboPath = turboDestination.toString();
+        const sourceDir = path.dirname(source.absolutePath);
+        const absoluteImportPath = path.resolve(sourceDir, importInfo.specifier);
+        const absoluteTurboPath = path.resolve(turboPath);
+
+        if (absoluteImportPath === absoluteTurboPath || addedImports.has(importInfo.specifier))
+          continue;
+
+        addedImports.add(importInfo.specifier);
+      }
+
+      imports += importInfo.importClause + '\n';
+    }
+  }
+
   return (
     PREAMBLE_IGNORE +
-    "import type { TadaDocumentNode, $tada } from 'gql.tada';\n\n" +
+    imports +
+    '\n' +
     "declare module 'gql.tada' {\n" +
     ' interface setupCache {\n' +
     output +

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import * as path from 'node:path';
 import type { GraphQLSPConfig } from '@gql.tada/internal';
 
 import { getSchemaNamesFromConfig } from '@gql.tada/internal';
@@ -7,12 +8,158 @@ import { findAllCallExpressions } from '@0no-co/graphqlsp/api';
 import { programFactory } from '../../ts';
 import { expose } from '../../threads';
 
-import type { TurboSignal, TurboWarning, TurboDocument } from './types';
+import type {
+  TurboSignal,
+  TurboWarning,
+  TurboDocument,
+  GraphQLSourceFile,
+  GraphQLSourceImport,
+} from './types';
 
 export interface TurboParams {
   rootPath: string;
   configPath: string;
   pluginConfig: GraphQLSPConfig;
+  turboOutputPath?: string;
+}
+
+function traceCallToImportSource(
+  callExpression: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  program: ts.Program
+): string | undefined {
+  const typeChecker = program.getTypeChecker();
+  const expression = callExpression.expression;
+
+  let identifier: ts.Identifier | undefined;
+  if (ts.isIdentifier(expression)) {
+    identifier = expression;
+  } else if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.expression)) {
+    identifier = expression.expression;
+  }
+
+  if (!identifier) return undefined;
+
+  const symbol = typeChecker.getSymbolAtLocation(identifier);
+  if (!symbol || !symbol.declarations) return undefined;
+
+  for (const declaration of symbol.declarations) {
+    const importDeclaration = findImportDeclaration(declaration);
+    if (importDeclaration && ts.isStringLiteral(importDeclaration.moduleSpecifier)) {
+      const moduleName = importDeclaration.moduleSpecifier.text;
+      return resolveModulePath(moduleName, sourceFile, program);
+    }
+  }
+
+  return undefined;
+}
+
+function findImportDeclaration(node: ts.Node): ts.ImportDeclaration | undefined {
+  let current: ts.Node | undefined = node;
+
+  while (current) {
+    if (ts.isImportDeclaration(current)) {
+      return current;
+    }
+    current = current.parent;
+  }
+
+  return undefined;
+}
+
+function resolveModulePath(
+  moduleName: string,
+  containingFile: ts.SourceFile,
+  program: ts.Program
+): string | undefined {
+  const compilerOptions = program.getCompilerOptions();
+  const host = ts.createCompilerHost(compilerOptions);
+
+  const resolved = ts.resolveModuleName(moduleName, containingFile.fileName, compilerOptions, host);
+
+  if (resolved.resolvedModule) {
+    return resolved.resolvedModule.resolvedFileName;
+  }
+
+  return undefined;
+}
+
+function collectImportsFromSourceFile(
+  sourceFile: ts.SourceFile,
+  pluginConfig: GraphQLSPConfig,
+  resolveModuleName: (importSpecifier: string, fromPath: string, toPath: string) => string,
+  turboOutputPath?: string
+): GraphQLSourceImport[] {
+  const imports: GraphQLSourceImport[] = [];
+
+  const tadaImportPaths = getTadaOutputPaths(pluginConfig);
+
+  function visit(node: ts.Node) {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const specifier = node.moduleSpecifier.text;
+
+      if (!isTadaImport(specifier, sourceFile.fileName, tadaImportPaths)) {
+        const importClause = node.getFullText().trim();
+        if (turboOutputPath) {
+          // Adjust the import specifier to point to the turbo output path
+          const adjustedSpecifier = resolveModuleName(
+            specifier,
+            sourceFile.fileName,
+            turboOutputPath
+          )
+            .replace(/\.ts$/, '')
+            .replace(/\.tsx$/, '');
+          if (adjustedSpecifier) {
+            imports.push({
+              specifier: adjustedSpecifier,
+              importClause: importClause.replace(specifier, adjustedSpecifier),
+            });
+          }
+        } else {
+          imports.push({ specifier, importClause });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return imports;
+}
+
+function getTadaOutputPaths(pluginConfig: GraphQLSPConfig): string[] {
+  const paths: string[] = [];
+
+  if ('schema' in pluginConfig && pluginConfig.tadaOutputLocation) {
+    paths.push(pluginConfig.tadaOutputLocation);
+  } else {
+    // Multiple schemas aren't supported in this context
+  }
+
+  return paths;
+}
+
+function isTadaImport(
+  importSpecifier: string,
+  sourceFilePath: string,
+  tadaOutputLocationPaths: string[]
+): boolean {
+  if (importSpecifier.startsWith('.')) {
+    const sourceDir = path.dirname(sourceFilePath);
+    const absoluteImportPath = path.resolve(sourceDir, importSpecifier);
+
+    return tadaOutputLocationPaths.some((tadaOutputLocationPath) => {
+      const absoluteTadaPath = path.resolve(tadaOutputLocationPath);
+      return (
+        absoluteImportPath === absoluteTadaPath ||
+        absoluteImportPath.startsWith(absoluteTadaPath + path.sep)
+      );
+    });
+  }
+
+  return tadaOutputLocationPaths.some(
+    (tadaPath) => importSpecifier === tadaPath || importSpecifier.startsWith(tadaPath + '/')
+  );
 }
 
 async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSignal> {
@@ -44,6 +191,8 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   };
 
   const checker = container.program.getTypeChecker();
+  const uniqueGraphQLSources = new Map<string, GraphQLSourceFile>();
+
   for (const sourceFile of sourceFiles) {
     let filePath = sourceFile.fileName;
     const documents: TurboDocument[] = [];
@@ -70,6 +219,28 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
           col: position.col,
         });
         continue;
+      }
+
+      const graphqlSourcePath = traceCallToImportSource(
+        callExpression,
+        sourceFile,
+        container.program
+      );
+
+      if (graphqlSourcePath && !uniqueGraphQLSources.has(graphqlSourcePath)) {
+        const graphqlSourceFile = container.program.getSourceFile(graphqlSourcePath);
+        if (graphqlSourceFile) {
+          const imports = collectImportsFromSourceFile(
+            graphqlSourceFile,
+            params.pluginConfig,
+            factory.resolveModuleName.bind(factory),
+            params.turboOutputPath
+          );
+          uniqueGraphQLSources.set(graphqlSourcePath, {
+            absolutePath: graphqlSourcePath,
+            imports,
+          });
+        }
       }
 
       const returnType = checker.getTypeAtLocation(callExpression);
@@ -108,6 +279,13 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       filePath,
       documents,
       warnings,
+    };
+  }
+
+  if (uniqueGraphQLSources.size > 0) {
+    yield {
+      kind: 'GRAPHQL_SOURCES',
+      sources: Array.from(uniqueGraphQLSources.values()),
     };
   }
 }

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -120,6 +120,7 @@ const BUILDER_FLAGS: ts.TypeFormatFlags =
   ts.TypeFormatFlags.InTypeAlias |
   ts.TypeFormatFlags.UseFullyQualifiedType |
   ts.TypeFormatFlags.GenerateNamesForShadowedTypeParams |
+  ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
   ts.TypeFormatFlags.AllowUniqueESSymbolType |
   ts.TypeFormatFlags.WriteTypeArgumentsOfSignature;
 

--- a/packages/cli-utils/src/commands/turbo/types.ts
+++ b/packages/cli-utils/src/commands/turbo/types.ts
@@ -11,6 +11,16 @@ export interface TurboDocument {
   documentType: string;
 }
 
+export interface GraphQLSourceImport {
+  specifier: string;
+  importClause: string;
+}
+
+export interface GraphQLSourceFile {
+  absolutePath: string;
+  imports: GraphQLSourceImport[];
+}
+
 export interface FileTurboSignal {
   kind: 'FILE_TURBO';
   filePath: string;
@@ -27,4 +37,9 @@ export interface WarningSignal {
   kind: 'EXTERNAL_WARNING';
 }
 
-export type TurboSignal = FileTurboSignal | FileCountSignal | WarningSignal;
+export interface GraphQLSourceSignal {
+  kind: 'GRAPHQL_SOURCES';
+  sources: GraphQLSourceFile[];
+}
+
+export type TurboSignal = FileTurboSignal | FileCountSignal | WarningSignal | GraphQLSourceSignal;


### PR DESCRIPTION
Reverts https://github.com/0no-co/gql.tada/pull/461
Closes #470 
Fixes https://github.com/0no-co/gql.tada/issues/445

We'll probably need a slightly different approach where we derive the file `graphql` is being imported from or leverage the global `tadaOutputLocation`. When we have this file we want to collect all imports in AST traversal and prepend it to the turbo file.