### PR TITLE
Support parsing executable definition descriptions

### DIFF
--- a/.changeset/clean-mails-exist.md
+++ b/.changeset/clean-mails-exist.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Support parsing executable descriptions

--- a/src/__tests__/parser.test-d.ts
+++ b/src/__tests__/parser.test-d.ts
@@ -901,4 +901,29 @@ describe('parseDocument', () => {
     expectTypeOf<actual>().toMatchTypeOf<kitchensinkDocument>();
     expectTypeOf<actual>().toMatchTypeOf<DocumentNode>();
   });
+
+  it('parses document with comments', () => {
+    const document = `
+      """test"""
+      mutation { ... Field}
+      
+      """test2"""
+      fragment Field on Type {
+        field
+      }
+    `;
+
+    expectTypeOf<parseDocument<typeof document>>().not.toBeNever();
+  });
+  it('parses document with variable comments', () => {
+    const document = `
+      """test"""
+      mutation (
+        """test"""
+        $var: String!
+      ) { field }
+    `;
+
+    expectTypeOf<parseDocument<typeof document>>().not.toBeNever();
+  });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -36,6 +36,12 @@ export type takeValue<In extends any[], Const extends boolean> =
       : void
     : void;
 
+export type takeString<In extends any[]> = In extends [Token.String, ...infer In]
+  ? _match<{ kind: Kind.STRING; value: string; block: false }, In>
+  : In extends [Token.BlockString, ...infer In]
+    ? _match<{ kind: Kind.STRING; value: string; block: true }, In>
+    : void;
+
 type takeListRec<Nodes extends any[], In extends any[], Const extends boolean> = In extends [
   Token.BracketClose,
   ...infer In,
@@ -277,7 +283,7 @@ type _takeVarDefinitionRec<Definitions extends any[], In extends any[]> = In ext
   ? _match<Definitions, In>
   : takeVarDefinition<In> extends _match<infer Definition, infer In>
     ? _takeVarDefinitionRec<[...Definitions, Definition], In>
-    : takeValue<In, true> extends _match<infer _, infer In>
+    : takeString<In> extends _match<infer _, infer In>
       ? _takeVarDefinitionRec<[...Definitions], In>
       : _match<Definitions, In>;
 
@@ -356,7 +362,7 @@ type _takeDocumentRec<Definitions extends any[], In extends any[]> =
     ? _takeDocumentRec<[...Definitions, Definition], In>
     : takeOperationDefinition<In> extends _match<infer Definition, infer In>
       ? _takeDocumentRec<[...Definitions, Definition], In>
-      : takeValue<In, true> extends _match<infer _, infer In>
+      : takeString<In> extends _match<infer _, infer In>
         ? _takeDocumentRec<[...Definitions], In>
         : _match<Definitions, In>;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -277,7 +277,10 @@ type _takeVarDefinitionRec<Definitions extends any[], In extends any[]> = In ext
   ? _match<Definitions, In>
   : takeVarDefinition<In> extends _match<infer Definition, infer In>
     ? _takeVarDefinitionRec<[...Definitions, Definition], In>
-    : void;
+    : takeValue<In, true> extends _match<infer _, infer In>
+      ? _takeVarDefinitionRec<[...Definitions], In>
+      : _match<Definitions, In>;
+
 export type takeVarDefinitions<In extends any[]> = In extends [Token.ParenOpen, ...infer In]
   ? _takeVarDefinitionRec<[], In>
   : _match<[], In>;
@@ -353,7 +356,9 @@ type _takeDocumentRec<Definitions extends any[], In extends any[]> =
     ? _takeDocumentRec<[...Definitions, Definition], In>
     : takeOperationDefinition<In> extends _match<infer Definition, infer In>
       ? _takeDocumentRec<[...Definitions, Definition], In>
-      : _match<Definitions, In>;
+      : takeValue<In, true> extends _match<infer _, infer In>
+        ? _takeDocumentRec<[...Definitions], In>
+        : _match<Definitions, In>;
 
 export type parseDocument<In extends string> =
   _takeDocumentRec<[], tokenize<In>> extends _match<[...infer Definitions], any>


### PR DESCRIPTION
Similar to https://github.com/0no-co/graphql.web/pull/59 but in the TS parser, making sure this doesn't start failing. For the LSP to support this we'll need to upgrade GraphQL.web