### PR TITLE
Upgrade pnpm to v11 and gate npm publishing

### DIFF
--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -1,0 +1,79 @@
+import { appendFileSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ignoredDirectories = new Set(['.git', 'dist', 'node_modules']);
+
+async function findPackageManifests(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const manifests = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        manifests.push(...(await findPackageManifests(fullPath)));
+      }
+    } else if (entry.isFile() && entry.name === 'package.json') {
+      const pkg = JSON.parse(await readFile(fullPath, 'utf8'));
+
+      if (!pkg.private && pkg.name && pkg.version) {
+        manifests.push({ name: pkg.name, version: pkg.version });
+      }
+    }
+  }
+
+  return manifests;
+}
+
+async function hasPublishedVersion(pkg) {
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  });
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to query ${pkg.name}: ${response.status} ${response.statusText}`);
+  }
+
+  const metadata = await response.json();
+  return Object.prototype.hasOwnProperty.call(metadata.versions ?? {}, pkg.version);
+}
+
+async function main() {
+  const packages = (await findPackageManifests(process.cwd())).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  let hasUnpublished = false;
+
+  for (const pkg of packages) {
+    const isPublished = await hasPublishedVersion(pkg);
+
+    if (isPublished) {
+      console.log(`${pkg.name}@${pkg.version} is already published`);
+    } else {
+      console.log(`${pkg.name}@${pkg.version} is not published yet`);
+      hasUnpublished = true;
+    }
+  }
+
+  const output =
+    [`has_unpublished=${String(hasUnpublished)}`, `should_publish=${String(hasUnpublished)}`].join(
+      '\n'
+    ) + '\n';
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,18 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,29 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+          run_install: false
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-      - name: Use pnpm store
-        uses: actions/cache@v4
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          cache: pnpm
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,11 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       contents: write
-      id-token: write
       issues: write
-      repository-projects: write
-      deployments: write
-      packages: write
       pull-requests: write
     steps:
       - name: Checkout Repo
@@ -22,44 +20,73 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+          run_install: false
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-      - name: Use pnpm store
-        uses: actions/cache@v3
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: pnpm install --frozen-lockfile
 
-      - name: Update npm
-        run: npm install -g npm@11.6
-
-      - name: PR or Publish
+      - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@v1.4.6
+        uses: changesets/action@v1.5.3
         with:
           version: pnpm changeset:version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.has_changesets == 'false'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/gql.tada
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@11.14.1
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish packages
+        id: changesets
+        uses: changesets/action@v1.5.3
+        with:
           publish: pnpm changeset:publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify discord
@@ -71,13 +98,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-      - name: Publish Prerelease
-        if: steps.changesets.outputs.published != 'true'
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git reset --hard origin/main
-          pnpm changeset version --no-git-tag --snapshot canary
-          pnpm changeset publish --no-git-tag --snapshot canary --tag canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,18 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@v1.8.0
         with:
           version: pnpm changeset:version
         env:
@@ -59,18 +59,18 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
@@ -83,7 +83,7 @@ jobs:
 
       - name: Publish packages
         id: changesets
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@v1.8.0
         with:
           publish: pnpm changeset:publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     timeout-minutes: 20
     outputs:
       has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
+      has_unpublished_packages: ${{ steps.unpublished.outputs.has_unpublished }}
     permissions:
       contents: write
       issues: write
@@ -32,6 +33,10 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      - name: Check for unpublished package versions
+        id: unpublished
+        run: node .github/scripts/has-unpublished-packages.mjs
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
@@ -46,7 +51,7 @@ jobs:
   publish:
     name: Publish
     needs: release
-    if: needs.release.outputs.has_changesets == 'false'
+    if: needs.release.outputs.has_changesets == 'false' && needs.release.outputs.has_unpublished_packages == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     environment:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,18 +20,18 @@ jobs:
       deployments: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -47,7 +47,7 @@ jobs:
         run: pnpm run export
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/pages-action@v1.5.0
         with:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -24,29 +24,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+          run_install: false
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-      - name: Use pnpm store
-        uses: actions/cache@v4
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          cache: pnpm
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,11 +131,13 @@ changes are merged. It will always open a **"Version Packages" PR** which is kep
 documents all changes that are made and will show in its description what all new changelogs are
 going to contain for their new entries.
 
-Once a "Version Packages" PR is approved by a contributor and merged, the action will automatically
-take care of creating the release, publishing all updated packages to the npm registry, and creating
+Once a "Version Packages" PR is approved by a contributor and merged, the release workflow will
+pause at the `npm` environment approval gate. After approval, the action will automatically take care
+of creating the release, publishing all updated packages to the npm registry, and creating
 appropriate tags on GitHub too.
 
-This process is automated, but the changelog should be checked for errors.
+This process is automated, but the changelog should be checked for errors before approving the `npm`
+environment deployment.
 
 As to **when** to merge the automated PR and publish? Maybe not after every change. Typically there
 are two release batches: hotfixes and release batches. We expect that a hotfix for a single package

--- a/package.json
+++ b/package.json
@@ -99,15 +99,6 @@
       "./scripts/eslint-preset.js"
     ]
   },
-  "pnpm": {
-    "overrides": {
-      "gql.tada": "workspace:*",
-      "@gql.tada/internal": "workspace:*",
-      "astro-expressive-code": "^0.31.0",
-      "typescript": "^5.5.2",
-      "@0no-co/graphqlsp": "^1.12.9"
-    }
-  },
   "devDependencies": {
     "@0no-co/typescript.js": "5.3.2-2",
     "@actions/core": "^1.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1137,46 +1137,55 @@ packages:
     resolution: {integrity: sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.0':
     resolution: {integrity: sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.21.0':
     resolution: {integrity: sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.21.0':
     resolution: {integrity: sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.0':
     resolution: {integrity: sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.0':
     resolution: {integrity: sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.21.0':
     resolution: {integrity: sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.21.0':
     resolution: {integrity: sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.21.0':
     resolution: {integrity: sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==}
@@ -1339,6 +1348,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@urql/core@5.0.6':
     resolution: {integrity: sha512-38rgSDqVNihFDauw1Pm9V7XLWIKuK8V9CKgrUF7/xEKinze8ENKP1ZeBhkG+dxWzJan7CHK+SLl46kAdvZwIlA==}
@@ -2116,6 +2126,7 @@ packages:
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,14 @@ packages:
   - 'examples/*'
   - './website'
   - './'
+
+allowBuilds:
+  esbuild: true
+  vue-demi: true
+
+overrides:
+  gql.tada: workspace:*
+  '@gql.tada/internal': workspace:*
+  astro-expressive-code: ^0.31.0
+  typescript: ^5.5.2
+  '@0no-co/graphqlsp': ^1.12.9


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions to current action versions and install pnpm v11
- Move pnpm overrides into pnpm-workspace.yaml and approve required install build scripts for pnpm v11
- Split the release workflow so npm publishing runs in a separate `npm` environment-gated job with OIDC provenance
- Skip the gated publish job when all package versions are already published on npm
- Update release docs to mention the npm environment approval step

## Checks
- `git diff --check`
- YAML parse check for workflows and `pnpm-workspace.yaml`
- `node --check .github/scripts/has-unpublished-packages.mjs`
- `node .github/scripts/has-unpublished-packages.mjs`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@11.1.1 install --frozen-lockfile`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@11.1.1 run check`
- GitHub Actions CI: https://github.com/0no-co/gql.tada/actions/runs/25752852333