### PR TITLE
fix(cli-utils): Prevent flicker on spinner updates

### DIFF
--- a/.changeset/sixty-phones-shop.md
+++ b/.changeset/sixty-phones-shop.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix spinner flicker in CLI commands

--- a/packages/cli-utils/src/commands/check/logger.ts
+++ b/packages/cli-utils/src/commands/check/logger.ts
@@ -1,4 +1,4 @@
-import { pipe, interval, map } from 'wonka';
+import { pipe, interval, map, concat, fromValue } from 'wonka';
 
 import * as path from 'node:path';
 import * as t from '../../term';
@@ -92,18 +92,21 @@ export function diagnosticMessageGithub(message: DiagnosticMessage): void {
 
 export function runningDiagnostics(file?: number, ofFiles?: number) {
   const progress = file ? (ofFiles ? `(${file}/${ofFiles})` : `(${file})`) : '';
-  return pipe(
-    interval(150),
-    map((state) => {
-      return t.text([
-        t.cmd(t.CSI.Style, t.Style.Magenta),
-        t.dotSpinner[state % t.dotSpinner.length],
-        ' ',
-        t.cmd(t.CSI.Style, t.Style.Foreground),
-        `Checking files${t.Chars.Ellipsis} `,
-        t.cmd(t.CSI.Style, t.Style.BrightBlack),
-        progress,
-      ]);
-    })
-  );
+  const frame = (state: number) =>
+    t.text([
+      t.cmd(t.CSI.Style, t.Style.Magenta),
+      t.dotSpinner[state % t.dotSpinner.length],
+      ' ',
+      t.cmd(t.CSI.Style, t.Style.Foreground),
+      `Checking files${t.Chars.Ellipsis} `,
+      t.cmd(t.CSI.Style, t.Style.BrightBlack),
+      progress,
+    ]);
+  return concat([
+    fromValue(frame(0)),
+    pipe(
+      interval(150),
+      map((state) => frame(state + 1))
+    ),
+  ]);
 }

--- a/packages/cli-utils/src/commands/doctor/logger.ts
+++ b/packages/cli-utils/src/commands/doctor/logger.ts
@@ -1,4 +1,4 @@
-import { pipe, interval, map } from 'wonka';
+import { pipe, interval, map, concat, fromValue } from 'wonka';
 
 import * as t from '../../term';
 import { indent } from '../shared/logger';
@@ -101,19 +101,22 @@ export function hintMessage(text: string) {
 }
 
 export function runningTask(description: string) {
-  return pipe(
-    interval(150),
-    map((state) => {
-      return t.text([
-        emptyLine(),
-        t.cmd(t.CSI.Style, t.Style.Magenta),
-        t.circleSpinner[state % t.circleSpinner.length],
-        ' ',
-        t.cmd(t.CSI.Style, t.Style.Foreground),
-        description.trim(),
-      ]);
-    })
-  );
+  const frame = (state: number) =>
+    t.text([
+      emptyLine(),
+      t.cmd(t.CSI.Style, t.Style.Magenta),
+      t.circleSpinner[state % t.circleSpinner.length],
+      ' ',
+      t.cmd(t.CSI.Style, t.Style.Foreground),
+      description.trim(),
+    ]);
+  return concat([
+    fromValue(frame(0)),
+    pipe(
+      interval(150),
+      map((state) => frame(state + 1))
+    ),
+  ]);
 }
 
 export function success() {

--- a/packages/cli-utils/src/commands/generate-persisted/logger.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/logger.ts
@@ -1,4 +1,4 @@
-import { pipe, interval, map } from 'wonka';
+import { pipe, interval, map, concat, fromValue } from 'wonka';
 
 import * as path from 'node:path';
 import * as t from '../../term';
@@ -98,18 +98,21 @@ export function warningGithub(message: PersistedWarning): void {
 
 export function runningPersisted(file?: number, ofFiles?: number) {
   const progress = file ? (ofFiles ? `(${file}/${ofFiles})` : `(${file})`) : '';
-  return pipe(
-    interval(150),
-    map((state) => {
-      return t.text([
-        t.cmd(t.CSI.Style, t.Style.Magenta),
-        t.dotSpinner[state % t.dotSpinner.length],
-        ' ',
-        t.cmd(t.CSI.Style, t.Style.Foreground),
-        `Scanning files${t.Chars.Ellipsis} `,
-        t.cmd(t.CSI.Style, t.Style.BrightBlack),
-        progress,
-      ]);
-    })
-  );
+  const frame = (state: number) =>
+    t.text([
+      t.cmd(t.CSI.Style, t.Style.Magenta),
+      t.dotSpinner[state % t.dotSpinner.length],
+      ' ',
+      t.cmd(t.CSI.Style, t.Style.Foreground),
+      `Scanning files${t.Chars.Ellipsis} `,
+      t.cmd(t.CSI.Style, t.Style.BrightBlack),
+      progress,
+    ]);
+  return concat([
+    fromValue(frame(0)),
+    pipe(
+      interval(150),
+      map((state) => frame(state + 1))
+    ),
+  ]);
 }

--- a/packages/cli-utils/src/commands/turbo/logger.ts
+++ b/packages/cli-utils/src/commands/turbo/logger.ts
@@ -1,4 +1,4 @@
-import { pipe, interval, map } from 'wonka';
+import { pipe, interval, map, concat, fromValue } from 'wonka';
 
 import * as path from 'node:path';
 import * as t from '../../term';
@@ -87,20 +87,23 @@ export function warningGithub(message: TurboWarning): void {
 
 export function runningTurbo(file?: number, ofFiles?: number) {
   const progress = file ? (ofFiles ? `(${file}/${ofFiles})` : `(${file})`) : '';
-  return pipe(
-    interval(150),
-    map((state) => {
-      return t.text([
-        t.cmd(t.CSI.Style, t.Style.Magenta),
-        t.dotSpinner[state % t.dotSpinner.length],
-        ' ',
-        t.cmd(t.CSI.Style, t.Style.Foreground),
-        `Scanning files${t.Chars.Ellipsis} `,
-        t.cmd(t.CSI.Style, t.Style.BrightBlack),
-        progress,
-      ]);
-    })
-  );
+  const frame = (state: number) =>
+    t.text([
+      t.cmd(t.CSI.Style, t.Style.Magenta),
+      t.dotSpinner[state % t.dotSpinner.length],
+      ' ',
+      t.cmd(t.CSI.Style, t.Style.Foreground),
+      `Scanning files${t.Chars.Ellipsis} `,
+      t.cmd(t.CSI.Style, t.Style.BrightBlack),
+      progress,
+    ]);
+  return concat([
+    fromValue(frame(0)),
+    pipe(
+      interval(150),
+      map((state) => frame(state + 1))
+    ),
+  ]);
 }
 
 export function hintMessage(message: string) {

--- a/packages/cli-utils/src/term/write.ts
+++ b/packages/cli-utils/src/term/write.ts
@@ -12,7 +12,10 @@ import {
   filter,
   share,
   scan,
-  map,
+  make,
+  onPush,
+  onEnd,
+  subscribe,
 } from 'wonka';
 
 import { cmd, CSI, EraseLine, Style } from './csi';
@@ -78,6 +81,25 @@ function clear(text: string) {
 
 type ComposeInput = undefined | string | CLIError | Source<string> | AsyncIterable<ComposeInput>;
 
+function commit(source: Source<string | CLIError>): Source<string | CLIError> {
+  return make((observer) => {
+    let last: string | CLIError | undefined;
+    const subscription = pipe(
+      source,
+      onPush((value) => {
+        last = value;
+        observer.next(value);
+      }),
+      onEnd(() => {
+        if (typeof last === 'string' && !last.endsWith('\n')) observer.next('');
+        observer.complete();
+      }),
+      subscribe(() => {})
+    );
+    return subscription.unsubscribe;
+  });
+}
+
 async function* convertError(outputs: AsyncIterable<ComposeInput>): AsyncIterable<ComposeInput> {
   try {
     yield* outputs;
@@ -117,14 +139,7 @@ function compose(outputs: AsyncIterable<ComposeInput>): Source<string | CLIError
         share
       );
       return pipe(
-        merge([
-          pipe(
-            output$,
-            takeLast(1),
-            map((output) => (typeof output === 'string' && !output.endsWith('\n') ? '' : output))
-          ),
-          output$,
-        ]),
+        commit(output$),
         scan((prev: CLIError | string, output) => {
           return typeof output === 'string'
             ? clear(typeof prev === 'string' ? prev : '') + output + reset


### PR DESCRIPTION
## Summary

The spinner currently flickers in and out while the progress in the `turbo` command updates.

## Set of changes

- Emit initial spinner state correctly
- Replace merge to flush synchronously on next update
