### PR TITLE
Fix turbo warnings for subpath imports

### DIFF
--- a/.changeset/calm-apples-doubt.md
+++ b/.changeset/calm-apples-doubt.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix turbo false warnings for subpath imports when moduleResolution is inherited from an extended tsconfig

--- a/packages/cli-utils/src/ts/__tests__/factory.test.ts
+++ b/packages/cli-utils/src/ts/__tests__/factory.test.ts
@@ -1,0 +1,79 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import ts from 'typescript';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../transformers', () => ({
+  transformExtensions: [] as const,
+  transform: vi.fn(),
+}));
+
+describe('programFactory', () => {
+  it('inherits module resolution from extended tsconfig files', async () => {
+    const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'gql-tada-factory-'));
+
+    try {
+      const { programFactory } = await import('../factory');
+      const configPath = path.join(rootPath, 'tsconfig.json');
+      const indexPath = path.join(rootPath, 'src', 'index.ts');
+      await fs.mkdir(path.join(rootPath, 'node_modules', '@acme', 'rig'), { recursive: true });
+      await fs.mkdir(path.join(rootPath, 'src'), { recursive: true });
+
+      await Promise.all([
+        fs.writeFile(
+          path.join(rootPath, 'package.json'),
+          JSON.stringify(
+            {
+              name: 'fixture',
+              type: 'module',
+              imports: {
+                '#*': './src/*',
+              },
+            },
+            null,
+            2
+          )
+        ),
+        fs.writeFile(
+          path.join(rootPath, 'node_modules', '@acme', 'rig', 'tsconfig.json'),
+          JSON.stringify(
+            {
+              compilerOptions: {
+                module: 'nodenext',
+                moduleResolution: 'nodenext',
+              },
+            },
+            null,
+            2
+          )
+        ),
+        fs.writeFile(
+          configPath,
+          JSON.stringify(
+            {
+              extends: '@acme/rig/tsconfig.json',
+              include: ['src/**/*'],
+            },
+            null,
+            2
+          )
+        ),
+        fs.writeFile(path.join(rootPath, 'src', 'tada.ts'), 'export const graphql = () => null;\n'),
+        fs.writeFile(indexPath, "import { graphql } from '#tada.ts';\ngraphql();\n"),
+      ]);
+
+      const factory = programFactory({ rootPath, configPath });
+      const program = factory.build().program;
+      const sourceFile = program.getSourceFile(indexPath)!;
+      const diagnostics = program
+        .getSemanticDiagnostics(sourceFile)
+        .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'));
+
+      expect(factory.wasOriginallyNodeNext).toBe(true);
+      expect(diagnostics).toEqual([]);
+    } finally {
+      await fs.rm(rootPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -59,7 +59,7 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
   const virtualMap: VirtualMap = new Map();
 
   const system = createFSBackedSystem(vfsMap, params.rootPath, ts, resolveDefaultLibsPath(params));
-  const config = resolveConfig(params, system);
+  const config = resolveConfig(params);
 
   const rootNames = new Set(config.fileNames);
   const options = {
@@ -271,14 +271,14 @@ const resolveDefaultLibsPath = (params: ProgramFactoryParams): string => {
   }
 };
 
-const resolveConfig = (params: ProgramFactoryParams, system: ts.System): ts.ParsedCommandLine => {
-  const text = system.readFile(params.configPath, 'utf8') || '{}';
+const resolveConfig = (params: ProgramFactoryParams): ts.ParsedCommandLine => {
+  const text = ts.sys.readFile(params.configPath, 'utf8') || '{}';
   const parseResult = ts.parseConfigFileTextToJson(params.configPath, text);
   if (parseResult.error != null) throw new Error(parseResult.error.messageText.toString());
   const projectRoot = path.dirname(params.configPath);
   return ts.parseJsonConfigFileContent(
     parseResult.config,
-    system,
+    ts.sys,
     projectRoot,
     ts.getDefaultCompilerOptions(),
     params.configPath


### PR DESCRIPTION
## Summary
Fix `turbo` false warnings for subpath imports when `moduleResolution` is inherited from an extended `tsconfig`.

Resolves #510

## Set of changes
- parse `tsconfig` with the real filesystem so inherited compiler options are preserved
- add a regression test for inherited `NodeNext` resolution with package imports