### PR TITLE
perf(cli-utils): Skip TS files that don't contain anything resembling GraphQL strings as call args

### DIFF
--- a/.changeset/wide-trams-hug.md
+++ b/.changeset/wide-trams-hug.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+In `turbo`, skip TypeScript files whose ASTs don't contain calls with string literal arguments that vaguely resemble GraphQL

--- a/packages/cli-utils/src/commands/turbo/__tests__/thread.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/thread.test.ts
@@ -1,7 +1,8 @@
 import * as path from 'node:path';
+import ts from 'typescript';
 import { describe, it, expect } from 'vitest';
 
-import { shouldScanTurboFile } from '../scan';
+import { hasGraphQLDocumentCandidate, shouldScanTurboFile } from '../scan';
 
 describe('shouldScanTurboFile', () => {
   it('excludes generated cache, declarations, and node_modules files', () => {
@@ -30,3 +31,46 @@ describe('shouldScanTurboFile', () => {
     ).toBe(false);
   });
 });
+
+describe('hasGraphQLDocumentCandidate', () => {
+  it('accepts executable GraphQL documents in string-call arguments', () => {
+    expect(
+      hasGraphQLDocumentCandidate(
+        createSourceFile(`
+          graphql(\`query Pokemons { pokemons { id } }\`);
+          graphql('fragment Pokemon on Pokemon { id }');
+        `)
+      )
+    ).toBe(true);
+  });
+
+  it('accepts shorthand selection-set documents', () => {
+    expect(
+      hasGraphQLDocumentCandidate(
+        createSourceFile(`
+          graphql('{ viewer { id } }');
+          graphql(\`
+            # graphql
+            { viewer { id } }
+          \`);
+        `)
+      )
+    ).toBe(true);
+  });
+
+  it('rejects files with only ordinary string-call arguments', () => {
+    expect(
+      hasGraphQLDocumentCandidate(
+        createSourceFile(`
+          t('settings.profile.title');
+          describe('query retries', () => {});
+          route('/users/:id', 'GET');
+        `)
+      )
+    ).toBe(false);
+  });
+});
+
+function createSourceFile(sourceText: string): ts.SourceFile {
+  return ts.createSourceFile('/fixture.ts', sourceText, ts.ScriptTarget.Latest, true);
+}

--- a/packages/cli-utils/src/commands/turbo/scan.ts
+++ b/packages/cli-utils/src/commands/turbo/scan.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import ts from 'typescript';
 
 export function shouldScanTurboFile(fileName: string, turboOutputPaths: Set<string>): boolean {
   if (turboOutputPaths.has(path.resolve(fileName))) return false;
@@ -6,4 +7,44 @@ export function shouldScanTurboFile(fileName: string, turboOutputPaths: Set<stri
     return false;
   }
   return !/(^|[/\\])node_modules([/\\]|$)/.test(fileName);
+}
+
+const GRAPHQL_DOCUMENT_START = /(?:^|[^\w])(query|mutation|subscription|fragment)\b/;
+
+export function hasGraphQLDocumentCandidate(sourceFile: ts.SourceFile): boolean {
+  if (!sourceFile.text.includes('{')) return false;
+
+  let hasCandidate = false;
+
+  const visit = (node: ts.Node): void => {
+    if (hasCandidate) return;
+
+    if (ts.isCallExpression(node)) {
+      const argument = node.arguments[0];
+      if (argument && ts.isStringLiteralLike(argument)) {
+        const text = argument.text;
+        if (text.includes('{') && isGraphQLDocumentCandidateText(text)) {
+          hasCandidate = true;
+          return;
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return hasCandidate;
+}
+
+function isGraphQLDocumentCandidateText(text: string): boolean {
+  if (GRAPHQL_DOCUMENT_START.test(text)) return true;
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    return trimmed.startsWith('{');
+  }
+
+  return false;
 }

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -23,7 +23,7 @@ import type {
 } from './types';
 import { readCachedTurboDocuments, type CachedTurboDocuments } from './cache';
 import { createDocumentHasher } from './hash';
-import { shouldScanTurboFile } from './scan';
+import { hasGraphQLDocumentCandidate, shouldScanTurboFile } from './scan';
 
 export interface TurboParams {
   rootPath: string;
@@ -279,6 +279,10 @@ export async function* _runTurbo(params: TurboParams): AsyncIterableIterator<Tur
     let filePath = sourceFile.fileName;
     const documents: TurboDocument[] = [];
     const warnings: TurboWarning[] = [];
+
+    if (!hasGraphQLDocumentCandidate(sourceFile)) {
+      return { filePath, documents, warnings };
+    }
 
     // NOTE: Turbo only consumes the discovered call nodes, so fragment definitions
     // aren't collected and external fragment documents aren't searched for

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -333,14 +333,7 @@ export async function* _runTurbo(params: TurboParams): AsyncIterableIterator<Tur
         }
       }
 
-      const argumentKey: string =
-        ts.isStringLiteral(call.node) || ts.isNoSubstitutionTemplateLiteral(call.node)
-          ? JSON.stringify(call.node.text)
-          : checker.typeToString(
-              checker.getTypeAtLocation(call.node),
-              callExpression,
-              BUILDER_FLAGS
-            );
+      const argumentKey = JSON.stringify(call.node.text);
 
       const documentHash = documentHasher.hashCallExpression(callExpression, call.schema);
       const cachedDocument =


### PR DESCRIPTION
## Summary

We can skip any document that doesn't contain any strings that vaguely resemble GraphQL documents in any call expression's arguments. This skips finding candidate call expressions, which in turn needs types to initially evaluate, speeding up the pre-cached `gql.tada turbo` runs quite a bit (~50% in testing)

## Set of changes

- Remove redundant `typeToString` on `argumentKey` (node type is known)
- Skip TypeScript source files that definitely don't contain `gql.tada` GraphQL calls
