### PR TITLE
fix(internal,cli-utils): Scope project creation to project or specified `tsconfig.json` path

### DIFF
--- a/.changeset/quiet-monorepos-check.md
+++ b/.changeset/quiet-monorepos-check.md
@@ -1,0 +1,6 @@
+---
+'@gql.tada/cli-utils': patch
+'@gql.tada/internal': patch
+---
+
+Scope TypeScript program creation to the originally requested project tsconfig when the GraphQLSP plugin is inherited from a shared monorepo config.

--- a/packages/cli-utils/src/commands/check/runner.ts
+++ b/packages/cli-utils/src/commands/check/runner.ts
@@ -46,6 +46,7 @@ export async function* run(tty: TTY, opts: Options): AsyncIterable<ComposeInput>
   const minSeverity = opts.minSeverity;
   const generator = runDiagnostics({
     rootPath: configResult.rootPath,
+    tsconfigPath: configResult.tsconfigPath,
     configPath: configResult.configPath,
     pluginConfig,
   });

--- a/packages/cli-utils/src/commands/check/thread.ts
+++ b/packages/cli-utils/src/commands/check/thread.ts
@@ -12,6 +12,7 @@ import type { Severity, DiagnosticMessage, DiagnosticSignal } from './types';
 
 export interface DiagnosticsParams {
   rootPath: string;
+  tsconfigPath?: string;
   configPath: string;
   pluginConfig: GraphQLSPConfig;
 }

--- a/packages/cli-utils/src/commands/generate-persisted/runner.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/runner.ts
@@ -44,6 +44,7 @@ export async function* run(tty: TTY, opts: PersistedOptions): AsyncIterable<Comp
   const generator = runPersisted({
     disableNormalization: !!opts.disableNormalization,
     rootPath: configResult.rootPath,
+    tsconfigPath: configResult.tsconfigPath,
     configPath: configResult.configPath,
     pluginConfig,
   });

--- a/packages/cli-utils/src/commands/generate-persisted/thread.ts
+++ b/packages/cli-utils/src/commands/generate-persisted/thread.ts
@@ -20,6 +20,7 @@ import type { PersistedSignal, PersistedWarning, PersistedDocument } from './typ
 export interface PersistedParams {
   disableNormalization: boolean;
   rootPath: string;
+  tsconfigPath?: string;
   configPath: string;
   pluginConfig: GraphQLSPConfig;
 }

--- a/packages/cli-utils/src/commands/turbo/__tests__/perf.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/perf.test.ts
@@ -164,6 +164,7 @@ describe.skipIf(!process.env.BENCH)('turbo performance', () => {
           const start = process.hrtime.bigint();
           for await (const signal of _runTurbo({
             rootPath: configResult.rootPath,
+            tsconfigPath: configResult.tsconfigPath,
             configPath: configResult.configPath,
             pluginConfig,
             turboOutputPath: path.join(rootPath, 'src', 'graphql-cache.d.ts'),

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -82,6 +82,7 @@ export async function* run(tty: TTY, opts: TurboOptions): AsyncIterable<ComposeI
 
   const generator = runTurbo({
     rootPath: configResult.rootPath,
+    tsconfigPath: configResult.tsconfigPath,
     configPath: configResult.configPath,
     pluginConfig,
     turboOutputPath: typeof destination! === 'string' ? destination : destinations,

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -27,6 +27,7 @@ import { shouldScanTurboFile } from './scan';
 
 export interface TurboParams {
   rootPath: string;
+  tsconfigPath?: string;
   configPath: string;
   pluginConfig: GraphQLSPConfig;
   turboOutputPath: string | TurboPath[];

--- a/packages/cli-utils/src/ts/__tests__/factory.test.ts
+++ b/packages/cli-utils/src/ts/__tests__/factory.test.ts
@@ -10,6 +10,71 @@ vi.mock('../transformers', () => ({
 }));
 
 describe('programFactory', () => {
+  it('uses the requested project tsconfig when the plugin is declared in an extended config', async () => {
+    const workspacePath = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'gql-tada-factory-'))
+    );
+
+    try {
+      const { loadConfig } = await import('../../../../internal/src/resolve');
+      const { programFactory } = await import('../factory');
+      const baseConfigPath = path.join(workspacePath, 'tsconfig.base.json');
+      const projectPath = path.join(workspacePath, 'packages', 'project');
+      const projectConfigPath = path.join(projectPath, 'tsconfig.app.json');
+      const projectEntryPath = path.join(projectPath, 'src', 'index.ts');
+      const otherPackagePath = path.join(workspacePath, 'packages', 'other', 'src', 'index.ts');
+
+      await fs.mkdir(path.dirname(projectEntryPath), { recursive: true });
+      await fs.mkdir(path.dirname(otherPackagePath), { recursive: true });
+
+      await Promise.all([
+        fs.writeFile(
+          baseConfigPath,
+          JSON.stringify(
+            {
+              compilerOptions: {
+                baseUrl: '.',
+                plugins: [
+                  {
+                    name: '@0no-co/graphqlsp',
+                    schema: './schema.graphql',
+                    tadaOutputLocation: './src/graphql-env.d.ts',
+                  },
+                ],
+              },
+            },
+            null,
+            2
+          )
+        ),
+        fs.writeFile(
+          projectConfigPath,
+          JSON.stringify(
+            {
+              extends: '../../tsconfig.base.json',
+              include: ['src/index.ts'],
+            },
+            null,
+            2
+          )
+        ),
+        fs.writeFile(projectEntryPath, 'export const project = 1;\n'),
+        fs.writeFile(otherPackagePath, 'export const other = 1;\n'),
+      ]);
+
+      const configResult = await loadConfig(projectConfigPath);
+      const factory = programFactory(configResult);
+
+      expect(configResult.configPath).toBe(baseConfigPath);
+      expect(configResult.tsconfigPath).toBe(projectConfigPath);
+      expect(configResult.rootPath).toBe(projectPath);
+      expect(factory.rootFileNames).toEqual([projectEntryPath]);
+      expect(factory.projectDirectories).toEqual([projectPath, path.dirname(projectEntryPath)]);
+    } finally {
+      await fs.rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
   it('inherits module resolution from extended tsconfig files', async () => {
     const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'gql-tada-factory-'));
 

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -15,6 +15,7 @@ export type VirtualExtension = (typeof transformExtensions)[number];
 
 export interface ProgramFactoryParams {
   rootPath: string;
+  tsconfigPath?: string;
   configPath: string;
 }
 
@@ -280,15 +281,16 @@ const resolveDefaultLibsPath = (params: ProgramFactoryParams): string => {
 };
 
 const resolveConfig = (params: ProgramFactoryParams): ts.ParsedCommandLine => {
-  const text = ts.sys.readFile(params.configPath, 'utf8') || '{}';
-  const parseResult = ts.parseConfigFileTextToJson(params.configPath, text);
+  const configPath = params.tsconfigPath || params.configPath;
+  const text = ts.sys.readFile(configPath, 'utf8') || '{}';
+  const parseResult = ts.parseConfigFileTextToJson(configPath, text);
   if (parseResult.error != null) throw new Error(parseResult.error.messageText.toString());
-  const projectRoot = path.dirname(params.configPath);
+  const projectRoot = path.dirname(configPath);
   return ts.parseJsonConfigFileContent(
     parseResult.config,
     ts.sys,
     projectRoot,
     ts.getDefaultCompilerOptions(),
-    params.configPath
+    configPath
   );
 };

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -71,6 +71,7 @@ const getPluginConfig = (tsconfig: TsConfigJson | null): Record<string, unknown>
 
 export interface LoadConfigResult {
   pluginConfig: Record<string, unknown>;
+  tsconfigPath: string;
   configPath: string;
   rootPath: string;
 }
@@ -92,6 +93,7 @@ export const loadConfig = async (targetPath?: string): Promise<LoadConfigResult>
     if (pluginConfig) {
       return {
         pluginConfig,
+        tsconfigPath: rootTsconfigPath,
         configPath: targetPath,
         rootPath: path.dirname(rootTsconfigPath),
       };


### PR DESCRIPTION
See #524

## Summary

Resolve `tsconfigPath` and scope program creation to this root path correctly, when inheriting plugin from root workspace `tsconfig.json` via `extends`

## Set of changes

- Scope root directory to `tsconfigPath` rather than "root" config path
- Add regression test