### PR TITLE
Prepare TypeScript latest and tsgo compatibility

### DIFF
--- a/.changeset/early-spoons-march.md
+++ b/.changeset/early-spoons-march.md
@@ -1,0 +1,9 @@
+---
+"gql.tada": patch
+"@gql.tada/cli-utils": patch
+"@gql.tada/internal": patch
+"@gql.tada/svelte-support": patch
+"@gql.tada/vue-support": patch
+---
+
+Prepare TypeScript compatibility checks for TS 6 latest and the native `tsgo` preview by modernizing tsconfig module resolution and widening TypeScript peer ranges through TS 8.

--- a/.github/workflows/typescript-compat.yml
+++ b/.github/workflows/typescript-compat.yml
@@ -1,0 +1,53 @@
+name: TypeScript Compatibility
+
+on:
+  pull_request:
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - tsconfig.json
+      - src/**
+      - packages/**
+      - examples/**
+      - .github/workflows/typescript-compat.yml
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  compatibility:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: TypeScript latest
+            script: check:ts-latest
+            experimental: false
+          - name: TypeScript native preview
+            script: check:tsgo
+            experimental: true
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Run compatibility check
+        run: pnpm run ${{ matrix.script }}

--- a/examples/example-pokemon-api/tsconfig.json
+++ b/examples/example-pokemon-api/tsconfig.json
@@ -11,7 +11,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "target": "es2016",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,

--- a/examples/example-pokemon-svelte/tsconfig.json
+++ b/examples/example-pokemon-svelte/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "target": "es2016",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,

--- a/examples/example-pokemon-vue/tsconfig.json
+++ b/examples/example-pokemon-vue/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "target": "es2016",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@gql.tada/internal": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "public": true,
   "keywords": [
@@ -75,7 +75,9 @@
     "prepublishOnly": "run-s clean build check test",
     "prepare": "node ./scripts/prepare.js",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "changeset publish",
+    "check:ts-latest": "pnpm --package=typescript@latest dlx tsc --noEmit",
+    "check:tsgo": "pnpm --package=@typescript/native-preview dlx tsgo --noEmit"
   },
   "repository": "https://github.com/0no-co/gql.tada",
   "bugs": {

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -71,7 +71,7 @@
     "@gql.tada/svelte-support": "workspace:*",
     "@gql.tada/vue-support": "workspace:*",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli-utils/src/ts/container.ts
+++ b/packages/cli-utils/src/ts/container.ts
@@ -8,8 +8,10 @@ import type { VirtualMap, SourceMappedFile, FileSpan } from './mapping';
 import type { SourcePosition } from './utils';
 import { spanToFilePosition } from './utils';
 
-function maybeBind<T extends Function>(that: object, fn: T | undefined): T {
-  return fn ? fn.bind(that) : fn;
+function maybeBind<T extends Function>(that: object, fn: T): T;
+function maybeBind(that: object, fn: undefined): undefined;
+function maybeBind<T extends Function>(that: object, fn: T | undefined): T | undefined {
+  return fn ? (fn.bind(that) as T) : undefined;
 }
 
 export interface PluginCreateInfo<Config extends {} = GraphQLSPConfig>

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/svelte-support/package.json
+++ b/packages/svelte-support/package.json
@@ -45,7 +45,7 @@
     "vscode-languageserver-textdocument": "^1.0.11"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vue-support/package.json
+++ b/packages/vue-support/package.json
@@ -44,7 +44,7 @@
     "@vue/language-core": "~2.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/src/__tests__/tsHarness/virtualHost.ts
+++ b/src/__tests__/tsHarness/virtualHost.ts
@@ -105,7 +105,9 @@ const _sourceFolderCache: Record<string, Files> = {};
 const _fileCache: Record<string, FileData> = {};
 
 export function readFileFromRoot(name: string): FileData {
-  return _fileCache[name] || (_fileCache[name] = fs.readFileSync(path.join(virtualRoot, name)));
+  return (
+    _fileCache[name] || (_fileCache[name] = fs.readFileSync(path.join(virtualRoot, name), 'utf8'))
+  );
 }
 
 export function readVirtualModule(moduleName: string): Files {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": ".",
     "paths": {
-      "@gql.tada/*": ["node_modules/@gql.tada/*/src", "packages/*/src"]
+      "@gql.tada/*": ["./node_modules/@gql.tada/*/src", "./packages/*/src"]
     },
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "remove",
     "noEmit": true,
     "esModuleInterop": true,
     "noUnusedLocals": true,
@@ -15,7 +13,7 @@
     "jsx": "react-jsx",
     "declaration": false,
     "module": "es2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "target": "esnext",
     "strict": true,


### PR DESCRIPTION
## Summary

- modernize repo/example tsconfigs for TS 7/tsgo by removing `baseUrl`, removing `importsNotUsedAsValues`, and switching to `moduleResolution: "bundler"`
- add `check:ts-latest` and `check:tsgo` scripts plus a scheduled compatibility workflow
- widen TypeScript peer ranges through TS 8 and fix the stricter TS latest/tsgo type errors found during verification

## Verification

- `pnpm run lint`
- `pnpm run check`
- `pnpm run check:ts-latest` (`typescript@latest` -> 6.0.3)
- `pnpm run check:tsgo` (`@typescript/native-preview` -> 7.0.0-dev.20260512.1)
- `pnpm run build`
- `CI=1 pnpm exec vitest run --reporter=dot --sequence.concurrent=false`

## Notes

`tsgo`'s upstream API/plugin support is still marked not ready/in progress, so this PR focuses on compiler compatibility and adds an experimental non-blocking workflow lane to track native-preview regressions as it evolves.
