### PR TITLE
fix(cli-internals): Prevent OOM on `turbo` run by batching

### DIFF
--- a/.changeset/good-moons-double.md
+++ b/.changeset/good-moons-double.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Prevent OOM on `turbo` run of TypeScript evaluations, by reinstantiating the type checker and program when the heap is close to reaching a memory limit

--- a/.github/workflows/typescript-compat.yml
+++ b/.github/workflows/typescript-compat.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 11
           run_install: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "rollup-plugin-cjs-check": "^1.0.3",
     "rollup-plugin-dts": "^6.1.1",
     "terser": "^5.31.6",
-    "typescript": "^5.5.4",
+    "typescript": "^5.9.3",
     "vitest": "2.0.5"
   },
   "publishConfig": {

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -50,7 +50,7 @@
     "semiver": "^1.1.0",
     "typanion": "^3.14.0",
     "type-fest": "^4.10.2",
-    "typescript": "^5.5.2",
+    "typescript": "^5.9.3",
     "wonka": "^6.3.4"
   },
   "dependencies": {

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -1,10 +1,13 @@
 import ts from 'typescript';
+import v8 from 'node:v8';
+import vm from 'node:vm';
 import * as path from 'node:path';
 import type { GraphQLSPConfig } from '@gql.tada/internal';
 
 import { getSchemaNamesFromConfig } from '@gql.tada/internal';
 import { findAllCallExpressions } from '@0no-co/graphqlsp/api';
 
+import type { ProgramContainer, PluginCreateInfo } from '../../ts';
 import { programFactory } from '../../ts';
 import { expose } from '../../threads';
 
@@ -23,6 +26,9 @@ export interface TurboParams {
   pluginConfig: GraphQLSPConfig;
   turboOutputPath: string | TurboPath[];
 }
+
+const HEAP_SOFT_LIMIT_BYTES = 2_500 * 1_024 * 1_024;
+const TURBO_MAX_BATCH = 1_000;
 
 function traceCallToImportSource(
   callExpression: ts.CallExpression,
@@ -192,19 +198,25 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
     await factory.addVirtualFiles(externalFiles);
   }
 
-  const container = factory.build();
-  const pluginInfo = container.buildPluginInfo(params.pluginConfig);
-  const sourceFiles = container.getSourceFiles();
+  // Initially, we only build the program to count files
+  // Later, we may reinstantiate to free up memory between batches
+  let container = factory.build();
+  let pluginInfo = container.buildPluginInfo(params.pluginConfig);
+  const fileNames = container.getSourceFiles().map((sourceFile) => sourceFile.fileName);
 
   yield {
     kind: 'FILE_COUNT',
-    fileCount: sourceFiles.length,
+    fileCount: fileNames.length,
   };
 
-  const checker = container.program.getTypeChecker();
   const uniqueGraphQLSources = new Map<string, GraphQLSourceFile>();
 
-  for (const sourceFile of sourceFiles) {
+  const processSourceFile = (
+    sourceFile: ts.SourceFile,
+    container: ProgramContainer,
+    pluginInfo: PluginCreateInfo,
+    checker: ts.TypeChecker
+  ): { filePath: string; documents: TurboDocument[]; warnings: TurboWarning[] } => {
     let filePath = sourceFile.fileName;
     const documents: TurboDocument[] = [];
     const warnings: TurboWarning[] = [];
@@ -289,6 +301,39 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       });
     }
 
+    return { filePath, documents, warnings };
+  };
+
+  const isHeapOverSoftLimit = (): boolean => {
+    if (process.memoryUsage().heapUsed < HEAP_SOFT_LIMIT_BYTES) return false;
+    forceGc();
+    return process.memoryUsage().heapUsed >= HEAP_SOFT_LIMIT_BYTES;
+  };
+
+  let checker = container.program.getTypeChecker();
+  let filesInBatch = 0;
+
+  for (const fileName of fileNames) {
+    // When heap or batch limit is reached, rotate out the type checker
+    if (filesInBatch > 0 && (filesInBatch >= TURBO_MAX_BATCH || isHeapOverSoftLimit())) {
+      container = factory.build();
+      pluginInfo = container.buildPluginInfo(params.pluginConfig);
+      forceGc();
+      checker = container.program.getTypeChecker();
+      filesInBatch = 0;
+    }
+
+    const sourceFile = container.getSourceFile(fileName);
+    if (!sourceFile) continue;
+
+    const { filePath, documents, warnings } = processSourceFile(
+      sourceFile,
+      container,
+      pluginInfo,
+      checker
+    );
+    filesInBatch++;
+
     yield {
       kind: 'FILE_TURBO',
       filePath,
@@ -303,6 +348,27 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       sources: Array.from(uniqueGraphQLSources.values()),
     };
   }
+}
+
+let cachedGc: (() => void) | null | undefined;
+
+function forceGc(): void {
+  if (cachedGc === undefined) {
+    const existing = (globalThis as { gc?: () => void }).gc;
+    if (typeof existing === 'function') {
+      cachedGc = existing;
+    } else {
+      // NOTE: If gc isn't available, try to retrieve it via `node:vm`
+      try {
+        v8.setFlagsFromString('--expose-gc');
+        cachedGc = vm.runInNewContext('gc') as () => void;
+        v8.setFlagsFromString('--no-expose-gc');
+      } catch {
+        cachedGc = null;
+      }
+    }
+  }
+  if (cachedGc) cachedGc();
 }
 
 export const runTurbo = expose(_runTurbo);

--- a/packages/cli-utils/src/ts/container.ts
+++ b/packages/cli-utils/src/ts/container.ts
@@ -38,6 +38,7 @@ export interface ContainerParams {
   rootNames: readonly string[];
   options: ts.CompilerOptions;
   system: ts.System;
+  documentRegistry?: ts.DocumentRegistry;
 }
 
 export const buildContainer = (params: ContainerParams): ProgramContainer => {
@@ -64,6 +65,7 @@ export const buildContainer = (params: ContainerParams): ProgramContainer => {
       options: params.options,
       projectRoot: params.projectRoot,
       languageServiceHost: getLanguageServiceHost(),
+      documentRegistry: params.documentRegistry,
     }));
 
   const getProgram = () => {
@@ -218,9 +220,13 @@ const buildLanguageService = (params: {
   rootNames: readonly string[];
   projectRoot: string;
   options: ts.CompilerOptions;
+  documentRegistry?: ts.DocumentRegistry;
 }): ts.LanguageService => {
   const { virtualMap } = params;
-  const languageService = ts.createLanguageService(params.languageServiceHost);
+  const languageService = ts.createLanguageService(
+    params.languageServiceHost,
+    params.documentRegistry
+  );
   const getProgram = maybeBind(languageService, languageService.getProgram);
 
   /** Remap filename to generated file if it's a mapped file */

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -82,6 +82,7 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
   }
 
   const host = createVirtualCompilerHost(system, options, ts);
+  const documentRegistry = ts.createDocumentRegistry();
 
   const factory: ProgramFactory = {
     get projectPath() {
@@ -242,6 +243,7 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
         rootNames: [...rootNames],
         options,
         system,
+        documentRegistry,
       });
     },
   };

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -62,9 +62,10 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
   const config = resolveConfig(params);
 
   const rootNames = new Set(config.fileNames);
-  const options = {
+  const options: ts.CompilerOptions = {
     ...ts.getDefaultCompilerOptions(),
     getDefaultLibFilePath: ts.getDefaultLibFilePath(config.options),
+    noCheck: true,
     ...config.options,
   };
 

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -48,7 +48,7 @@
     "rollup": "^4.9.4",
     "sade": "^1.8.1",
     "type-fest": "^4.10.2",
-    "typescript": "^5.5.2"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   gql.tada: workspace:*
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
-  typescript: ^5.5.2
+  typescript: ^5.9.3
   '@0no-co/graphqlsp': ^1.12.9
 
 importers:
@@ -20,7 +20,7 @@ importers:
         version: 1.0.7(graphql@16.9.0)
       '@0no-co/graphqlsp':
         specifier: ^1.12.9
-        version: 1.12.13(graphql@16.9.0)(typescript@5.5.4)
+        version: 1.12.13(graphql@16.9.0)(typescript@5.9.3)
       '@gql.tada/cli-utils':
         specifier: workspace:*
         version: link:packages/cli-utils
@@ -66,10 +66,10 @@ importers:
         version: 22.4.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.1.0
-        version: 8.1.0(@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
+        version: 8.1.0(@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.1.0
-        version: 8.1.0(eslint@8.57.0)(typescript@5.5.4)
+        version: 8.1.0(eslint@8.57.0)(typescript@5.9.3)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -111,13 +111,13 @@ importers:
         version: 1.0.3(rollup@4.21.0)
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.1.1(rollup@4.21.0)(typescript@5.5.4)
+        version: 6.1.1(rollup@4.21.0)(typescript@5.9.3)
       terser:
         specifier: ^5.31.6
         version: 5.31.6
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: 2.0.5
         version: 2.0.5(@types/node@22.4.0)(terser@5.31.6)
@@ -142,7 +142,7 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.9
-        version: 1.12.13(graphql@16.9.0)(typescript@5.5.4)
+        version: 1.12.13(graphql@16.9.0)(typescript@5.9.3)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.3
@@ -153,8 +153,8 @@ importers:
         specifier: ^4.2.1
         version: 4.3.1(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
       vite:
         specifier: ^5.2.10
         version: 5.4.1(@types/node@22.4.0)(terser@5.31.6)
@@ -176,13 +176,13 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.9
-        version: 1.12.13(graphql@16.9.0)(typescript@5.5.4)
+        version: 1.12.13(graphql@16.9.0)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
         version: 3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
       vite:
         specifier: ^5.2.10
         version: 5.4.1(@types/node@22.4.0)(terser@5.31.6)
@@ -194,7 +194,7 @@ importers:
         version: 5.0.6(graphql@16.9.0)
       '@urql/vue':
         specifier: ^1.1.3
-        version: 1.4.1(@urql/core@5.0.6(graphql@16.9.0))(vue@3.4.38(typescript@5.5.4))
+        version: 1.4.1(@urql/core@5.0.6(graphql@16.9.0))(vue@3.4.38(typescript@5.9.3))
       gql.tada:
         specifier: workspace:*
         version: link:../..
@@ -203,29 +203,29 @@ importers:
         version: 16.9.0
       vue:
         specifier: ^3.4.25
-        version: 3.4.38(typescript@5.5.4)
+        version: 3.4.38(typescript@5.9.3)
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.9
-        version: 1.12.13(graphql@16.9.0)(typescript@5.5.4)
+        version: 1.12.13(graphql@16.9.0)(typescript@5.9.3)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.5.4))
+        version: 5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.9.3))
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
       vite:
         specifier: ^5.2.10
         version: 5.4.1(@types/node@22.4.0)(terser@5.31.6)
       vue-tsc:
         specifier: ^2.0.14
-        version: 2.0.29(typescript@5.5.4)
+        version: 2.0.29(typescript@5.9.3)
 
   packages/cli-utils:
     dependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.9
-        version: 1.12.13(graphql@16.9.0)(typescript@5.5.4)
+        version: 1.12.13(graphql@16.9.0)(typescript@5.9.3)
       '@gql.tada/internal':
         specifier: workspace:*
         version: link:../internal
@@ -270,8 +270,8 @@ importers:
         specifier: ^4.10.2
         version: 4.25.0
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
       wonka:
         specifier: ^6.3.4
         version: 6.3.4
@@ -304,8 +304,8 @@ importers:
         specifier: ^4.10.2
         version: 4.25.0
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/svelte-support:
     dependencies:
@@ -314,17 +314,17 @@ importers:
         version: 1.5.0
       svelte2tsx:
         specifier: ^0.7.6
-        version: 0.7.15(svelte@4.2.18)(typescript@5.5.4)
+        version: 0.7.15(svelte@4.2.18)(typescript@5.9.3)
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
       vscode-languageserver-textdocument:
         specifier: ^1.0.11
         version: 1.0.12
     devDependencies:
       '@vue/language-core':
         specifier: ~2.0.0
-        version: 2.0.29(typescript@5.5.4)
+        version: 2.0.29(typescript@5.9.3)
 
   packages/vue-support:
     dependencies:
@@ -333,10 +333,10 @@ importers:
         version: 3.4.38
       '@vue/language-core':
         specifier: ^2.0.0 || ^3.0.0
-        version: 2.0.29(typescript@5.5.4)
+        version: 2.0.29(typescript@5.9.3)
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.4
+        specifier: ^5.9.3
+        version: 5.9.3
 
   website:
     dependencies:
@@ -369,7 +369,7 @@ importers:
         version: 4.1.0(@urql/core@5.0.6(graphql@16.9.0))(react@18.3.1)
       vue:
         specifier: ^3.4.21
-        version: 3.4.38(typescript@5.5.4)
+        version: 3.4.38(typescript@5.9.3)
     devDependencies:
       '@shikijs/core':
         specifier: ^1.3.0
@@ -382,13 +382,13 @@ importers:
         version: 0.10.2
       shikiji-twoslash:
         specifier: ^0.10.2
-        version: 0.10.2(typescript@5.5.4)
+        version: 0.10.2(typescript@5.9.3)
       vitepress:
         specifier: 1.1.3
-        version: 1.1.3(@algolia/client-search@5.0.0)(@types/node@22.4.0)(@types/react@18.3.3)(postcss@8.4.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.16.3)(terser@5.31.6)(typescript@5.5.4)
+        version: 1.1.3(@algolia/client-search@5.0.0)(@types/node@22.4.0)(@types/react@18.3.3)(postcss@8.4.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.16.3)(terser@5.31.6)(typescript@5.9.3)
       vitepress-plugin-twoslash:
         specifier: ^0.10.2
-        version: 0.10.2(typescript@5.5.4)
+        version: 0.10.2(typescript@5.9.3)
 
 packages:
 
@@ -404,7 +404,7 @@ packages:
     resolution: {integrity: sha512-/C9yXft+mq+VdoniBgWvA+iK5X6cB50KKThg1je4bFIhhBNccLJlNbWFxOglXseKuisq+h5oIY4ELTVKs6GhRQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   '@0no-co/typescript.js@5.3.2-2':
     resolution: {integrity: sha512-IGQZZ7vcVD/GOUKLJckpQiq8F5raQZLR7kOVhxN5nHOywl1dB9EFMA7FJkyNoCEig7EkCb291X8FswMwwrz9yg==}
@@ -1137,46 +1137,55 @@ packages:
     resolution: {integrity: sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.0':
     resolution: {integrity: sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.21.0':
     resolution: {integrity: sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.21.0':
     resolution: {integrity: sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.0':
     resolution: {integrity: sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.0':
     resolution: {integrity: sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.21.0':
     resolution: {integrity: sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.21.0':
     resolution: {integrity: sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.21.0':
     resolution: {integrity: sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==}
@@ -1442,7 +1451,7 @@ packages:
   '@vue/language-core@1.8.27':
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1450,7 +1459,7 @@ packages:
   '@vue/language-core@2.0.29':
     resolution: {integrity: sha512-o2qz9JPjhdoVj8D2+9bDXbaI4q2uZTHQA/dbyZT4Bj1FR9viZxDJnLcKVHfxdn6wsOzRgpqIzJEEmSSvgMvDTQ==}
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2989,7 +2998,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   rollup@4.21.0:
     resolution: {integrity: sha512-vo+S/lfA2lMS7rZ2Qoubi6I5hwZwzXeUIctILZLbHI+laNtvhhOIon2S1JksA5UEDQ7l3vberd0fxK44lTYjbQ==}
@@ -3228,7 +3237,7 @@ packages:
     resolution: {integrity: sha512-91RbLJI448FR1UEZqXSS3ucVMERuWo8ACOhxfkBPK1CL2ocGMOC5bwc8tzFvb/Ji8NqZ7wmSGfvRebcUsiauKA==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
@@ -3290,7 +3299,7 @@ packages:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   ts-invariant@0.10.3:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
@@ -3306,12 +3315,12 @@ packages:
   twoslash-vue@0.1.2:
     resolution: {integrity: sha512-LCD3VTw0+gKVMXou/nP8OAtpajGAoKuzFx9oyGteBkeMRgDj2DO95WDBHy/o+ihkckYZ0lUbvIFFjzmDy7zHag==}
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   twoslash@0.1.2:
     resolution: {integrity: sha512-q0jnapnD3b0umNGCJCRlo6Em1oSFl2OBPwsXqhLzijtEzuORrGVrJffG7E1k1KPHFlwBSRX2q6yYA61etn5hSg==}
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
@@ -3343,8 +3352,8 @@ packages:
   typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3518,12 +3527,12 @@ packages:
     resolution: {integrity: sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
 
   vue@3.4.38:
     resolution: {integrity: sha512-f0ZgN+mZ5KFgVv9wz0f4OgVKukoXtS3nwET4c2vLBGQR50aI8G0cqbFtLlX9Yiyg3LFGBitruPHt2PxwTduJEw==}
     peerDependencies:
-      typescript: ^5.5.2
+      typescript: ^5.9.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3600,11 +3609,11 @@ snapshots:
     optionalDependencies:
       graphql: 16.9.0
 
-  '@0no-co/graphqlsp@1.12.13(graphql@16.9.0)(typescript@5.5.4)':
+  '@0no-co/graphqlsp@1.12.13(graphql@16.9.0)(typescript@5.9.3)':
     dependencies:
       '@gql.tada/internal': link:packages/internal
       graphql: 16.9.0
-      typescript: 5.5.4
+      typescript: 5.9.3
 
   '@0no-co/typescript.js@5.3.2-2': {}
 
@@ -4631,34 +4640,34 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.1.0
-      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.1.0
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.1.0
       '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.1.0
       debug: 4.3.6
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4667,21 +4676,21 @@ snapshots:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
 
-  '@typescript-eslint/type-utils@8.1.0(eslint@8.57.0)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.1.0(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.9.3)
       debug: 4.3.6
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - eslint
       - supports-color
 
   '@typescript-eslint/types@8.1.0': {}
 
-  '@typescript-eslint/typescript-estree@8.1.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.1.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
@@ -4690,18 +4699,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.1.0(eslint@8.57.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.1.0(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 8.1.0
       '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.9.3)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -4743,10 +4752,10 @@ snapshots:
       svelte: 4.2.18
       wonka: 6.3.4
 
-  '@urql/vue@1.4.1(@urql/core@5.0.6(graphql@16.9.0))(vue@3.4.38(typescript@5.5.4))':
+  '@urql/vue@1.4.1(@urql/core@5.0.6(graphql@16.9.0))(vue@3.4.38(typescript@5.9.3))':
     dependencies:
       '@urql/core': 5.0.6(graphql@16.9.0)
-      vue: 3.4.38(typescript@5.5.4)
+      vue: 3.4.38(typescript@5.9.3)
       wonka: 6.3.4
 
   '@vitejs/plugin-react@4.3.1(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))':
@@ -4760,10 +4769,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.9.3))':
     dependencies:
       vite: 5.4.1(@types/node@22.4.0)(terser@5.31.6)
-      vue: 3.4.38(typescript@5.5.4)
+      vue: 3.4.38(typescript@5.9.3)
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -4875,7 +4884,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@1.8.27(typescript@5.5.4)':
+  '@vue/language-core@1.8.27(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
@@ -4887,9 +4896,9 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
 
-  '@vue/language-core@2.0.29(typescript@5.5.4)':
+  '@vue/language-core@2.0.29(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.0
       '@vue/compiler-dom': 3.4.38
@@ -4900,7 +4909,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
 
   '@vue/reactivity@3.4.38':
     dependencies:
@@ -4918,29 +4927,29 @@ snapshots:
       '@vue/shared': 3.4.38
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.38(vue@3.4.38(typescript@5.5.4))':
+  '@vue/server-renderer@3.4.38(vue@3.4.38(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.4.38
       '@vue/shared': 3.4.38
-      vue: 3.4.38(typescript@5.5.4)
+      vue: 3.4.38(typescript@5.9.3)
 
   '@vue/shared@3.4.38': {}
 
-  '@vueuse/core@10.11.1(vue@3.4.38(typescript@5.5.4))':
+  '@vueuse/core@10.11.1(vue@3.4.38(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.4.38(typescript@5.5.4))
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.5.4))
+      '@vueuse/shared': 10.11.1(vue@3.4.38(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.4.38(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@10.11.1(focus-trap@7.5.4)(vue@3.4.38(typescript@5.5.4))':
+  '@vueuse/integrations@10.11.1(focus-trap@7.5.4)(vue@3.4.38(typescript@5.9.3))':
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.5.4))
-      '@vueuse/shared': 10.11.1(vue@3.4.38(typescript@5.5.4))
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.5.4))
+      '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.4.38(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.4.38(typescript@5.9.3))
     optionalDependencies:
       focus-trap: 7.5.4
     transitivePeerDependencies:
@@ -4949,9 +4958,9 @@ snapshots:
 
   '@vueuse/metadata@10.11.1': {}
 
-  '@vueuse/shared@10.11.1(vue@3.4.38(typescript@5.5.4))':
+  '@vueuse/shared@10.11.1(vue@3.4.38(typescript@5.9.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.5.4))
+      vue-demi: 0.14.10(vue@3.4.38(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -5553,11 +5562,11 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  floating-vue@5.2.2(vue@3.4.38(typescript@5.5.4)):
+  floating-vue@5.2.2(vue@3.4.38(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.1.1
-      vue: 3.4.38(typescript@5.5.4)
-      vue-resize: 2.0.0-alpha.1(vue@3.4.38(typescript@5.5.4))
+      vue: 3.4.38(typescript@5.9.3)
+      vue-resize: 2.0.0-alpha.1(vue@3.4.38(typescript@5.9.3))
 
   focus-trap@7.5.4:
     dependencies:
@@ -6591,11 +6600,11 @@ snapshots:
       cjs-module-lexer: 1.2.3
       rollup: 4.21.0
 
-  rollup-plugin-dts@6.1.1(rollup@4.21.0)(typescript@5.5.4):
+  rollup-plugin-dts@6.1.1(rollup@4.21.0)(typescript@5.9.3):
     dependencies:
       magic-string: 0.30.11
       rollup: 4.21.0
-      typescript: 5.5.4
+      typescript: 5.9.3
     optionalDependencies:
       '@babel/code-frame': 7.24.7
 
@@ -6698,10 +6707,10 @@ snapshots:
 
   shikiji-core@0.10.2: {}
 
-  shikiji-twoslash@0.10.2(typescript@5.5.4):
+  shikiji-twoslash@0.10.2(typescript@5.9.3):
     dependencies:
       shikiji-core: 0.10.2
-      twoslash: 0.1.2(typescript@5.5.4)
+      twoslash: 0.1.2(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6848,12 +6857,12 @@ snapshots:
     dependencies:
       svelte: 4.2.18
 
-  svelte2tsx@0.7.15(svelte@4.2.18)(typescript@5.5.4):
+  svelte2tsx@0.7.15(svelte@4.2.18)(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
       svelte: 4.2.18
-      typescript: 5.5.4
+      typescript: 5.9.3
 
   svelte@4.2.18:
     dependencies:
@@ -6910,9 +6919,9 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@1.3.0(typescript@5.5.4):
+  ts-api-utils@1.3.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
 
   ts-invariant@0.10.3:
     dependencies:
@@ -6922,18 +6931,18 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  twoslash-vue@0.1.2(typescript@5.5.4):
+  twoslash-vue@0.1.2(typescript@5.9.3):
     dependencies:
-      '@vue/language-core': 1.8.27(typescript@5.5.4)
-      twoslash: 0.1.2(typescript@5.5.4)
-      typescript: 5.5.4
+      '@vue/language-core': 1.8.27(typescript@5.9.3)
+      twoslash: 0.1.2(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  twoslash@0.1.2(typescript@5.5.4):
+  twoslash@0.1.2(typescript@5.9.3):
     dependencies:
       '@typescript/vfs': 1.5.0
-      typescript: 5.5.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6974,7 +6983,7 @@ snapshots:
       for-each: 0.3.3
       is-typed-array: 1.1.12
 
-  typescript@5.5.4: {}
+  typescript@5.9.3: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -7080,38 +7089,38 @@ snapshots:
     optionalDependencies:
       vite: 5.4.1(@types/node@22.4.0)(terser@5.31.6)
 
-  vitepress-plugin-twoslash@0.10.2(typescript@5.5.4):
+  vitepress-plugin-twoslash@0.10.2(typescript@5.9.3):
     dependencies:
-      floating-vue: 5.2.2(vue@3.4.38(typescript@5.5.4))
+      floating-vue: 5.2.2(vue@3.4.38(typescript@5.9.3))
       mdast-util-from-markdown: 2.0.0
       mdast-util-gfm: 3.0.0
       mdast-util-to-hast: 13.1.0
       shikiji: 0.10.2
-      shikiji-twoslash: 0.10.2(typescript@5.5.4)
-      twoslash-vue: 0.1.2(typescript@5.5.4)
-      vue: 3.4.38(typescript@5.5.4)
+      shikiji-twoslash: 0.10.2(typescript@5.9.3)
+      twoslash-vue: 0.1.2(typescript@5.9.3)
+      vue: 3.4.38(typescript@5.9.3)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
       - typescript
 
-  vitepress@1.1.3(@algolia/client-search@5.0.0)(@types/node@22.4.0)(@types/react@18.3.3)(postcss@8.4.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.16.3)(terser@5.31.6)(typescript@5.5.4):
+  vitepress@1.1.3(@algolia/client-search@5.0.0)(@types/node@22.4.0)(@types/react@18.3.3)(postcss@8.4.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.16.3)(terser@5.31.6)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.6.1
       '@docsearch/js': 3.6.1(@algolia/client-search@5.0.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.16.3)
       '@shikijs/core': 1.14.1
       '@shikijs/transformers': 1.14.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.5.4))
+      '@vitejs/plugin-vue': 5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.9.3))
       '@vue/devtools-api': 7.3.8
-      '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.5.4))
-      '@vueuse/integrations': 10.11.1(focus-trap@7.5.4)(vue@3.4.38(typescript@5.5.4))
+      '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.9.3))
+      '@vueuse/integrations': 10.11.1(focus-trap@7.5.4)(vue@3.4.38(typescript@5.9.3))
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.14.1
       vite: 5.4.1(@types/node@22.4.0)(terser@5.31.6)
-      vue: 3.4.38(typescript@5.5.4)
+      vue: 3.4.38(typescript@5.9.3)
     optionalDependencies:
       postcss: 8.4.41
     transitivePeerDependencies:
@@ -7179,35 +7188,35 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-demi@0.14.10(vue@3.4.38(typescript@5.5.4)):
+  vue-demi@0.14.10(vue@3.4.38(typescript@5.9.3)):
     dependencies:
-      vue: 3.4.38(typescript@5.5.4)
+      vue: 3.4.38(typescript@5.9.3)
 
-  vue-resize@2.0.0-alpha.1(vue@3.4.38(typescript@5.5.4)):
+  vue-resize@2.0.0-alpha.1(vue@3.4.38(typescript@5.9.3)):
     dependencies:
-      vue: 3.4.38(typescript@5.5.4)
+      vue: 3.4.38(typescript@5.9.3)
 
   vue-template-compiler@2.7.16:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-tsc@2.0.29(typescript@5.5.4):
+  vue-tsc@2.0.29(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.0
-      '@vue/language-core': 2.0.29(typescript@5.5.4)
+      '@vue/language-core': 2.0.29(typescript@5.9.3)
       semver: 7.6.3
-      typescript: 5.5.4
+      typescript: 5.9.3
 
-  vue@3.4.38(typescript@5.5.4):
+  vue@3.4.38(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.4.38
       '@vue/compiler-sfc': 3.4.38
       '@vue/runtime-dom': 3.4.38
-      '@vue/server-renderer': 3.4.38(vue@3.4.38(typescript@5.5.4))
+      '@vue/server-renderer': 3.4.38(vue@3.4.38(typescript@5.9.3))
       '@vue/shared': 3.4.38
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.9.3
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,5 +12,5 @@ overrides:
   gql.tada: workspace:*
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
-  typescript: ^5.5.2
+  typescript: ^5.9.3
   '@0no-co/graphqlsp': ^1.12.9

--- a/src/__tests__/tsHarness/virtualHost.ts
+++ b/src/__tests__/tsHarness/virtualHost.ts
@@ -41,7 +41,7 @@ export const compilerOptions: CompilerOptions = {
   disableSolutionSearching: true,
 };
 
-export type FileData = Uint8Array | string;
+export type FileData = Buffer | string;
 export type Files = Record<string, FileData>;
 
 class File {
@@ -197,7 +197,7 @@ export function createVirtualHost(files: Files) {
     const parts = split(name);
     let directory = root;
     for (let i = 0; i < parts.length - 1; i++) directory = directory.dir(parts[i]);
-    directory.set(parts[parts.length - 1], new File(name, data));
+    directory.set(parts[parts.length - 1], new File(name, data as any));
   }
 
   return {


### PR DESCRIPTION
Resolves #382
Related to #529 / #503

## Summary

The turbo runs are prone to running out of memory, since GraphQL parsing in the TypeScript program is expensive. Since symbols for type checking are always retained (and there's no way to evict them), this leads to an OOM error.

We can prevent this by manually keeping track of the heap, and clearing (recreating) the checker and program when we're close to hitting this limit.

Further, we can share a document registry to prevent reparsing. Since `noCheck` is active and we're only accessing the document nodes, this is relatively cheap and doesn't increase run time by much, typically, compared to increasing the memory limit and allowing a run to complete.

## Set of changes

- Upgrade to TypeScript@^5.9.3 (`noCheck` was added in 5.6)
- Enable `noCheck: true` by default
- Rebuild TS program/checker in batches when heap limit is close
- Share a `DocumentRegistry` between program rebuild
