### PR TITLE
Add support for unmask

### DIFF
--- a/.changeset/eleven-bears-search.md
+++ b/.changeset/eleven-bears-search.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Add support for `unmask` alongside `_unmask`

--- a/src/__tests__/api.test-d.ts
+++ b/src/__tests__/api.test-d.ts
@@ -94,6 +94,44 @@ describe('graphql()', () => {
     }>();
   });
 
+  it('should create a fragment type on unmasked fragments', () => {
+    const fragment = graphql(`
+      fragment Fields on Todo @unmask {
+        id
+        text
+      }
+    `);
+
+    const query = graphql(
+      `
+        query Test($limit: Int) {
+          todos(limit: $limit) {
+            ...Fields
+          }
+        }
+      `,
+      [fragment]
+    );
+
+    expectTypeOf<FragmentOf<typeof fragment>>().toEqualTypeOf<{
+      id: string;
+      text: string;
+    }>();
+
+    expectTypeOf<ResultOf<typeof query>>().toEqualTypeOf<{
+      todos:
+        | ({
+            id: string;
+            text: string;
+          } | null)[]
+        | null;
+    }>();
+
+    expectTypeOf<VariablesOf<typeof query>>().toEqualTypeOf<{
+      limit?: number | null;
+    }>();
+  });
+
   // See: https://github.com/0no-co/gql.tada/issues/100#issuecomment-1974924487
   it('should create a fragment type on unmasked fragments on nested interface', () => {
     const fragment = graphql(`

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -33,7 +33,7 @@ type isMaskedRec<Directives extends readonly unknown[] | undefined> = Directives
   ...infer Rest,
 ]
   ? Directive extends { kind: Kind.DIRECTIVE; name: any }
-    ? Directive['name']['value'] extends '_unmask'
+    ? Directive['name']['value'] extends '_unmask' | 'unmask'
       ? false
       : isMaskedRec<Rest>
     : isMaskedRec<Rest>


### PR DESCRIPTION
This enables Apollo-Client to use gql.tada and have unmasking - the LSP already supports this https://github.com/0no-co/GraphQLSP/blob/main/packages/graphqlsp/src/diagnostics.ts#L36