### PR TITLE
Isolate monorepo packages

### DIFF
--- a/.changeset/fix-monorepo-tsconfig-scan.md
+++ b/.changeset/fix-monorepo-tsconfig-scan.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix `programFactory` scanning the entire monorepo when the `@0no-co/graphqlsp` plugin is declared in a shared root tsconfig that individual projects extend.

--- a/packages/cli-utils/src/ts/__tests__/factory.test.ts
+++ b/packages/cli-utils/src/ts/__tests__/factory.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { programFactory } from '../factory';
+
+describe('programFactory', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('resolveConfig', () => {
+    it('scopes file discovery to the project when configPath is a parent tsconfig', () => {
+      // Reproduce the monorepo scenario: the gql.tada plugin is declared in a shared
+      // tsconfig.base.json at the workspace root (so loadConfig returns configPath =
+      // workspace root), but the actual project has its own tsconfig.json with a
+      // narrowed `include`. Without the fix, TypeScript resolves `baseUrl` against the
+      // workspace root and scans the entire monorepo.
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gql-tada-factory-'));
+
+      // Workspace root: shared tsconfig with no include (would scan everything)
+      const workspaceDir = path.join(tmpDir, 'workspace');
+      fs.mkdirSync(workspaceDir);
+      fs.writeFileSync(
+        path.join(workspaceDir, 'tsconfig.base.json'),
+        JSON.stringify({ compilerOptions: { strict: true } })
+      );
+
+      // A stray .ts file at workspace root that must NOT end up in the program
+      fs.writeFileSync(path.join(workspaceDir, 'stray.ts'), 'export const x = 1;\n');
+
+      // Project with its own tsconfig scoped to src/
+      const projectDir = path.join(workspaceDir, 'packages', 'project');
+      const srcDir = path.join(projectDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, 'tsconfig.json'),
+        JSON.stringify({ extends: '../../tsconfig.base.json', include: ['src'] })
+      );
+      fs.writeFileSync(path.join(srcDir, 'index.ts'), 'export const value = 42;\n');
+
+      // configPath = parent tsconfig (where plugin was found via `extends`)
+      // rootPath  = the project directory (where `gql-tada check` was invoked)
+      const factory = programFactory({
+        configPath: path.join(workspaceDir, 'tsconfig.base.json'),
+        rootPath: projectDir,
+      });
+
+      // Every scanned directory must be inside the project — the workspace root must
+      // not appear, which it would if the parent tsconfig's baseUrl drove the scan.
+      const dirs = factory.projectDirectories;
+      expect(dirs.every((d) => d.startsWith(projectDir))).toBe(true);
+    });
+  });
+});

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -272,15 +272,31 @@ const resolveDefaultLibsPath = (params: ProgramFactoryParams): string => {
 };
 
 const resolveConfig = (params: ProgramFactoryParams, system: ts.System): ts.ParsedCommandLine => {
-  const text = system.readFile(params.configPath, 'utf8') || '{}';
-  const parseResult = ts.parseConfigFileTextToJson(params.configPath, text);
+  let configFile = params.configPath;
+  const basePath = params.rootPath || path.dirname(params.configPath);
+
+  // When the plugin config is found in a parent tsconfig (via `extends`), `loadConfig` returns
+  // configPath pointing to the parent (e.g. tsconfig.base.json at workspace root) while rootPath
+  // is the project directory. Parsing the parent config uses its directory as context, causing
+  // TypeScript to resolve `baseUrl: "."` against the workspace root and scan the entire monorepo.
+  // Fix: when configPath is in a different directory than rootPath, use the project's own
+  // tsconfig.json instead, which carries the correct `include` list and relative `baseUrl`.
+  // We use ts.sys (real TS sys) because the VFS blocks all tsconfig.json fileExists lookups.
+  if (params.rootPath && path.dirname(params.configPath) !== params.rootPath) {
+    const projectTsconfig = path.join(params.rootPath, 'tsconfig.json');
+    if (ts.sys.fileExists(projectTsconfig)) {
+      configFile = projectTsconfig;
+    }
+  }
+
+  const text = system.readFile(configFile, 'utf8') || '{}';
+  const parseResult = ts.parseConfigFileTextToJson(configFile, text);
   if (parseResult.error != null) throw new Error(parseResult.error.messageText.toString());
-  const projectRoot = path.dirname(params.configPath);
   return ts.parseJsonConfigFileContent(
     parseResult.config,
     system,
-    projectRoot,
+    basePath,
     ts.getDefaultCompilerOptions(),
-    params.configPath
+    configFile
   );
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,26 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, type Plugin } from 'vitest/config';
+
+// @gql.tada/svelte-support and @gql.tada/vue-support are optional peer
+// dependencies of @gql.tada/cli-utils. They are not installed in a source
+// checkout (no dist/, not symlinked). Any test that loads a module chain
+// ending at these packages needs them to be resolvable, even if the actual
+// lazy-import code path is never executed. This plugin creates lightweight
+// virtual stubs so Vite never hits the "Failed to resolve entry" error.
+function stubOptionalPeerPlugin(): Plugin {
+  const stubs = new Set(['@gql.tada/svelte-support', '@gql.tada/vue-support']);
+  return {
+    name: 'vitest:stub-optional-peers',
+    resolveId(id) {
+      if (stubs.has(id)) return '\0stub:' + id;
+    },
+    load(id) {
+      if (id.startsWith('\0stub:')) return 'export default {}';
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [stubOptionalPeerPlugin()],
   test: {
     benchmark: {},
     typecheck: {


### PR DESCRIPTION
## Summary

Fixes a performance regression in monorepo setups where `gql-tada check` scans the entire workspace instead of just the target project.

**Root cause:** When the `@0no-co/graphqlsp` plugin is declared in a shared root tsconfig (e.g. tsconfig.base.json) and individual projects extend it, `loadConfig` returns `configPath` pointing to the root tsconfig while `rootPath` is the project directory. `resolveConfig` was parsing the root config unconditionally, so TypeScript resolved `baseUrl: "."` against the workspace root — causing `programFactory` to walk every `.ts` file in the entire monorepo on every `check` invocation.

**Fix:** In `resolveConfig`, when `configPath` lives in a different directory than `rootPath`, look for a `tsconfig.json` directly in `rootPath` and use that instead. The project's own tsconfig carries the correct `include` list and relative paths, scoping the TypeScript program to just the project. 

## Set of changes

- `resolveConfig`: detect when `configPath` (parent tsconfig) is in a different directory from `rootPath` (project dir) and fall back to the project's own `tsconfig.json` when one exists
- test that creates a tmp monorepo with a shared tsconfig.base.json at the root and a project with its own scoped `tsconfig.json`, asserts that `programFactory.projectDirectories` contains only paths inside the project

## AI Disclosure

Claude may have been involved :) Especially in digging through and identifying the root cause of the slowdown.