### PR TITLE
ci: remove review trigger from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  pull_request_review:
-    types: [submitted, edited]
-    branches: changeset-release/main
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- Removes the pull request review event from the CI workflow trigger

## Verification
- Confirmed `.github/workflows/ci.yml` no longer contains `pull_request_review`
- Ran a structural check for the expected `pull_request` trigger
