### PR TITLE
perf(cli-utils): Implement hash-based change detection

### DIFF
--- a/.changeset/cold-rockets-design.md
+++ b/.changeset/cold-rockets-design.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': minor
+---
+
+Implement `turbo` change hashing and skip re-computing types of documents that haven't changed

--- a/packages/cli-utils/src/commands/turbo/__tests__/cache.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/cache.test.ts
@@ -1,0 +1,56 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { describe, it, expect } from 'vitest';
+
+import { readCachedTurboDocuments } from '../cache';
+
+describe('readCachedTurboDocuments', () => {
+  it('reads document hashes and cached document types', async () => {
+    const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'gql-tada-cache-'));
+    const cachePath = path.join(rootPath, 'graphql-cache.d.ts');
+
+    try {
+      await fs.writeFile(
+        cachePath,
+        [
+          '/* eslint-disable */',
+          "import type { TadaDocumentNode } from 'gql.tada';",
+          '',
+          "declare module 'gql.tada' {",
+          ' interface setupCache {',
+          '    /** @gql.tada/hash sha256:first */',
+          '    "query First { id }":',
+          '      TadaDocumentNode<{ id: string; }, {}, void>;',
+          '    /** @gql.tada/hash sha256:second */',
+          '    "fragment Second on Todo { id }":',
+          '      TadaDocumentNode<',
+          '        { id: string; },',
+          '        {},',
+          '        { fragment: "Second"; on: "Todo"; masked: true; }',
+          '      >;',
+          '  }',
+          '}',
+        ].join('\n')
+      );
+
+      const documents = readCachedTurboDocuments(cachePath);
+
+      expect(documents.get('"query First { id }"')).toEqual({
+        documentHash: 'sha256:first',
+        documentType: 'TadaDocumentNode<{ id: string; }, {}, void>',
+      });
+      expect(documents.get('"fragment Second on Todo { id }"')).toEqual({
+        documentHash: 'sha256:second',
+        documentType:
+          'TadaDocumentNode<\n' +
+          '        { id: string; },\n' +
+          '        {},\n' +
+          '        { fragment: "Second"; on: "Todo"; masked: true; }\n' +
+          '      >',
+      });
+    } finally {
+      await fs.rm(rootPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli-utils/src/commands/turbo/__tests__/hash.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/hash.test.ts
@@ -33,6 +33,27 @@ describe('createDocumentHasher', () => {
     expect(a.documentHash).not.toBe(b.documentHash);
   });
 
+  it('salts hashes by schema fingerprint', () => {
+    const before = createFixture(
+      `
+        declare const graphql: any;
+        export const query = graphql(\`query Todos { todos { id } }\`);
+      `,
+      new Map([[null, 'sha256:schema-a']])
+    );
+    const after = createFixture(
+      `
+        declare const graphql: any;
+        export const query = graphql(\`query Todos { todos { id } }\`);
+      `,
+      new Map([[null, 'sha256:schema-b']])
+    );
+
+    expect(before.hashes.query.hashable).toBe(true);
+    expect(after.hashes.query.hashable).toBe(true);
+    expect(before.hashes.query.documentHash).not.toBe(after.hashes.query.documentHash);
+  });
+
   it('does not hash dynamic fragment lists', () => {
     const fixture = createFixture(`
       declare const graphql: any;
@@ -44,7 +65,10 @@ describe('createDocumentHasher', () => {
   });
 });
 
-function createFixture(sourceText: string) {
+function createFixture(
+  sourceText: string,
+  schemaFingerprints: ReadonlyMap<string | null, string> = new Map()
+) {
   const fileName = '/fixture.ts';
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -73,7 +97,7 @@ function createFixture(sourceText: string) {
   const calls = getExportedCalls(sourceFile);
   const hasher = createDocumentHasher({
     checker,
-    pluginConfig: { schema: undefined } as any,
+    schemaFingerprints,
   });
   const hashes = Object.fromEntries(
     Object.entries(calls).map(([name, call]) => [name, hasher.hashCallExpression(call, null)])

--- a/packages/cli-utils/src/commands/turbo/__tests__/hash.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/hash.test.ts
@@ -1,0 +1,102 @@
+import ts from 'typescript';
+import { describe, it, expect } from 'vitest';
+
+import { createDocumentHasher } from '../hash';
+
+describe('createDocumentHasher', () => {
+  it('includes fragment dependency hashes in operation hashes', () => {
+    const first = createFixture(`
+      declare const graphql: any;
+      export const fragment = graphql(\`fragment Item on Todo { id }\`);
+      export const query = graphql(\`query Todos { todos { ...Item } }\`, [fragment]);
+    `);
+    const second = createFixture(`
+      declare const graphql: any;
+      export const fragment = graphql(\`fragment Item on Todo { id text }\`);
+      export const query = graphql(\`query Todos { todos { ...Item } }\`, [fragment]);
+    `);
+
+    expect(first.hashes.query.hashable).toBe(true);
+    expect(second.hashes.query.hashable).toBe(true);
+    expect(first.hashes.query.documentHash).not.toBe(second.hashes.query.documentHash);
+  });
+
+  it('salts hashes by schema name', () => {
+    const fixture = createFixture(`
+      declare const graphql: any;
+      export const query = graphql(\`query Todos { todos { id } }\`);
+    `);
+
+    const a = fixture.hasher.hashCallExpression(fixture.calls.query, 'a');
+    const b = fixture.hasher.hashCallExpression(fixture.calls.query, 'b');
+
+    expect(a.documentHash).not.toBe(b.documentHash);
+  });
+
+  it('does not hash dynamic fragment lists', () => {
+    const fixture = createFixture(`
+      declare const graphql: any;
+      declare const fragments: readonly any[];
+      export const query = graphql(\`query Todos { todos { id } }\`, fragments);
+    `);
+
+    expect(fixture.hashes.query).toEqual({ hashable: false });
+  });
+});
+
+function createFixture(sourceText: string) {
+  const fileName = '/fixture.ts';
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS
+  );
+  const host = ts.createCompilerHost({});
+  host.getSourceFile = (requestedFileName) =>
+    requestedFileName === fileName ? sourceFile : undefined;
+  host.fileExists = (requestedFileName) => requestedFileName === fileName;
+  host.readFile = (requestedFileName) => (requestedFileName === fileName ? sourceText : undefined);
+  host.writeFile = () => {};
+
+  const program = ts.createProgram({
+    rootNames: [fileName],
+    options: {
+      noLib: true,
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+    },
+    host,
+  });
+  const checker = program.getTypeChecker();
+  const calls = getExportedCalls(sourceFile);
+  const hasher = createDocumentHasher({
+    checker,
+    pluginConfig: { schema: undefined } as any,
+  });
+  const hashes = Object.fromEntries(
+    Object.entries(calls).map(([name, call]) => [name, hasher.hashCallExpression(call, null)])
+  );
+
+  return { calls, hashes, hasher };
+}
+
+function getExportedCalls(sourceFile: ts.SourceFile): Record<string, ts.CallExpression> {
+  const calls: Record<string, ts.CallExpression> = {};
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer)
+    ) {
+      calls[node.name.text] = node.initializer;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return calls;
+}

--- a/packages/cli-utils/src/commands/turbo/__tests__/thread.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/thread.test.ts
@@ -1,0 +1,32 @@
+import * as path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { shouldScanTurboFile } from '../scan';
+
+describe('shouldScanTurboFile', () => {
+  it('excludes generated cache, declarations, and node_modules files', () => {
+    const root = path.resolve('/project');
+    const turboOutputPath = path.join(root, 'src', 'graphql-cache.d.ts');
+    const turboOutputPaths = new Set([turboOutputPath]);
+
+    expect(shouldScanTurboFile(path.join(root, 'src', 'documents.ts'), turboOutputPaths)).toBe(
+      true
+    );
+    expect(shouldScanTurboFile(turboOutputPath, turboOutputPaths)).toBe(false);
+    expect(shouldScanTurboFile(path.join(root, 'src', 'graphql-env.d.ts'), turboOutputPaths)).toBe(
+      false
+    );
+    expect(shouldScanTurboFile(path.join(root, 'types', 'env.d.mts'), turboOutputPaths)).toBe(
+      false
+    );
+    expect(
+      shouldScanTurboFile(
+        path.join(root, 'node_modules', '@types', 'react', 'index.d.ts'),
+        turboOutputPaths
+      )
+    ).toBe(false);
+    expect(
+      shouldScanTurboFile(path.join(root, 'node_modules', 'pkg', 'index.ts'), turboOutputPaths)
+    ).toBe(false);
+  });
+});

--- a/packages/cli-utils/src/commands/turbo/cache.ts
+++ b/packages/cli-utils/src/commands/turbo/cache.ts
@@ -1,0 +1,65 @@
+import ts from 'typescript';
+import * as fs from 'node:fs';
+
+const HASH_COMMENT = /@gql\.tada\/hash\s+([^\s*]+)/;
+
+export interface CachedTurboDocument {
+  documentHash: string;
+  documentType: string;
+}
+
+export type CachedTurboDocuments = Map<string, CachedTurboDocument>;
+
+export function readCachedTurboDocuments(cachePath: string | undefined): CachedTurboDocuments {
+  const documents: CachedTurboDocuments = new Map();
+  if (!cachePath || !fs.existsSync(cachePath)) {
+    return documents;
+  }
+
+  let contents: string;
+  try {
+    contents = fs.readFileSync(cachePath, 'utf8');
+  } catch {
+    return documents;
+  }
+
+  const sourceFile = ts.createSourceFile(
+    cachePath,
+    contents,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS
+  );
+
+  const visit = (node: ts.Node) => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === 'setupCache') {
+      for (const member of node.members) {
+        if (!ts.isPropertySignature(member) || !member.type) continue;
+        if (!ts.isStringLiteral(member.name) && !ts.isNumericLiteral(member.name)) continue;
+
+        const documentHash = getHashComment(contents, member);
+        if (!documentHash) continue;
+
+        documents.set(JSON.stringify(member.name.text), {
+          documentHash,
+          documentType: member.type.getText(sourceFile),
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return documents;
+}
+
+function getHashComment(contents: string, node: ts.Node): string | undefined {
+  const comments = ts.getLeadingCommentRanges(contents, node.pos) || [];
+  for (let i = comments.length - 1; i >= 0; i--) {
+    const comment = contents.slice(comments[i].pos, comments[i].end);
+    const match = HASH_COMMENT.exec(comment);
+    if (match) return match[1];
+  }
+  return undefined;
+}

--- a/packages/cli-utils/src/commands/turbo/hash.ts
+++ b/packages/cli-utils/src/commands/turbo/hash.ts
@@ -1,0 +1,224 @@
+import ts from 'typescript';
+import * as crypto from 'node:crypto';
+import type { GraphQLSPConfig } from '@gql.tada/internal';
+
+// NOTE(@kitten): Change if document type input or output changes
+const CACHE_BUSTER = 'turbo-document-hash-v1';
+
+export interface DocumentHashResult {
+  hashable: boolean;
+  documentHash?: string;
+}
+
+export interface DocumentHasher {
+  hashCallExpression(
+    callExpression: ts.CallExpression,
+    schemaName: string | null
+  ): DocumentHashResult;
+}
+
+interface HashContext {
+  readonly checker: ts.TypeChecker;
+  pluginConfig: GraphQLSPConfig;
+}
+
+export function createDocumentHasher(context: HashContext): DocumentHasher {
+  const callExpressionCache = new WeakMap<ts.CallExpression, Map<string, DocumentHashResult>>();
+  const symbolCallCache = new Map<ts.Symbol, ts.CallExpression | null>();
+  const activeCalls = new WeakSet<ts.CallExpression>();
+
+  let _pluginConfigKey: string | null;
+  const computePluginConfigKey = () => {
+    if (_pluginConfigKey == null) {
+      _pluginConfigKey = stableStringify(context.pluginConfig);
+    }
+    return _pluginConfigKey;
+  };
+
+  const hashCallExpression = (
+    callExpression: ts.CallExpression,
+    schemaName: string | null
+  ): DocumentHashResult => {
+    const schemaKey = schemaName || '';
+    const cached = callExpressionCache.get(callExpression)?.get(schemaKey);
+    if (cached) {
+      return cached;
+    } else if (activeCalls.has(callExpression)) {
+      return { hashable: false };
+    }
+
+    activeCalls.add(callExpression);
+    const result = computeCallExpressionHash(callExpression, schemaName);
+    activeCalls.delete(callExpression);
+
+    let schemaCache = callExpressionCache.get(callExpression);
+    if (!schemaCache) {
+      schemaCache = new Map();
+      callExpressionCache.set(callExpression, schemaCache);
+    }
+
+    schemaCache.set(schemaKey, result);
+    return result;
+  };
+
+  const computeCallExpressionHash = (
+    callExpression: ts.CallExpression,
+    schemaName: string | null
+  ): DocumentHashResult => {
+    const documentText = getStaticStringValue(callExpression.arguments[0]);
+    if (documentText == null) {
+      return { hashable: false };
+    }
+
+    const fragmentHashes = getFragmentHashes(callExpression.arguments[1], schemaName);
+    if (!fragmentHashes) {
+      return { hashable: false };
+    }
+
+    const hash = crypto.createHash('sha256');
+
+    addHashPart(hash, CACHE_BUSTER);
+    addHashPart(hash, schemaName || '');
+    addHashPart(hash, computePluginConfigKey());
+    addHashPart(hash, documentText);
+    for (const fragmentHash of fragmentHashes) {
+      addHashPart(hash, fragmentHash);
+    }
+
+    return {
+      hashable: true,
+      documentHash: `sha256:${hash.digest('hex').slice(0, 32)}`,
+    };
+  };
+
+  const getFragmentHashes = (
+    fragmentsExpression: ts.Expression | undefined,
+    schemaName: string | null
+  ): string[] | null => {
+    if (!fragmentsExpression) return [];
+
+    fragmentsExpression = unwrapExpression(fragmentsExpression);
+
+    if (ts.isArrayLiteralExpression(fragmentsExpression)) {
+      const hashes: string[] = [];
+      for (const element of fragmentsExpression.elements) {
+        if (ts.isSpreadElement(element)) {
+          const spreadHashes = getFragmentHashes(element.expression, schemaName);
+          if (!spreadHashes) return null;
+          hashes.push(...spreadHashes);
+          continue;
+        }
+
+        const documentCall = resolveDocumentCallExpression(element);
+        if (!documentCall) return null;
+
+        const fragmentHash = hashCallExpression(documentCall, schemaName);
+        if (!fragmentHash.hashable || !fragmentHash.documentHash) return null;
+        hashes.push(fragmentHash.documentHash);
+      }
+      return hashes;
+    }
+
+    const declarationExpression = resolveDeclarationInitializer(fragmentsExpression);
+    if (declarationExpression && declarationExpression !== fragmentsExpression) {
+      return getFragmentHashes(declarationExpression, schemaName);
+    }
+
+    return null;
+  };
+
+  const resolveDocumentCallExpression = (expression: ts.Expression): ts.CallExpression | null => {
+    expression = unwrapExpression(expression);
+    if (ts.isCallExpression(expression)) return expression;
+
+    let initializer = resolveDeclarationInitializer(expression);
+    if (initializer) {
+      initializer = unwrapExpression(initializer);
+      if (ts.isCallExpression(initializer)) return initializer;
+    }
+
+    const symbol = getSymbol(expression);
+    if (!symbol) return null;
+
+    const cached = symbolCallCache.get(symbol);
+    if (cached !== undefined) return cached;
+
+    const callExpression = resolveSymbolCallExpression(symbol);
+    symbolCallCache.set(symbol, callExpression);
+    return callExpression;
+  };
+
+  const resolveDeclarationInitializer = (expression: ts.Expression): ts.Expression | null => {
+    const symbol = getSymbol(expression);
+    if (!symbol) return null;
+
+    for (const declaration of symbol.declarations || []) {
+      if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+        return declaration.initializer;
+      }
+    }
+
+    return null;
+  };
+
+  const resolveSymbolCallExpression = (symbol: ts.Symbol): ts.CallExpression | null => {
+    for (const declaration of symbol.declarations || []) {
+      if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+        const initializer = unwrapExpression(declaration.initializer);
+        if (ts.isCallExpression(initializer)) return initializer;
+      }
+    }
+    return null;
+  };
+
+  const getSymbol = (expression: ts.Expression): ts.Symbol | undefined => {
+    let symbol = context.checker.getSymbolAtLocation(expression);
+    if (symbol && symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = context.checker.getAliasedSymbol(symbol);
+    }
+    return symbol;
+  };
+
+  return { hashCallExpression };
+}
+
+function getStaticStringValue(expression: ts.Expression | undefined): string | undefined {
+  if (!expression) return undefined;
+  expression = unwrapExpression(expression);
+
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text;
+  }
+
+  return undefined;
+}
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    expression = expression.expression;
+  }
+  return expression;
+}
+
+function addHashPart(hash: crypto.Hash, part: string): void {
+  hash.update(`${part.length}:`);
+  hash.update(part);
+  hash.update('\0');
+}
+
+function stableStringify(input: unknown): string {
+  if (input === null || typeof input !== 'object') return JSON.stringify(input) ?? 'undefined';
+  if (Array.isArray(input)) return `[${input.map(stableStringify).join(',')}]`;
+
+  const record = input as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(',')}}`;
+}

--- a/packages/cli-utils/src/commands/turbo/hash.ts
+++ b/packages/cli-utils/src/commands/turbo/hash.ts
@@ -131,12 +131,6 @@ export function createDocumentHasher(context: HashContext): DocumentHasher {
     expression = unwrapExpression(expression);
     if (ts.isCallExpression(expression)) return expression;
 
-    let initializer = resolveDeclarationInitializer(expression);
-    if (initializer) {
-      initializer = unwrapExpression(initializer);
-      if (ts.isCallExpression(initializer)) return initializer;
-    }
-
     const symbol = getSymbol(expression);
     if (!symbol) return null;
 

--- a/packages/cli-utils/src/commands/turbo/hash.ts
+++ b/packages/cli-utils/src/commands/turbo/hash.ts
@@ -1,6 +1,5 @@
 import ts from 'typescript';
 import * as crypto from 'node:crypto';
-import type { GraphQLSPConfig } from '@gql.tada/internal';
 
 // NOTE(@kitten): Change if document type input or output changes
 const CACHE_BUSTER = 'turbo-document-hash-v1';
@@ -19,21 +18,13 @@ export interface DocumentHasher {
 
 interface HashContext {
   readonly checker: ts.TypeChecker;
-  pluginConfig: GraphQLSPConfig;
+  schemaFingerprints: ReadonlyMap<string | null, string>;
 }
 
 export function createDocumentHasher(context: HashContext): DocumentHasher {
   const callExpressionCache = new WeakMap<ts.CallExpression, Map<string, DocumentHashResult>>();
   const symbolCallCache = new Map<ts.Symbol, ts.CallExpression | null>();
   const activeCalls = new WeakSet<ts.CallExpression>();
-
-  let _pluginConfigKey: string | null;
-  const computePluginConfigKey = () => {
-    if (_pluginConfigKey == null) {
-      _pluginConfigKey = stableStringify(context.pluginConfig);
-    }
-    return _pluginConfigKey;
-  };
 
   const hashCallExpression = (
     callExpression: ts.CallExpression,
@@ -79,7 +70,7 @@ export function createDocumentHasher(context: HashContext): DocumentHasher {
 
     addHashPart(hash, CACHE_BUSTER);
     addHashPart(hash, schemaName || '');
-    addHashPart(hash, computePluginConfigKey());
+    addHashPart(hash, context.schemaFingerprints.get(schemaName) || '');
     addHashPart(hash, documentText);
     for (const fragmentHash of fragmentHashes) {
       addHashPart(hash, fragmentHash);
@@ -204,15 +195,4 @@ function addHashPart(hash: crypto.Hash, part: string): void {
   hash.update(`${part.length}:`);
   hash.update(part);
   hash.update('\0');
-}
-
-function stableStringify(input: unknown): string {
-  if (input === null || typeof input !== 'object') return JSON.stringify(input) ?? 'undefined';
-  if (Array.isArray(input)) return `[${input.map(stableStringify).join(',')}]`;
-
-  const record = input as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
-    .join(',')}}`;
 }

--- a/packages/cli-utils/src/commands/turbo/logger.ts
+++ b/packages/cli-utils/src/commands/turbo/logger.ts
@@ -34,14 +34,19 @@ export function warningMessage(message: TurboWarning) {
   ]);
 }
 
-const documentSummary = (documentCount: number | Record<string, number>) => {
+const documentSummary = (
+  documentCount: number | Record<string, number>,
+  cachedCount?: number | Record<string, number>
+) => {
   let out = '';
   if (typeof documentCount === 'number') {
+    const cachedLabel =
+      typeof cachedCount === 'number' && cachedCount > 0 ? `, ${cachedCount} reused` : '';
     out += t.text([
       t.cmd(t.CSI.Style, t.Style.BrightGreen),
       `${t.Icons.Tick} Type cache was generated successfully `,
       t.cmd(t.CSI.Style, t.Style.BrightBlack),
-      `(${documentCount} document types cached)\n`,
+      `(${documentCount} document types cached${cachedLabel})\n`,
     ]);
   } else {
     out += t.text([
@@ -49,11 +54,14 @@ const documentSummary = (documentCount: number | Record<string, number>) => {
       `${t.Icons.Tick} Type caches were generated successfully.\n`,
     ]);
     for (const schemaName in documentCount) {
+      const schemaCachedCount =
+        cachedCount && typeof cachedCount !== 'number' ? cachedCount[schemaName] : undefined;
+      const cachedLabel = schemaCachedCount ? `, ${schemaCachedCount} reused` : '';
       out += t.text([
         t.cmd(t.CSI.Style, t.Style.BrightBlack),
         `${t.HeavyBox.BottomLeft} `,
         t.cmd(t.CSI.Style, t.Style.BrightBlue),
-        `${documentCount[schemaName]} document types cached for the '${schemaName}' schema\n`,
+        `${documentCount[schemaName]} document types cached for the '${schemaName}' schema${cachedLabel}\n`,
       ]);
     }
   }
@@ -64,7 +72,11 @@ export function warningSummary(warningCount: number) {
   return t.error([t.cmd(t.CSI.Style, t.Style.Red), `${t.Icons.Cross} ${warningCount} warnings\n`]);
 }
 
-export function infoSummary(warningCount: number, documentCount: number | Record<string, number>) {
+export function infoSummary(
+  warningCount: number,
+  documentCount: number | Record<string, number>,
+  cachedCount?: number | Record<string, number>
+) {
   let out = '';
   if (warningCount) {
     out += t.text([
@@ -73,7 +85,7 @@ export function infoSummary(warningCount: number, documentCount: number | Record
       ` ${warningCount} warnings\n`,
     ]);
   }
-  out += documentSummary(documentCount);
+  out += documentSummary(documentCount, cachedCount);
   return out;
 }
 

--- a/packages/cli-utils/src/commands/turbo/logger.ts
+++ b/packages/cli-utils/src/commands/turbo/logger.ts
@@ -34,14 +34,15 @@ export function warningMessage(message: TurboWarning) {
   ]);
 }
 
+const reusedLabel = (count: number | undefined) => (count ? `, ${count} reused` : '');
+
 const documentSummary = (
   documentCount: number | Record<string, number>,
   cachedCount?: number | Record<string, number>
 ) => {
   let out = '';
   if (typeof documentCount === 'number') {
-    const cachedLabel =
-      typeof cachedCount === 'number' && cachedCount > 0 ? `, ${cachedCount} reused` : '';
+    const cachedLabel = reusedLabel(typeof cachedCount === 'number' ? cachedCount : undefined);
     out += t.text([
       t.cmd(t.CSI.Style, t.Style.BrightGreen),
       `${t.Icons.Tick} Type cache was generated successfully `,
@@ -54,9 +55,9 @@ const documentSummary = (
       `${t.Icons.Tick} Type caches were generated successfully.\n`,
     ]);
     for (const schemaName in documentCount) {
-      const schemaCachedCount =
-        cachedCount && typeof cachedCount !== 'number' ? cachedCount[schemaName] : undefined;
-      const cachedLabel = schemaCachedCount ? `, ${schemaCachedCount} reused` : '';
+      const cachedLabel = reusedLabel(
+        cachedCount && typeof cachedCount !== 'number' ? cachedCount[schemaName] : undefined
+      );
       out += t.text([
         t.cmd(t.CSI.Style, t.Style.BrightBlack),
         `${t.HeavyBox.BottomLeft} `,

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -92,6 +92,7 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
   let warnings = 0;
   let totalFileCount = 0;
   let fileCount = 0;
+  let cachedDocumentCount = 0;
 
   try {
     if (tty.isInteractive) yield logger.runningTurbo();
@@ -108,6 +109,7 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
       } else {
         fileCount++;
         documents.push(...signal.documents);
+        cachedDocumentCount += signal.documents.filter((document) => document.isCached).length;
         warnings += signal.warnings.length;
         if (signal.warnings.length) {
           let buffer = logger.warningFile(signal.filePath);
@@ -131,15 +133,13 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
     }
 
     try {
-      const cache: Record<string, string> = {};
-      for (const item of documents) cache[item.argumentKey] = item.documentType;
-      const contents = createCacheContents(cache, graphqlSources, destination!);
+      const contents = createCacheContents(documents, graphqlSources, destination!);
       await writeOutput(destination!, contents);
     } catch (error) {
       throw logger.externalError('Something went wrong while writing the type cache file', error);
     }
 
-    yield logger.infoSummary(warnings, documents.length);
+    yield logger.infoSummary(warnings, documents.length, cachedDocumentCount);
   } else {
     if (opts.output) {
       throw logger.errorMessage(
@@ -153,6 +153,7 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
     }
 
     const documentCount: Record<string, number> = {};
+    const cachedCount: Record<string, number> = {};
     for (const schemaConfig of pluginConfig.schemas) {
       const { name, tadaTurboLocation } = schemaConfig;
       if (!tadaTurboLocation) {
@@ -166,11 +167,13 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
 
       try {
         documentCount[name] = 0;
-        const cache: Record<string, string> = {};
+        cachedCount[name] = 0;
+        const cache: TurboDocument[] = [];
         for (const item of documents) {
           if (item.schemaName === name) {
-            cache[item.argumentKey] = item.documentType;
+            cache.push(item);
             documentCount[name]++;
+            if (item.isCached) cachedCount[name]++;
           }
         }
         const destination = path.resolve(projectPath, tadaTurboLocation);
@@ -187,20 +190,24 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
     if (warnings && opts.failOnWarn) {
       throw logger.warningSummary(warnings);
     } else {
-      yield logger.infoSummary(warnings, documentCount);
+      yield logger.infoSummary(warnings, documentCount, cachedCount);
     }
   }
 }
 
 function createCacheContents(
-  cache: Record<string, string>,
+  cache: TurboDocument[],
   graphqlSources: GraphQLSourceFile[],
   turboDestination: WriteTarget
 ): string {
+  const documentsByKey = new Map<string, TurboDocument>();
+  for (const document of cache) documentsByKey.set(document.argumentKey, document);
+
   let output = '';
-  for (const key in cache) {
+  for (const document of documentsByKey.values()) {
     if (output) output += '\n';
-    output += `    ${key}:\n      ${cache[key]};`;
+    if (document.documentHash) output += `    /** @gql.tada/hash ${document.documentHash} */\n`;
+    output += `    ${document.argumentKey}:\n      ${document.documentType};`;
   }
 
   let imports = "import type { TadaDocumentNode, $tada } from 'gql.tada';\n";

--- a/packages/cli-utils/src/commands/turbo/scan.ts
+++ b/packages/cli-utils/src/commands/turbo/scan.ts
@@ -1,0 +1,9 @@
+import * as path from 'node:path';
+
+export function shouldScanTurboFile(fileName: string, turboOutputPaths: Set<string>): boolean {
+  if (turboOutputPaths.has(path.resolve(fileName))) return false;
+  if (fileName.endsWith('.d.ts') || fileName.endsWith('.d.mts') || fileName.endsWith('.d.cts')) {
+    return false;
+  }
+  return !/(^|[/\\])node_modules([/\\]|$)/.test(fileName);
+}

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -310,16 +310,10 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
           : undefined;
 
       let documentType: string;
+      let isCached = false;
       if (cachedDocument && cachedDocument.documentHash === documentHash.documentHash) {
         documentType = cachedDocument.documentType;
-        documents.push({
-          schemaName: call.schema,
-          argumentKey,
-          documentType,
-          documentHash: documentHash.documentHash,
-          isCached: true,
-        });
-        continue;
+        isCached = true;
       } else {
         const returnType = checker.getTypeAtLocation(callExpression);
         // NOTE: `returnType.symbol` is incorrectly typed and is in fact
@@ -344,6 +338,7 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
         argumentKey,
         documentType,
         documentHash: documentHash.documentHash,
+        isCached,
       });
     }
 

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -21,6 +21,7 @@ import type {
 } from './types';
 import { readCachedTurboDocuments, type CachedTurboDocuments } from './cache';
 import { createDocumentHasher } from './hash';
+import { shouldScanTurboFile } from './scan';
 
 export interface TurboParams {
   rootPath: string;
@@ -225,8 +226,8 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   const turboOutputPaths = new Set(
     getTurboOutputPaths(params.turboOutputPath).map((fileName) => path.resolve(fileName))
   );
-  const fileNames = factory.rootFileNames.filter(
-    (fileName) => !turboOutputPaths.has(path.resolve(fileName))
+  const fileNames = factory.rootFileNames.filter((fileName) =>
+    shouldScanTurboFile(fileName, turboOutputPaths)
   );
 
   yield {

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -222,7 +222,12 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   // Later, we may reinstantiate to free up memory between batches
   let container = factory.build();
   let pluginInfo = container.buildPluginInfo(params.pluginConfig);
-  const fileNames = container.getSourceFiles().map((sourceFile) => sourceFile.fileName);
+  const turboOutputPaths = new Set(
+    getTurboOutputPaths(params.turboOutputPath).map((fileName) => path.resolve(fileName))
+  );
+  const fileNames = factory.rootFileNames.filter(
+    (fileName) => !turboOutputPaths.has(path.resolve(fileName))
+  );
 
   yield {
     kind: 'FILE_COUNT',
@@ -394,6 +399,12 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       sources: Array.from(uniqueGraphQLSources.values()),
     };
   }
+}
+
+function getTurboOutputPaths(turboOutputPath: string | TurboPath[]): string[] {
+  return typeof turboOutputPath === 'string'
+    ? [turboOutputPath]
+    : turboOutputPath.map((cfg) => cfg.path);
 }
 
 let cachedGc: (() => void) | null | undefined;

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -187,13 +187,8 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   const factory = programFactory(params);
   const cachedDocumentsByPath = new Map<string, CachedTurboDocuments>();
 
-  const getTurboOutputPath = (schemaName: string | null): string | undefined => {
-    if (typeof params.turboOutputPath === 'string') return params.turboOutputPath;
-    return params.turboOutputPath.find((cfg) => cfg.schemaName === schemaName)?.path;
-  };
-
   const getCachedDocuments = (schemaName: string | null): CachedTurboDocuments => {
-    const turboOutputPath = getTurboOutputPath(schemaName);
+    const turboOutputPath = getTurboOutputPath(params.turboOutputPath, schemaName);
     if (!turboOutputPath) return new Map();
 
     let cachedDocuments = cachedDocumentsByPath.get(turboOutputPath);
@@ -279,7 +274,7 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       if (graphqlSourcePath && !uniqueGraphQLSources.has(graphqlSourcePath)) {
         const graphqlSourceFile = container.program.getSourceFile(graphqlSourcePath);
         if (graphqlSourceFile) {
-          const turboPath = getTurboOutputPath(call.schema);
+          const turboPath = getTurboOutputPath(params.turboOutputPath, call.schema);
           const imports = collectImportsFromSourceFile(
             graphqlSourceFile,
             params.pluginConfig,
@@ -395,6 +390,14 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       sources: Array.from(uniqueGraphQLSources.values()),
     };
   }
+}
+
+function getTurboOutputPath(
+  turboOutputPath: string | TurboPath[],
+  schemaName: string | null
+): string | undefined {
+  if (typeof turboOutputPath === 'string') return turboOutputPath;
+  return turboOutputPath.find((cfg) => cfg.schemaName === schemaName)?.path;
 }
 
 function getTurboOutputPaths(turboOutputPath: string | TurboPath[]): string[] {

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -1,10 +1,12 @@
 import ts from 'typescript';
 import v8 from 'node:v8';
 import vm from 'node:vm';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import type { GraphQLSPConfig } from '@gql.tada/internal';
 
-import { getSchemaNamesFromConfig } from '@gql.tada/internal';
+import { getSchemaNamesFromConfig, getSchemaConfigForName } from '@gql.tada/internal';
 import { findAllCallExpressions } from '@0no-co/graphqlsp/api';
 
 import type { ProgramContainer, PluginCreateInfo } from '../../ts';
@@ -351,7 +353,7 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
     get checker() {
       return checker;
     },
-    pluginConfig: params.pluginConfig,
+    schemaFingerprints: computeSchemaFingerprints(params),
   });
   let filesInBatch = 0;
 
@@ -390,6 +392,27 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       sources: Array.from(uniqueGraphQLSources.values()),
     };
   }
+}
+
+function computeSchemaFingerprints(params: TurboParams): Map<string | null, string> {
+  const fingerprints = new Map<string | null, string>();
+  const configDir = path.dirname(params.configPath);
+  for (const schemaName of getSchemaNamesFromConfig(params.pluginConfig)) {
+    const schemaConfig = getSchemaConfigForName(params.pluginConfig, schemaName || undefined);
+    const outputLocation = schemaConfig && schemaConfig.tadaOutputLocation;
+    if (!outputLocation) continue;
+
+    let contents: string;
+    try {
+      contents = fs.readFileSync(path.resolve(configDir, outputLocation), 'utf8');
+    } catch {
+      continue;
+    }
+
+    const hash = crypto.createHash('sha256').update(contents).digest('hex');
+    fingerprints.set(schemaName, `sha256:${hash.slice(0, 32)}`);
+  }
+  return fingerprints;
 }
 
 function getTurboOutputPath(

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -288,13 +288,14 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
         }
       }
 
-      const argumentType = checker.getTypeAtLocation(call.node);
       const argumentKey: string =
-        'value' in argumentType &&
-        typeof argumentType.value === 'string' &&
-        (argumentType.flags & ts.TypeFlags.StringLiteral) === 0
-          ? JSON.stringify(argumentType.value)
-          : checker.typeToString(argumentType, callExpression, BUILDER_FLAGS);
+        ts.isStringLiteral(call.node) || ts.isNoSubstitutionTemplateLiteral(call.node)
+          ? JSON.stringify(call.node.text)
+          : checker.typeToString(
+              checker.getTypeAtLocation(call.node),
+              callExpression,
+              BUILDER_FLAGS
+            );
 
       const documentHash = documentHasher.hashCallExpression(callExpression, call.schema);
       const cachedDocument =

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -19,6 +19,8 @@ import type {
   GraphQLSourceImport,
   TurboPath,
 } from './types';
+import { readCachedTurboDocuments, type CachedTurboDocuments } from './cache';
+import { createDocumentHasher } from './hash';
 
 export interface TurboParams {
   rootPath: string;
@@ -182,6 +184,24 @@ function isTadaImport(
 async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSignal> {
   const schemaNames = getSchemaNamesFromConfig(params.pluginConfig);
   const factory = programFactory(params);
+  const cachedDocumentsByPath = new Map<string, CachedTurboDocuments>();
+
+  const getTurboOutputPath = (schemaName: string | null): string | undefined => {
+    if (typeof params.turboOutputPath === 'string') return params.turboOutputPath;
+    return params.turboOutputPath.find((cfg) => cfg.schemaName === schemaName)?.path;
+  };
+
+  const getCachedDocuments = (schemaName: string | null): CachedTurboDocuments => {
+    const turboOutputPath = getTurboOutputPath(schemaName);
+    if (!turboOutputPath) return new Map();
+
+    let cachedDocuments = cachedDocumentsByPath.get(turboOutputPath);
+    if (!cachedDocuments) {
+      cachedDocuments = readCachedTurboDocuments(turboOutputPath);
+      cachedDocumentsByPath.set(turboOutputPath, cachedDocuments);
+    }
+    return cachedDocuments;
+  };
 
   // NOTE: We add our override declaration here before loading all files
   // This sets `__cacheDisabled` on the turbo cache, which disables the cache temporarily
@@ -253,9 +273,7 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
       if (graphqlSourcePath && !uniqueGraphQLSources.has(graphqlSourcePath)) {
         const graphqlSourceFile = container.program.getSourceFile(graphqlSourcePath);
         if (graphqlSourceFile) {
-          const turboPath = Array.isArray(params.turboOutputPath)
-            ? params.turboOutputPath.find((cfg) => cfg.schemaName === call.schema)?.path
-            : params.turboOutputPath;
+          const turboPath = getTurboOutputPath(call.schema);
           const imports = collectImportsFromSourceFile(
             graphqlSourceFile,
             params.pluginConfig,
@@ -270,34 +288,55 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
         }
       }
 
-      const returnType = checker.getTypeAtLocation(callExpression);
       const argumentType = checker.getTypeAtLocation(call.node);
-      // NOTE: `returnType.symbol` is incorrectly typed and is in fact
-      // optional and not always present
-      if (!returnType.symbol || returnType.symbol.getEscapedName() !== 'TadaDocumentNode') {
-        warnings.push({
-          message:
-            `The discovered document is not of type "TadaDocumentNode".\n` +
-            'If this is unexpected, please file an issue describing your case.',
-          file: position.fileName,
-          line: position.line,
-          col: position.col,
-        });
-        continue;
-      }
-
       const argumentKey: string =
         'value' in argumentType &&
         typeof argumentType.value === 'string' &&
         (argumentType.flags & ts.TypeFlags.StringLiteral) === 0
           ? JSON.stringify(argumentType.value)
           : checker.typeToString(argumentType, callExpression, BUILDER_FLAGS);
-      const documentType = checker.typeToString(returnType, callExpression, BUILDER_FLAGS);
+
+      const documentHash = documentHasher.hashCallExpression(callExpression, call.schema);
+      const cachedDocument =
+        documentHash.hashable && documentHash.documentHash
+          ? getCachedDocuments(call.schema).get(argumentKey)
+          : undefined;
+
+      let documentType: string;
+      if (cachedDocument && cachedDocument.documentHash === documentHash.documentHash) {
+        documentType = cachedDocument.documentType;
+        documents.push({
+          schemaName: call.schema,
+          argumentKey,
+          documentType,
+          documentHash: documentHash.documentHash,
+          isCached: true,
+        });
+        continue;
+      } else {
+        const returnType = checker.getTypeAtLocation(callExpression);
+        // NOTE: `returnType.symbol` is incorrectly typed and is in fact
+        // optional and not always present
+        if (!returnType.symbol || returnType.symbol.getEscapedName() !== 'TadaDocumentNode') {
+          warnings.push({
+            message:
+              `The discovered document is not of type "TadaDocumentNode".\n` +
+              'If this is unexpected, please file an issue describing your case.',
+            file: position.fileName,
+            line: position.line,
+            col: position.col,
+          });
+          continue;
+        }
+
+        documentType = checker.typeToString(returnType, callExpression, BUILDER_FLAGS);
+      }
 
       documents.push({
         schemaName: call.schema,
         argumentKey,
         documentType,
+        documentHash: documentHash.documentHash,
       });
     }
 
@@ -311,6 +350,12 @@ async function* _runTurbo(params: TurboParams): AsyncIterableIterator<TurboSigna
   };
 
   let checker = container.program.getTypeChecker();
+  const documentHasher = createDocumentHasher({
+    get checker() {
+      return checker;
+    },
+    pluginConfig: params.pluginConfig,
+  });
   let filesInBatch = 0;
 
   for (const fileName of fileNames) {

--- a/packages/cli-utils/src/commands/turbo/types.ts
+++ b/packages/cli-utils/src/commands/turbo/types.ts
@@ -14,6 +14,7 @@ export interface TurboDocument {
   schemaName: string | null;
   argumentKey: string;
   documentType: string;
+  documentHash?: string | undefined;
 }
 
 export interface GraphQLSourceImport {

--- a/packages/cli-utils/src/commands/turbo/types.ts
+++ b/packages/cli-utils/src/commands/turbo/types.ts
@@ -15,6 +15,7 @@ export interface TurboDocument {
   argumentKey: string;
   documentType: string;
   documentHash?: string | undefined;
+  isCached?: boolean | undefined;
 }
 
 export interface GraphQLSourceImport {

--- a/packages/cli-utils/src/ts/__tests__/factory.test.ts
+++ b/packages/cli-utils/src/ts/__tests__/factory.test.ts
@@ -76,4 +76,55 @@ describe('programFactory', () => {
       await fs.rm(rootPath, { recursive: true, force: true });
     }
   });
+
+  it('keeps root file names scoped to the parsed tsconfig inputs', async () => {
+    const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'gql-tada-factory-'));
+
+    try {
+      const { programFactory } = await import('../factory');
+      const configPath = path.join(rootPath, 'tsconfig.json');
+      const entryPath = path.join(rootPath, 'src', 'entry.ts');
+      const importedPath = path.join(rootPath, 'src', 'imported.ts');
+      const outsidePath = path.join(rootPath, 'outside-rootdir', 'outside.ts');
+
+      await fs.mkdir(path.join(rootPath, 'src'), { recursive: true });
+      await fs.mkdir(path.join(rootPath, 'outside-rootdir'), { recursive: true });
+
+      await Promise.all([
+        fs.writeFile(
+          configPath,
+          JSON.stringify(
+            {
+              compilerOptions: {
+                rootDir: 'src',
+                module: 'esnext',
+                moduleResolution: 'bundler',
+              },
+              include: ['src/entry.ts'],
+            },
+            null,
+            2
+          )
+        ),
+        fs.writeFile(
+          entryPath,
+          "import './imported';\nimport '../outside-rootdir/outside';\nexport const entry = 1;\n"
+        ),
+        fs.writeFile(importedPath, 'export const imported = 1;\n'),
+        fs.writeFile(outsidePath, 'export const outside = 1;\n'),
+      ]);
+
+      const factory = programFactory({ rootPath, configPath });
+      const container = factory.build();
+      const programFileNames = container.getSourceFiles().map((file) => file.fileName);
+
+      expect(factory.rootFileNames).toContain(entryPath);
+      expect(factory.rootFileNames).not.toContain(importedPath);
+      expect(factory.rootFileNames).not.toContain(outsidePath);
+      expect(programFileNames).toContain(importedPath);
+      expect(programFileNames).toContain(outsidePath);
+    } finally {
+      await fs.rm(rootPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -33,6 +33,7 @@ export interface ProgramFactory {
   readonly projectPath: string;
   readonly wasOriginallyNodeNext: boolean;
   readonly projectDirectories: readonly string[];
+  readonly rootFileNames: readonly string[];
 
   createSourceFile(params: SourceFileParams, scriptKind?: ts.ScriptKind): ts.SourceFile;
   createExternalFiles(exts?: readonly VirtualExtension[]): readonly ts.SourceFile[];
@@ -97,6 +98,10 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
       const directories = new Set([params.rootPath]);
       for (const rootName of rootNames) directories.add(path.dirname(rootName));
       return [...directories];
+    },
+
+    get rootFileNames() {
+      return [...rootNames];
     },
 
     createSourceFile(params, scriptKind) {


### PR DESCRIPTION
Resolves #471
Supersedes #475

## Summary

This implements change detection after #531, which lifted restrictions on project sizes due to OOM errors, and narrowed cost to `typeToString`. We can avoid evaluating types and calling `typeToString` by strategically reusing parts of the cache.

The key difference to #475 is the use of the AST to store hashes (via TSdoc comments) and hashing by more inputs, focused on the input documents (and stable keys, based on the schema name and inputs.

It also addresses the excessive cost of retrieving `graphql()` arguments, by adding a fast path.

## Set of changes

- Add turbo cache metadata parser
- Reuse unchanged turbo document types
