### PR TITLE
docs: Improve clarity of heading in docs

### DIFF
--- a/website/get-started/workflows.md
+++ b/website/get-started/workflows.md
@@ -333,7 +333,7 @@ generates the typings output file and since this file is necessary for
 type inference, if it's not generated and missing, running type
 checks (for instance, with `tsc`) will likely fail with type errors.
 
-### Uncommitted output files
+### Verifying committed output files
 
 As you've seen on this page, there are two different output files we're
 concerned with when running inside an continuous integration environment.


### PR DESCRIPTION
## Summary

It seems that the paragraphs under the heading are talking about verifying the committed files in CI. The heading says "uncommitted" which I think is wrong? This PR tries to bring the heading in line with the paragraphs under it.
