### PR TITLE
fix(cli-utils): Fix SIGTERM/SIGINT termination on commands

### DIFF
--- a/.changeset/nasty-paws-flash.md
+++ b/.changeset/nasty-paws-flash.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix SIGTERM/SIGINT being ignored

--- a/packages/cli-utils/src/commands/init/index.ts
+++ b/packages/cli-utils/src/commands/init/index.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 import { Command, Option } from 'clipanion';
-import { run } from './runner';
 
 export class InitCommand extends Command {
   static paths = [['init']];
@@ -8,6 +7,7 @@ export class InitCommand extends Command {
   input = Option.String({ name: 'dir' });
 
   async execute() {
+    const { run } = await import('./runner');
     const target = path.resolve(process.cwd(), this.input);
     await run(target);
   }

--- a/packages/cli-utils/src/commands/init/runner.ts
+++ b/packages/cli-utils/src/commands/init/runner.ts
@@ -6,12 +6,12 @@ import { execa } from 'execa';
 import { MINIMUM_VERSIONS, semverComply } from '../../utils/semver';
 import { readTSConfigFile } from '@gql.tada/internal';
 
-const s = spinner();
-
 const TADA_VERSION = '^1.4.3';
 const LSP_VERSION = '^1.8.0';
 
 export async function run(target: string) {
+  const s = spinner();
+
   intro(`GQL.Tada`);
 
   const schemaLocation = await question(

--- a/packages/cli-utils/src/term/tty.ts
+++ b/packages/cli-utils/src/term/tty.ts
@@ -58,12 +58,12 @@ function fromReadStream(stream: ReadStream): Source<KeypressEvent> {
         case 'c':
         case 'd':
         case 'x':
-          if (event.ctrl) cleanup();
+          if (event.ctrl) return cleanup();
+          break;
         case 'escape':
-          cleanup();
-        default:
-          observer.next({ ...event, data });
+          return cleanup();
       }
+      observer.next({ ...event, data });
     }
 
     function cleanup() {

--- a/packages/cli-utils/src/term/tty.ts
+++ b/packages/cli-utils/src/term/tty.ts
@@ -51,14 +51,14 @@ export interface TTY {
   modeOff(...modes: readonly (Mode | PrivateMode)[]): void;
 }
 
-function fromReadStream(stream: ReadStream): Source<KeypressEvent> {
+function fromReadStream(stream: ReadStream, onTerminate: () => void): Source<KeypressEvent> {
   return make((observer) => {
     function onKeypress(data: string | undefined, event: KeypressEvent) {
       switch (event.name) {
         case 'c':
         case 'd':
         case 'x':
-          if (event.ctrl) return cleanup();
+          if (event.ctrl) return onTerminate();
           break;
         case 'escape':
           return cleanup();
@@ -106,9 +106,13 @@ export function initTTY(params: TTYParams = {}): TTY {
     );
   }
 
-  function _signal(signal: NodeJS.Signals) {
+  function _terminate(code: number) {
     _restore();
-    process.exit(signal === 'SIGINT' ? 130 : 143);
+    process.exit(code);
+  }
+
+  function _signal(signal: NodeJS.Signals) {
+    _terminate(signal === 'SIGINT' ? 130 : 143);
   }
 
   function _start() {
@@ -130,7 +134,12 @@ export function initTTY(params: TTYParams = {}): TTY {
     }
   }
 
-  const inputSource = pipe(fromReadStream(process.stdin), onStart(_start), onEnd(_end), share);
+  const inputSource = pipe(
+    fromReadStream(process.stdin, () => _terminate(130)),
+    onStart(_start),
+    onEnd(_end),
+    share
+  );
 
   const cancelSource = pipe(
     concat([

--- a/packages/cli-utils/src/term/tty.ts
+++ b/packages/cli-utils/src/term/tty.ts
@@ -99,15 +99,31 @@ export function initTTY(params: TTYParams = {}): TTY {
   const hasColorEnv = 'FORCE_COLOR' in process.env || (!process.env.NO_COLOR && !process.env.CI);
   _setColor((isTTY && hasColorEnv) || hasColorArg || isGithubCI);
 
+  function _restore() {
+    if (process.stdin.isTTY) process.stdin.setRawMode(false);
+    output.write(
+      cmd(CSI.Reset) + cmd(CSI.ResetPrivateMode) + cmd(CSI.SetPrivateMode, PrivateMode.ShowCursor)
+    );
+  }
+
+  function _signal(signal: NodeJS.Signals) {
+    _restore();
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  }
+
   function _start() {
     _setColor((isTTY && hasColorEnv) || hasColorArg);
     if (isTTY) {
       output.write(cmd(CSI.UnsetPrivateMode, PrivateMode.ShowCursor));
+      process.on('SIGINT', _signal);
+      process.on('SIGTERM', _signal);
     }
   }
 
   function _end() {
     if (isTTY) {
+      process.removeListener('SIGINT', _signal);
+      process.removeListener('SIGTERM', _signal);
       output.write(
         cmd(CSI.Reset) + cmd(CSI.ResetPrivateMode) + cmd(CSI.SetPrivateMode, PrivateMode.ShowCursor)
       );


### PR DESCRIPTION
## Summary

Due to a few different problems ctrl-c (and other signals) didn't lead to commands like `turbo` terminating properly

## Set of changes

- Prevent clack `spinner` on `init` from leaving dangling handlers around for all commands
- Fix missing early return on explicit `ctrl-[key]` handlers
- Handle explicit signal in `tty.ts` and terminate explicitly
