### PR TITLE
ci: use staged npm publishing

### DIFF
--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const root = process.cwd();
+const config = JSON.parse(readFileSync(join(root, ".changeset/config.json"), "utf8"));
+const ignored = new Set(config.ignore || []);
+const access = config.access || "public";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function packageJsonPathsFromWorkspace() {
+  const paths = [];
+
+  function visit(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (
+        entry.name === ".git" ||
+        entry.name === "node_modules" ||
+        entry.name === ".pnpm" ||
+        entry.name === "dist" ||
+        entry.name === "coverage"
+      ) {
+        continue;
+      }
+
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        paths.push(path);
+      }
+    }
+  }
+
+  visit(root);
+  return paths;
+}
+
+function packageJsonPaths() {
+  return [...new Set(packageJsonPathsFromWorkspace())].filter(existsSync);
+}
+
+function versionExists(name, version) {
+  const result = spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status === 0) return true;
+  const output = `${result.stdout}
+${result.stderr}`;
+  if (output.includes("E404") || output.includes("No match found")) return false;
+
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  throw new Error(`Could not check npm version for ${name}@${version}`);
+}
+
+function distTag(version) {
+  const prerelease = version.match(/^[^-]+-([0-9A-Za-z-]+)/);
+  return prerelease ? prerelease[1] : "latest";
+}
+
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+}
+
+function hasLocalGitTag(tagName) {
+  const result = spawnSync(
+    "git",
+    ["rev-parse", "--verify", "--quiet", `refs/tags/${tagName}`],
+    {
+      cwd: root,
+      stdio: "ignore",
+    }
+  );
+  return result.status === 0;
+}
+
+function createGitTag(tagName) {
+  if (hasLocalGitTag(tagName)) {
+    console.log(`Git tag ${tagName} already exists locally.`);
+  } else {
+    runGit(["tag", tagName, "-m", tagName]);
+  }
+
+  // changesets/action parses this line, then pushes the tag and creates the GitHub release.
+  console.log(`New tag: ${tagName}`);
+}
+
+const staged = [];
+for (const packageJsonPath of packageJsonPaths()) {
+  const pkg = readJson(packageJsonPath);
+  if (!pkg.name || !pkg.version || pkg.private || ignored.has(pkg.name)) continue;
+  if (versionExists(pkg.name, pkg.version)) {
+    console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
+    continue;
+  }
+
+  const packageDir = dirname(packageJsonPath);
+  const tag = distTag(pkg.version);
+  const args = [
+    "stage",
+    "publish",
+    packageDir,
+    "--provenance",
+    "--access",
+    pkg.publishConfig?.access || access,
+    "--tag",
+    tag,
+    "--json",
+  ];
+
+  console.log(`Staging ${pkg.name}@${pkg.version} with dist-tag ${tag}...`);
+  const result = spawnSync("pnpm", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+
+  const stageId = result.stdout.match(/"stageId"\s*:\s*"([^"]+)"/)?.[1];
+  const tagName = `${pkg.name}@${pkg.version}`;
+  createGitTag(tagName);
+
+  staged.push({
+    name: pkg.name,
+    version: pkg.version,
+    path: relative(root, packageDir) || ".",
+    stageId,
+  });
+}
+
+if (staged.length === 0) {
+  console.log("No unpublished packages to stage.");
+} else {
+  console.log("Staged packages:");
+  for (const pkg of staged) {
+    console.log(`- ${pkg.name}@${pkg.version}${pkg.stageId ? ` (${pkg.stageId})` : ""}`);
+  }
+  console.log("Approve staged packages with `npm stage approve <stage-id>` after review.");
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,18 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           package-manager-cache: false
           node-version: 22
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@v1.8.0
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm changeset:version
         env:
@@ -65,18 +65,18 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           package-manager-cache: false
           node-version: 22
@@ -90,7 +90,7 @@ jobs:
 
       - name: Publish packages
         id: changesets
-        uses: changesets/action@v1.8.0
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: pnpm changeset:publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
-          version: 11
+          version: 11.3.0
           run_install: false
 
       - name: Setup Node
@@ -72,7 +72,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
-          version: 11
+          version: 11.3.0
           run_install: false
 
       - name: Setup Node
@@ -83,7 +83,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@11.14.1
+        run: npm install -g npm@11.15.0
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -92,7 +92,8 @@ jobs:
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          publish: pnpm changeset:publish
+          publish: node .github/scripts/stage-packages.mjs
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
@@ -77,6 +78,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- Switches the trusted npm publish path to `pnpm stage publish`.
- Uses pnpm 11.3.0 and npm 11.15.0 in the publish workflow.
- Preserves Changesets tag/GitHub release creation by emitting package tags from the staging helper.

## Verification
- `node --check .github/scripts/stage-packages.mjs`
- Workflow YAML parsed locally.