### PR TITLE
fix: surface turbo worker failures

### DIFF
--- a/.changeset/silent-workers-doubt.md
+++ b/.changeset/silent-workers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Surface worker thread errors and unexpected exits during turbo generation instead of allowing pending work to resolve silently.

--- a/packages/cli-utils/src/threads/__tests__/index.test.ts
+++ b/packages/cli-utils/src/threads/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MockWorker extends EventEmitter {
+  static instances: MockWorker[] = [];
+  messages: unknown[] = [];
+  refs = 0;
+  unrefs = 0;
+
+  constructor() {
+    super();
+    MockWorker.instances.push(this);
+  }
+
+  ref() {
+    this.refs++;
+  }
+
+  unref() {
+    this.unrefs++;
+  }
+
+  postMessage(message: unknown) {
+    this.messages.push(message);
+  }
+}
+
+vi.mock('node:worker_threads', () => ({
+  Worker: MockWorker,
+  isMainThread: true,
+  parentPort: null,
+  SHARE_ENV: Symbol('SHARE_ENV'),
+}));
+
+describe('threads expose', () => {
+  beforeEach(() => {
+    MockWorker.instances = [];
+  });
+
+  it('keeps the worker referenced while an iterator is active', async () => {
+    const { expose } = await import('../index');
+    const run = expose(async function* (): AsyncIterableIterator<never> {});
+    const iterator = run();
+
+    const next = iterator.next();
+    const worker = MockWorker.instances[0];
+
+    expect(worker.refs).toBe(1);
+
+    worker.emit('error', new Error('boom'));
+    await expect(next).rejects.toThrow('boom');
+    expect(worker.unrefs).toBe(2);
+  });
+
+  it('rejects pending pulls when a worker exits before posting a terminal message', async () => {
+    const { expose } = await import('../index');
+    const run = expose(async function* (): AsyncIterableIterator<never> {});
+    const iterator = run();
+
+    const next = iterator.next();
+    MockWorker.instances[0].emit('exit', 1);
+
+    await expect(next).rejects.toThrow(/Worker stopped unexpectedly with exit code 1/);
+  });
+
+  it('rejects pending pulls with the original worker error', async () => {
+    const { expose } = await import('../index');
+    const run = expose(async function* (): AsyncIterableIterator<never> {});
+    const iterator = run();
+    const error = new Error(
+      'Worker terminated due to reaching memory limit: JS heap out of memory'
+    );
+
+    const next = iterator.next();
+    MockWorker.instances[0].emit('error', error);
+
+    await expect(next).rejects.toThrow(/out of memory/i);
+  });
+});

--- a/packages/cli-utils/src/threads/index.ts
+++ b/packages/cli-utils/src/threads/index.ts
@@ -73,7 +73,8 @@ export interface Generator<Args extends readonly any[], Next> {
 }
 
 function main<Args extends readonly any[], Next>(url: string | URL): Generator<Args, Next> {
-  let worker: Worker;
+  let worker: Worker | undefined;
+  let activeCalls = 0;
   let ids = 0;
   return (...args: Args) => {
     if (!worker) {
@@ -81,6 +82,7 @@ function main<Args extends readonly any[], Next>(url: string | URL): Generator<A
       worker.unref();
     }
 
+    const currentWorker = worker;
     const id = ++ids | 0;
     const buffer: ThreadMessage[] = [];
 
@@ -91,25 +93,43 @@ function main<Args extends readonly any[], Next>(url: string | URL): Generator<A
     let reject: ((error: any) => void) | void;
 
     function cleanup() {
+      if (ended) return;
       ended = true;
       resolve = undefined;
       reject = undefined;
-      worker.removeListener('message', receiveMessage);
-      worker.removeListener('error', receiveError);
+      currentWorker.removeListener('message', receiveMessage);
+      currentWorker.removeListener('error', receiveError);
+      currentWorker.removeListener('exit', receiveExit);
+      if (--activeCalls === 0) currentWorker.unref();
     }
 
     function sendMessage(kind: MainMessageCodes) {
-      worker.postMessage({ id, kind });
+      currentWorker.postMessage({ id, kind });
+    }
+
+    function fail(error: any) {
+      const pendingReject = reject;
+      cleanup();
+      if (pendingReject) {
+        pendingReject(error);
+      } else {
+        buffer.length = 1;
+        buffer[0] = {
+          id,
+          kind: ThreadMessageCodes.Throw,
+          data: error,
+        };
+      }
     }
 
     function receiveError(error: any) {
-      cleanup();
-      buffer.length = 1;
-      buffer[0] = {
-        id,
-        kind: ThreadMessageCodes.Throw,
-        data: error,
-      };
+      fail(error);
+    }
+
+    function receiveExit(code: number) {
+      if (ended) return;
+      if (worker === currentWorker) worker = undefined;
+      fail(new Error(`Worker stopped unexpectedly with exit code ${code}`));
     }
 
     function receiveMessage(data: unknown) {
@@ -142,9 +162,11 @@ function main<Args extends readonly any[], Next>(url: string | URL): Generator<A
       async next() {
         if (!started) {
           started = true;
-          worker.addListener('message', receiveMessage);
-          worker.addListener('error', receiveError);
-          worker.postMessage({
+          if (activeCalls++ === 0) currentWorker.ref();
+          currentWorker.addListener('message', receiveMessage);
+          currentWorker.addListener('error', receiveError);
+          currentWorker.addListener('exit', receiveExit);
+          currentWorker.postMessage({
             id,
             kind: MainMessageCodes.Start,
             data: args,


### PR DESCRIPTION
## Summary
- keep turbo worker threads referenced while work is active
- reject pending turbo pulls on worker errors and unexpected exits
- add regression coverage for worker lifecycle/error propagation

Closes #503
