### PR TITLE
Update vue-support to support language-core 3.x

### DIFF
--- a/.changeset/calm-tigers-jog.md
+++ b/.changeset/calm-tigers-jog.md
@@ -1,7 +1,5 @@
 ---
 '@gql.tada/vue-support': patch
-'gql.tada': patch
-'@gql.tada/cli-utils': patch
 ---
 
 Support @vue/language-core version 3.0.0. This fixes compatibility issues with projects having a dependency on vue-tsc@3.x (through the transitive dependency of entities, which changed it's exports)

--- a/.changeset/calm-tigers-jog.md
+++ b/.changeset/calm-tigers-jog.md
@@ -1,0 +1,7 @@
+---
+'@gql.tada/vue-support': patch
+'gql.tada': patch
+'@gql.tada/cli-utils': patch
+---
+
+Support @vue/language-core version 3.0.0. This fixes compatibility issues with projects having a dependency on vue-tsc@3.x (through the transitive dependency of entities, which changed it's exports)

--- a/packages/vue-support/package.json
+++ b/packages/vue-support/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@vue/compiler-dom": "^3.4.23",
-    "@vue/language-core": "~2.0.0"
+    "@vue/language-core": "^2.0.0 || ^3.0.0"
   },
   "peerDependencies": {
     "typescript": "^5.0.0 || ^6.0.0"

--- a/packages/vue-support/src/index.ts
+++ b/packages/vue-support/src/index.ts
@@ -83,7 +83,10 @@ if ('createPlugins' in vue) {
   createPlugins = (vue as any).getDefaultVueLanguagePlugins;
 }
 
-const vueCompilerOptions = vue.resolveVueCompilerOptions({});
+const vueCompilerOptions =
+  'resolveVueCompilerOptions' in vue
+    ? vue.resolveVueCompilerOptions({})
+    : (vue as any).getDefaultCompilerOptions();
 
 let plugins: ReturnType<typeof vue.createPlugins> | undefined;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,7 +332,7 @@ importers:
         specifier: ^3.4.23
         version: 3.4.38
       '@vue/language-core':
-        specifier: ~2.0.0
+        specifier: ^2.0.0 || ^3.0.0
         version: 2.0.29(typescript@5.5.4)
       typescript:
         specifier: ^5.5.2
@@ -1137,55 +1137,46 @@ packages:
     resolution: {integrity: sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.0':
     resolution: {integrity: sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.21.0':
     resolution: {integrity: sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.21.0':
     resolution: {integrity: sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.0':
     resolution: {integrity: sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.0':
     resolution: {integrity: sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.21.0':
     resolution: {integrity: sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.21.0':
     resolution: {integrity: sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.21.0':
     resolution: {integrity: sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==}


### PR DESCRIPTION
## Summary

`@gql.tada/vue-support` declares `@vue/language-core: ~2.0.0`. The ~2.0.0 semver range allows only >=2.0.0 <2.1.0. 

Projects using `vue-tsc@3.x` have `@vue/language-core@3.x` at the root, so npm/yarn creates a nested install of `@vue/language-core@2.0.29` inside `node_modules/@gql.tada/vue-support/node_modules/`. 
That nested version brings in `@vue/compiler-core@3.5.24`, which depends on entities@^4.5.0. 
But `@vue/compiler-core` recently has updated the version of entities to 7.0.1, which restructured its exports and dropped ./lib/decode.js. 

This leads to `gql.tada turbo` to fail with this error:
```
 ⚠ System Error 
Could not build cache
┗ For Vue support the `@gql.tada/vue-support` package must be installed.
  Install the package and try again.
```

## Set of changes

- Allow `@vue/language-core": "^2.0.0 || ^3.0.0"` (so also 3.x)
- Change how compiler options are resolved to work with both language-core 2.x and 3.x (later versions of 2.x also exported a `getDefaultCompilerOptions`, but earlier ones did not)
