### PR TITLE
Fix external scalars 2

### DIFF
--- a/.changeset/gentle-carpets-sing.md
+++ b/.changeset/gentle-carpets-sing.md
@@ -2,4 +2,6 @@
 '@gql.tada/cli-utils': patch
 ---
 
-Revert https://github.com/0no-co/gql.tada/pull/461 as it was leading to full paths in the turbo-output
+Fix external scalars in the `graphql` definition files,
+we will collect the imports and rewrite them into the 
+cached file.

--- a/examples/example-pokemon-api/src/Test.ts
+++ b/examples/example-pokemon-api/src/Test.ts
@@ -1,0 +1,1 @@
+export type Test = Record<string, any>;

--- a/examples/example-pokemon-api/src/components/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/components/graphql-cache.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { TadaDocumentNode, $tada } from 'gql.tada';
+import { initGraphQLTada } from 'gql.tada';
+import type { Test } from '../Test';
+
+declare module 'gql.tada' {
+ interface setupCache {
+    "\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n":
+      TadaDocumentNode<{ id: string; name: string; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>;
+    "\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n":
+      TadaDocumentNode<{ pokemons: ({ id: string; [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; } | null)[] | null; }, { limit?: number | null | undefined; }, void>;
+  }
+}

--- a/examples/example-pokemon-api/src/graphql-cache.d.ts
+++ b/examples/example-pokemon-api/src/graphql-cache.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { TadaDocumentNode, $tada } from 'gql.tada';
+import { initGraphQLTada } from 'gql.tada';
+import type { Test } from './Test';
+
+declare module 'gql.tada' {
+ interface setupCache {
+    "\n  fragment PokemonItem on Pokemon {\n    id\n    name\n  }\n":
+      TadaDocumentNode<{ id: string; name: Test; }, {}, { fragment: "PokemonItem"; on: "Pokemon"; masked: true; }>;
+    "\n  query Pokemons ($limit: Int = 10) {\n    pokemons(limit: $limit) {\n      id\n      ...PokemonItem\n    }\n  }\n":
+      TadaDocumentNode<{ pokemons: ({ id: string; [$tada.fragmentRefs]: { PokemonItem: "Pokemon"; }; } | null)[] | null; }, { limit?: number | null | undefined; }, void>;
+  }
+}

--- a/examples/example-pokemon-api/src/graphql.ts
+++ b/examples/example-pokemon-api/src/graphql.ts
@@ -1,8 +1,13 @@
 import { initGraphQLTada } from 'gql.tada';
 import type { introspection } from './graphql-env.d.ts';
+import type { Test } from './Test';
 
 export const graphql = initGraphQLTada<{
   introspection: introspection;
+  // Add any additional types or configurations here
+  scalars: {
+    Test: Test;
+  };
 }>();
 
 export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';

--- a/examples/example-pokemon-api/tsconfig.json
+++ b/examples/example-pokemon-api/tsconfig.json
@@ -4,7 +4,8 @@
       {
         "name": "@0no-co/graphqlsp",
         "schema": "./schema.graphql",
-        "tadaOutputLocation": "./src/graphql-env.d.ts"
+        "tadaOutputLocation": "./src/graphql-env.d.ts",
+        "tadaTurboLocation": "./src/components/graphql-cache.d.ts"
       }
     ],
     "noEmit": true,

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -193,10 +193,8 @@ function createCacheContents(
     output += `    ${key}:\n      ${cache[key]};`;
   }
 
-  // Generate adjusted imports from GraphQL source files
   let imports = "import type { TadaDocumentNode, $tada } from 'gql.tada';\n";
 
-  // Only adjust import paths if destination is a file path (not a WriteStream like stdout)
   const isFilePath =
     typeof turboDestination === 'string' ||
     (turboDestination &&
@@ -216,15 +214,12 @@ function createCacheContents(
           turboDestination.toString()
         );
 
-        // Skip imports that would create circular references to the turbo cache itself
         const turboPath = turboDestination.toString();
         const sourceDir = path.dirname(source.absolutePath);
         const absoluteImportPath = path.resolve(sourceDir, importInfo.specifier);
         const absoluteTurboPath = path.resolve(turboPath);
 
-        if (absoluteImportPath === absoluteTurboPath) {
-          continue; // Skip this import to avoid circular reference
-        }
+        if (absoluteImportPath === absoluteTurboPath) continue;
 
         adjustedImportClause = importInfo.importClause
           .replace(`'${importInfo.specifier}'`, `'${adjustedSpecifier}'`)

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -84,7 +84,6 @@ function resolveModulePath(
     const containingDir = path.dirname(containingFile.fileName);
     const resolvedPath = path.resolve(containingDir, moduleName);
 
-    // Try common extensions
     for (const ext of ['.ts', '.tsx', '.js', '.jsx']) {
       const fullPath = resolvedPath + ext;
       if (host.fileExists(fullPath)) {
@@ -92,7 +91,6 @@ function resolveModulePath(
       }
     }
 
-    // Try index files
     for (const ext of ['.ts', '.tsx', '.js', '.jsx']) {
       const indexPath = path.join(resolvedPath, 'index' + ext);
       if (host.fileExists(indexPath)) {
@@ -149,7 +147,6 @@ function isTadaImport(
   sourceFilePath: string,
   tadaOutputLocationPaths: string[]
 ): boolean {
-  // For relative imports, resolve to absolute path and check
   if (importSpecifier.startsWith('.')) {
     const sourceDir = path.dirname(sourceFilePath);
     const absoluteImportPath = path.resolve(sourceDir, importSpecifier);
@@ -163,7 +160,6 @@ function isTadaImport(
     });
   }
 
-  // For absolute imports, check if they match any Tada paths
   return tadaOutputLocationPaths.some(
     (tadaPath) => importSpecifier === tadaPath || importSpecifier.startsWith(tadaPath + '/')
   );
@@ -228,14 +224,13 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
         continue;
       }
 
-      // Trace back to the GraphQL source file
       const graphqlSourcePath = traceCallToImportSource(
         callExpression,
         sourceFile,
         container.program
       );
+
       if (graphqlSourcePath && !uniqueGraphQLSources.has(graphqlSourcePath)) {
-        // Load and analyze the GraphQL source file
         const graphqlSourceFile = container.program.getSourceFile(graphqlSourcePath);
         if (graphqlSourceFile) {
           const imports = collectImportsFromSourceFile(graphqlSourceFile, params.pluginConfig);
@@ -285,7 +280,6 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
     };
   }
 
-  // Emit collected GraphQL source files and their imports
   if (uniqueGraphQLSources.size > 0) {
     yield {
       kind: 'GRAPHQL_SOURCES',

--- a/packages/cli-utils/src/commands/turbo/types.ts
+++ b/packages/cli-utils/src/commands/turbo/types.ts
@@ -11,6 +11,16 @@ export interface TurboDocument {
   documentType: string;
 }
 
+export interface GraphQLSourceImport {
+  specifier: string;
+  importClause: string;
+}
+
+export interface GraphQLSourceFile {
+  absolutePath: string;
+  imports: GraphQLSourceImport[];
+}
+
 export interface FileTurboSignal {
   kind: 'FILE_TURBO';
   filePath: string;
@@ -27,4 +37,9 @@ export interface WarningSignal {
   kind: 'EXTERNAL_WARNING';
 }
 
-export type TurboSignal = FileTurboSignal | FileCountSignal | WarningSignal;
+export interface GraphQLSourceSignal {
+  kind: 'GRAPHQL_SOURCES';
+  sources: GraphQLSourceFile[];
+}
+
+export type TurboSignal = FileTurboSignal | FileCountSignal | WarningSignal | GraphQLSourceSignal;


### PR DESCRIPTION
## What's the problem?

When generating the turbo cache, we collect all the `graphql()` call expressions and their types, but we weren't copying over the imports from the GraphQL source files (like `examples/example-pokemon-api/src/graphql.ts`). This meant the generated cache file was missing imports like:

```ts
import type { introspection } from './graphql-env.d.ts';
import type { Test } from './Test';
```

## What's the fix?

- **Trace graphql() calls back to source**: Added AST traversal to find where each `graphql()` call is imported from
- **Collect imports**: Extract all import statements from GraphQL source files 
- **Adjust paths**: Update relative import paths to work from the turbo cache location
- **Avoid circular imports**: Filter out any imports that would reference the output files themselves
- **Deduplicate**: Only process each unique GraphQL source file once

## Example

Before:
```ts
// turbo cache only had:
import type { TadaDocumentNode, $tada } from 'gql.tada';
```

After:
```ts  
// turbo cache now includes the GraphQL source imports:
import type { TadaDocumentNode, $tada } from 'gql.tada';
import type { Test } from '../examples/example-pokemon-api/src/Test';
```

Works for both single and multi-schema setups.