### PR TITLE
fix: Reduce type instantiations in the tokenizer

### DIFF
--- a/.changeset/tame-lizards-beam.md
+++ b/.changeset/tame-lizards-beam.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Reduce type instantiations in tokenizer types

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -106,49 +106,65 @@ interface _state<In extends string, Out extends TokenNode[]> {
   in: In;
 }
 
-// NOTE: This tokenizer is wrapped with the `_state` interface to facilitate it becoming tail-recursive
-// prettier-ignore
+interface _punctuator {
+  '!': Token.Exclam;
+  '=': Token.Equal;
+  ':': Token.Colon;
+  '{': Token.BraceOpen;
+  '}': Token.BraceClose;
+  '(': Token.ParenOpen;
+  ')': Token.ParenClose;
+  '[': Token.BracketOpen;
+  ']': Token.BracketClose;
+}
+
 type tokenizeRec<State> =
   State extends _state<'', any>
     ? State['out']
     : State extends _state<infer In, infer Out>
-    ? tokenizeRec<
-        In extends `#${string}` ? _state<skipIgnored<In>, Out>
-          : In extends `${ignored}${string}` ? _state<skipIgnored<In>, Out>
-          : In extends `...${infer In}` ? _state<In, [...Out, Token.Spread]>
-          : In extends `!${infer In}` ? _state<In, [...Out, Token.Exclam]>
-          : In extends `=${infer In}` ? _state<In, [...Out, Token.Equal]>
-          : In extends `:${infer In}` ? _state<In, [...Out, Token.Colon]>
-          : In extends `{${infer In}` ? _state<In, [...Out, Token.BraceOpen]>
-          : In extends `}${infer In}` ? _state<In, [...Out, Token.BraceClose]>
-          : In extends `(${infer In}` ? _state<In, [...Out, Token.ParenOpen]>
-          : In extends `)${infer In}` ? _state<In, [...Out, Token.ParenClose]>
-          : In extends `[${infer In}` ? _state<In, [...Out, Token.BracketOpen]>
-          : In extends `]${infer In}` ? _state<In, [...Out, Token.BracketClose]>
-          : In extends `"""${infer In}` ? _state<skipBlockString<In>, [...Out, Token.BlockString]>
-          : In extends `"${infer In}` ? _state<skipString<In>, [...Out, Token.String]>
-          : In extends `-${digit}${infer In}` ?
-            (skipFloat<skipDigits<In>> extends `${infer In}`
-              ? _state<In, [...Out, Token.Float]>
-              : _state<skipDigits<In>, [...Out, Token.Integer]>)
-          : In extends `${digit}${infer In}` ?
-            (skipFloat<skipDigits<In>> extends `${infer In}`
-              ? _state<In, [...Out, Token.Float]>
-              : _state<skipDigits<In>, [...Out, Token.Integer]>)
-          : In extends `$${infer In}` ?
-            (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
-              ? _state<In, [...Out, VarTokenNode<Match>]>
-              : void)
-          : In extends `@${infer In}` ?
-            (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
-              ? _state<In, [...Out, DirectiveTokenNode<Match>]>
-              : void)
-          : In extends `${letter | '_'}${string}` ?
-            (takeNameLiteralRec<'', In> extends _match<infer Match, infer In>
-              ? _state<In, [...Out, NameTokenNode<Match>]>
-              : void)
-          : void
-      >
-    : [];
+      ? tokenizeRec<
+          In extends `#${string}`
+            ? _state<skipIgnored<In>, Out>
+            : In extends `${infer Char}${infer Rest}`
+              ? Char extends ignored
+                ? _state<skipIgnored<In>, Out>
+                : Char extends keyof _punctuator
+                  ? _state<Rest, [...Out, _punctuator[Char]]>
+                  : Char extends '"'
+                    ? In extends `"""${infer In}`
+                      ? _state<skipBlockString<In>, [...Out, Token.BlockString]>
+                      : In extends `"${infer In}`
+                        ? _state<skipString<In>, [...Out, Token.String]>
+                        : void
+                    : Char extends '.'
+                      ? In extends `...${infer In}`
+                        ? _state<In, [...Out, Token.Spread]>
+                        : void
+                      : Char extends '$'
+                        ? takeNameLiteralRec<'', Rest> extends _match<infer Match, infer In>
+                          ? _state<In, [...Out, VarTokenNode<Match>]>
+                          : void
+                        : Char extends '@'
+                          ? takeNameLiteralRec<'', Rest> extends _match<infer Match, infer In>
+                            ? _state<In, [...Out, DirectiveTokenNode<Match>]>
+                            : void
+                          : Char extends '-' | digit
+                            ? In extends `-${digit}${infer In}`
+                              ? skipFloat<skipDigits<In>> extends `${infer In}`
+                                ? _state<In, [...Out, Token.Float]>
+                                : _state<skipDigits<In>, [...Out, Token.Integer]>
+                              : In extends `${digit}${infer In}`
+                                ? skipFloat<skipDigits<In>> extends `${infer In}`
+                                  ? _state<In, [...Out, Token.Float]>
+                                  : _state<skipDigits<In>, [...Out, Token.Integer]>
+                                : void
+                            : Char extends letter | '_'
+                              ? takeNameLiteralRec<Char, Rest> extends _match<infer Match, infer In>
+                                ? _state<In, [...Out, NameTokenNode<Match>]>
+                                : void
+                              : void
+              : void
+        >
+      : [];
 
 export type tokenize<In extends string> = tokenizeRec<_state<In, []>>;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -34,13 +34,25 @@ type letter =
   | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
   | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
 
+// PERF(@kitten): unions cause excessive instantiations
+// Expanded literals are cheaper if an early case is more likely, and whitespaces then newlines are
 type skipIgnored<In> = In extends `#${infer _}\n${infer In}`
   ? skipIgnored<In>
   : In extends `#${infer _}`
     ? ''
-    : In extends `${ignored}${infer In}`
+    : In extends ` ${infer In}`
       ? skipIgnored<In>
-      : In;
+      : In extends `\n${infer In}`
+        ? skipIgnored<In>
+        : In extends `\t${infer In}`
+          ? skipIgnored<In>
+          : In extends `\r${infer In}`
+            ? skipIgnored<In>
+            : In extends `,${infer In}`
+              ? skipIgnored<In>
+              : In extends `\ufeff${infer In}`
+                ? skipIgnored<In>
+                : In;
 
 type skipDigits<In> = In extends `${digit}${infer In}` ? skipDigits<In> : In;
 


### PR DESCRIPTION
## Summary

After figuring out that the tokenizer makes up almost 80% of the type instantiations and memory usage of our types, I threw a few ideas at the wall to see what helps.

It turns out that replacing unions is a large lever in the tokenizer to reduce type instantiations, as the union force expansion and hence matching + instantiations. We can avoid this by inlining this with multiple checks. This is a trade-off, as the checks themselves may be causing instantiations on failed checks as well, and/or are slower. However, this is beneficial if some checks are more likely than others (whitespaces and newlines are)

Further, the punctuation match cases in the remaining tokenizer are very expensive. However, in that case, separating out a few likely/common checks into a simple 1:1 lookup helps reduce instantiations.

Both changes combined should reduce type instantiations in the tokenizer by ~20%.

## Set of changes

- Inline/replace union for ignored token checks
- Separate out early punctuation token checks
