### PR TITLE
Propagate schema loader errors and support forced reloads

### DIFF
--- a/.changeset/eighty-yaks-search.md
+++ b/.changeset/eighty-yaks-search.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/internal': minor
+---
+
+Propagate schema loader errors instead of swallowing them. `SchemaLoader.notifyOnUpdate` and `SchemaRef.autoupdate` accept an optional `onError` callback that's called with per-schema attribution when a watched SDL file fails to reload (e.g. it's temporarily invalid mid-edit), when a URL schema fails to re-poll, or when a loader's initial load fails during `autoupdate` setup. Failing SDL reloads no longer kill the `fs.watch` fallback watcher, and reset the loader's cached result so subsequent loads retry. `SchemaRef.load` additionally accepts a `reload` option to force re-reading schemas, e.g. when a file watcher may have missed events

--- a/packages/internal/src/helpers.ts
+++ b/packages/internal/src/helpers.ts
@@ -6,3 +6,6 @@ export const maybeRelative = (filePath: string): string => {
   const relative = path.relative(cwd, filePath);
   return !relative.startsWith('..') ? relative : filePath;
 };
+
+export const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(`${error}`);

--- a/packages/internal/src/loaders/__tests__/loaders.test.ts
+++ b/packages/internal/src/loaders/__tests__/loaders.test.ts
@@ -1,0 +1,143 @@
+import { expect, describe, it, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadRef, loadFromSDL } from '../index';
+
+const VALID_SCHEMA = 'type Query { hello: String }';
+const UPDATED_SCHEMA = 'type Query { hello: String, world: String }';
+const INVALID_SCHEMA = 'type Query { hello: ';
+
+const tmpdirs: string[] = [];
+
+const makeSchemaFile = async (contents: string): Promise<string> => {
+  // The realpath matters: macOS tmpdirs live behind a /var symlink, which
+  // confuses fs-event watchers that report resolved paths
+  const tmp = await fs.realpath(os.tmpdir());
+  const dir = await fs.mkdtemp(path.join(tmp, 'tada-loaders-'));
+  tmpdirs.push(dir);
+  const file = path.join(dir, 'schema.graphql');
+  await fs.writeFile(file, contents);
+  return file;
+};
+
+afterEach(async () => {
+  let dir: string | undefined;
+  while ((dir = tmpdirs.pop()) != null) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('loadFromSDL', () => {
+  it('returns the cached result unless a reload is forced', async () => {
+    const file = await makeSchemaFile(VALID_SCHEMA);
+    const loader = loadFromSDL({ file, assumeValid: true });
+
+    const initial = await loader.load();
+    expect(initial.schema.getQueryType()!.getFields().world).toBeUndefined();
+
+    await fs.writeFile(file, UPDATED_SCHEMA);
+    const cached = await loader.load();
+    expect(cached).toBe(initial);
+
+    const reloaded = await loader.load(true);
+    expect(reloaded.schema.getQueryType()!.getFields().world).toBeDefined();
+  });
+});
+
+describe('loadRef', () => {
+  it('supports forced reloads through load()', async () => {
+    const file = await makeSchemaFile(VALID_SCHEMA);
+    const ref = loadRef({ schema: file });
+
+    await ref.load({});
+    expect(ref.current!.schema.getQueryType()!.getFields().world).toBeUndefined();
+    const version = ref.version;
+
+    await fs.writeFile(file, UPDATED_SCHEMA);
+    await ref.load({ reload: true });
+    expect(ref.current!.schema.getQueryType()!.getFields().world).toBeDefined();
+    expect(ref.version).toBeGreaterThan(version);
+  });
+
+  it('reports load failures during autoupdate setup through onError', async () => {
+    const file = await makeSchemaFile(VALID_SCHEMA);
+    const missing = path.join(path.dirname(file), 'does-not-exist.graphql');
+    const ref = loadRef({
+      schemas: [
+        { name: 'valid', schema: file, tadaOutputLocation: 'valid.d.ts' },
+        { name: 'broken', schema: missing, tadaOutputLocation: 'broken.d.ts' },
+      ],
+    });
+
+    await expect(ref.load({})).rejects.toThrow(/does-not-exist\.graphql/);
+
+    const errors: { message: string; name: string | undefined }[] = [];
+    const teardown = ref.autoupdate(
+      {},
+      () => {},
+      (error, input) => {
+        errors.push({ message: error.message, name: input.name });
+      }
+    );
+
+    try {
+      // The autoupdate setup retries loaders that have no result yet and
+      // reports their failures with the failing schema's input attached
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(errors).toHaveLength(1);
+      expect(errors[0].name).toBe('broken');
+      expect(errors[0].message).toMatch(/does-not-exist\.graphql/);
+      expect(ref.multi.valid).not.toBeNull();
+    } finally {
+      teardown();
+    }
+  });
+
+  it('reports watch-time reload failures through onError and recovers', async () => {
+    const file = await makeSchemaFile(VALID_SCHEMA);
+    const ref = loadRef({ schema: file });
+    await ref.load({});
+
+    const updates: unknown[] = [];
+    const errors: Error[] = [];
+    const teardown = ref.autoupdate(
+      {},
+      (schemaRef) => {
+        updates.push(schemaRef.current);
+      },
+      (error) => {
+        errors.push(error);
+      }
+    );
+
+    // Repeatedly rewrites the file until the condition is met, since
+    // fs-event watchers can miss events fired right after their creation
+    const writeUntil = async (contents: string, condition: () => boolean) => {
+      for (let attempt = 0; attempt < 40; attempt++) {
+        await fs.writeFile(file, contents);
+        const deadline = Date.now() + 500;
+        while (Date.now() < deadline) {
+          if (condition()) return;
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      }
+      throw new Error('timed out waiting for the file watcher');
+    };
+
+    try {
+      // Breaking the schema file must surface an error instead of silence
+      await writeUntil(INVALID_SCHEMA, () => errors.length > 0);
+      expect(errors[0].message).toMatch(/Syntax Error/);
+      expect(updates).toHaveLength(0);
+
+      // Fixing the file must notify subscribers again, i.e. the watcher
+      // survived the failing reload
+      await writeUntil(UPDATED_SCHEMA, () => updates.length > 0);
+      expect(ref.current!.schema.getQueryType()!.getFields().world).toBeDefined();
+    } finally {
+      teardown();
+    }
+  }, 30_000);
+});

--- a/packages/internal/src/loaders/index.ts
+++ b/packages/internal/src/loaders/index.ts
@@ -1,6 +1,7 @@
 export type * from './types';
 
 import path from 'node:path';
+import { toError } from '../helpers';
 import { loadFromSDL } from './sdl';
 import { loadFromURL } from './url';
 
@@ -86,7 +87,7 @@ export function loadRef(
       return acc;
     }, {}),
 
-    autoupdate(config: BaseLoadConfig, onUpdate) {
+    autoupdate(config: BaseLoadConfig, onUpdate, onError) {
       const loaders = getLoaders(config);
       teardowns.push(
         ...loaders.map(({ input, loader }) => {
@@ -100,18 +101,21 @@ export function loadRef(
                 ref.current = { ...input, ...result };
               }
             })
-            .catch((_error) => {
-              /*noop*/
+            .catch((error) => {
+              if (onError) onError(toError(error), input);
             });
-          return loader.notifyOnUpdate((result) => {
-            ref.version++;
-            if (input.name) {
-              ref.multi[input.name] = { ...input, ...result };
-            } else {
-              ref.current = { ...input, ...result };
-            }
-            onUpdate(ref, input);
-          });
+          return loader.notifyOnUpdate(
+            (result) => {
+              ref.version++;
+              if (input.name) {
+                ref.multi[input.name] = { ...input, ...result };
+              } else {
+                ref.current = { ...input, ...result };
+              }
+              onUpdate(ref, input);
+            },
+            onError && ((error) => onError(toError(error), input))
+          );
         })
       );
       return () => {
@@ -119,11 +123,11 @@ export function loadRef(
         while ((teardown = teardowns.pop()) != null) teardown();
       };
     },
-    async load(config: BaseLoadConfig) {
+    async load(config: BaseLoadConfig & { reload?: boolean }) {
       const loaders = getLoaders(config);
       await Promise.all(
         loaders.map(async ({ input, loader }) => {
-          const result = await loader.load();
+          const result = await loader.load(config.reload);
           ref.version++;
           if (input.name) {
             ref.multi[input.name] = { ...input, ...result };

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -7,7 +7,8 @@ import path from 'node:path';
 
 import { makeIntrospectionQuery, getPeerSupportedFeatures } from './introspection';
 
-import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
+import { toError } from '../helpers';
+import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate, OnSchemaError } from './types';
 
 interface LoadFromSDLConfig {
   name?: string;
@@ -17,6 +18,7 @@ interface LoadFromSDLConfig {
 
 export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
   const subscriptions = new Set<OnSchemaUpdate>();
+  const errorSubscriptions = new Set<OnSchemaError>();
 
   let abort: (() => void) | null = null;
   let result: SchemaLoaderResult | null = null;
@@ -60,25 +62,28 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
     }
   };
 
+  // On reload failures the cached result is reset, so the next `load()` call
+  // retries instead of returning the last successful result, and subscribers
+  // are notified of the error rather than failing silently
+  const reload = async () => {
+    try {
+      if ((result = await load())) {
+        for (const subscriber of subscriptions) subscriber(result);
+      }
+    } catch (error) {
+      result = null;
+      for (const subscriber of errorSubscriptions) subscriber(toError(error));
+    }
+  };
+
   const watch = async () => {
     if (ts.sys.watchFile) {
-      const watcher = ts.sys.watchFile(
-        config.file,
-        async () => {
-          try {
-            if ((result = await load())) {
-              for (const subscriber of subscriptions) subscriber(result);
-            }
-          } catch (_error) {}
-        },
-        250,
-        {
-          // NOTE: Using `ts.WatchFileKind.UseFsEvents` causes missed events just like fs.watch
-          // as below on macOS, as of TypeScript 5.5 and is hence avoided here
-          watchFile: ts.WatchFileKind.UseFsEventsOnParentDirectory,
-          fallbackPolling: ts.PollingWatchKind.PriorityInterval,
-        }
-      );
+      const watcher = ts.sys.watchFile(config.file, reload, 250, {
+        // NOTE: Using `ts.WatchFileKind.UseFsEvents` causes missed events just like fs.watch
+        // as below on macOS, as of TypeScript 5.5 and is hence avoided here
+        watchFile: ts.WatchFileKind.UseFsEventsOnParentDirectory,
+        fallbackPolling: ts.PollingWatchKind.PriorityInterval,
+      });
       abort = () => watcher.close();
     } else {
       const controller = new AbortController();
@@ -88,11 +93,10 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
         persistent: false,
       });
       try {
-        for await (const _event of watcher) {
-          if ((result = await load())) {
-            for (const subscriber of subscriptions) subscriber(result);
-          }
-        }
+        // A failing reload previously threw out of this loop, which silently
+        // killed the watcher for the rest of the session; `reload` contains
+        // load errors so watching continues
+        for await (const _event of watcher) await reload();
       } catch (error: any) {
         if (error.name !== 'AbortError') throw error;
       } finally {
@@ -108,11 +112,13 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
     async load(reload?: boolean) {
       return reload || !result ? (result = await load()) : result;
     },
-    notifyOnUpdate(onUpdate) {
+    notifyOnUpdate(onUpdate, onError) {
       if (!subscriptions.size) watch();
       subscriptions.add(onUpdate);
+      if (onError) errorSubscriptions.add(onError);
       return () => {
         subscriptions.delete(onUpdate);
+        if (onError) errorSubscriptions.delete(onError);
         if (!subscriptions.size && abort) abort();
       };
     },

--- a/packages/internal/src/loaders/types.ts
+++ b/packages/internal/src/loaders/types.ts
@@ -13,11 +13,12 @@ export interface SchemaLoaderResult {
 }
 
 export type OnSchemaUpdate = (result: SchemaLoaderResult) => void;
+export type OnSchemaError = (error: Error) => void;
 
 export interface SchemaLoader {
   readonly name: string | undefined;
   load(reload?: boolean): Promise<SchemaLoaderResult>;
-  notifyOnUpdate(onUpdate: OnSchemaUpdate): () => void;
+  notifyOnUpdate(onUpdate: OnSchemaUpdate, onError?: OnSchemaError): () => void;
 
   /** @internal */
   loadIntrospection(): Promise<IntrospectionResult | null>;
@@ -45,10 +46,13 @@ export interface SchemaRef<Result = SchemaLoaderResult | null> {
   /** Starts automatically updating the ref */
   autoupdate(
     config: BaseLoadConfig,
-    onUpdate: (ref: SchemaRef<Result>, input: SingleSchemaInput) => void
+    onUpdate: (ref: SchemaRef<Result>, input: SingleSchemaInput) => void,
+    onError?: (error: Error, input: SingleSchemaInput) => void
   ): () => void;
-  /** Loads the initial result for the schema */
-  load(config: BaseLoadConfig): Promise<SchemaRef<SchemaLoaderResult>>;
+  /** Loads the initial result for the schema.
+   * Loaders cache their last successful result; pass `reload` to force
+   * re-reading schemas, e.g. when a file watcher may have missed events. */
+  load(config: BaseLoadConfig & { reload?: boolean }): Promise<SchemaRef<SchemaLoaderResult>>;
   current: Result;
   multi: { [name: string]: Result };
   version: number;

--- a/packages/internal/src/loaders/url.ts
+++ b/packages/internal/src/loaders/url.ts
@@ -12,7 +12,9 @@ import {
 } from './introspection';
 
 import type { SupportedFeatures, IntrospectSupportQueryData } from './introspection';
-import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate } from './types';
+
+import { toError } from '../helpers';
+import type { SchemaLoader, SchemaLoaderResult, OnSchemaUpdate, OnSchemaError } from './types';
 
 interface LoadFromURLConfig {
   name?: string;
@@ -24,6 +26,7 @@ interface LoadFromURLConfig {
 export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
   const interval = config.interval || 60_000;
   const subscriptions = new Set<OnSchemaUpdate>();
+  const errorSubscriptions = new Set<OnSchemaError>();
 
   let timeoutID: NodeJS.Timeout | null = null;
   let supportedFeatures: SupportedFeatures | null = null;
@@ -52,8 +55,9 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
         timeoutID = null;
         try {
           result = await load();
-        } catch (_error) {
+        } catch (error) {
           result = null;
+          for (const subscriber of errorSubscriptions) subscriber(toError(error));
         }
         if (result) for (const subscriber of subscriptions) subscriber(result);
       }, interval);
@@ -121,10 +125,12 @@ export function loadFromURL(config: LoadFromURLConfig): SchemaLoader {
     async load(reload?: boolean) {
       return reload || !result ? (result = await load()) : result;
     },
-    notifyOnUpdate(onUpdate) {
+    notifyOnUpdate(onUpdate, onError) {
       subscriptions.add(onUpdate);
+      if (onError) errorSubscriptions.add(onError);
       return () => {
         subscriptions.delete(onUpdate);
+        if (onError) errorSubscriptions.delete(onError);
         if (!subscriptions.size && timeoutID) {
           clearTimeout(timeoutID);
           timeoutID = null;

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -8,5 +8,9 @@ const hook = `
 pnpm exec lint-staged --quiet --relative
 `.trim();
 
-fs.writeFileSync(precommit, hook);
-fs.chmodSync(precommit, '755');
+// In git worktrees `.git` is a file rather than a directory and hooks are
+// shared from the main checkout, so there's nothing to write here
+if (fs.existsSync(path.dirname(precommit))) {
+  fs.writeFileSync(precommit, hook);
+  fs.chmodSync(precommit, '755');
+}


### PR DESCRIPTION
## Summary

Part of the follow-up to #432 (paired with [0no-co/GraphQLSP#398](https://github.com/0no-co/GraphQLSP/pull/398)): the schema loaders had three ways to go silently stale, which presents downstream as "my types stopped regenerating":

- A watched SDL file failing to reload (e.g. invalid SDL mid-edit) was swallowed in `loadFromSDL`'s watcher — and in the `fs.watch` fallback branch it even killed the watcher loop for the rest of the session.
- A URL schema failing to re-poll reset `result` without telling anyone.
- A loader failing its initial load during `autoupdate` setup was a `/*noop*/` catch.

`SchemaLoader.notifyOnUpdate` and `SchemaRef.autoupdate` now accept an optional `onError` callback (per-schema attribution via the `input` argument), so consumers like GraphQLSP can surface these as editor diagnostics. Failing SDL reloads also reset the loader's cached result so subsequent `load()` calls retry instead of returning the last-good result forever.

`SchemaRef.load` additionally accepts a `reload` option to force re-reading schemas — the escape hatch for fs-event watchers missing events (the macOS caveat already noted in `sdl.ts`), which GraphQLSP will use for a staleness self-check.

Both additions are optional parameters; existing callers and `SchemaLoader` implementations are unaffected.

Also includes a tiny fix for `scripts/prepare.js` to not crash `pnpm install` in git worktrees, where `.git` is a file.

## Test plan

New `loaders.test.ts` covering: cached vs forced loader reloads, `reload: true` through `SchemaRef.load`, per-schema `onError` attribution for initial load failures during `autoupdate`, and a real-watcher test that breaks an SDL file (expects `onError`), then fixes it (expects `onUpdate`, proving the watcher survived). Internal suite: 16 tests passing; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)