### PR TITLE
fix(cli-utils): Fix incomplete filtering of `tadaOutputLocation` in turbo `d.ts` output

### DIFF
--- a/.changeset/ready-donkeys-visit.md
+++ b/.changeset/ready-donkeys-visit.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix multi-schema introspections being confused in turbo output, leading to multiple introspection outputs being referenced in the turbo output

--- a/packages/cli-utils/src/commands/turbo/__tests__/thread.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/thread.test.ts
@@ -1,8 +1,14 @@
 import * as path from 'node:path';
 import ts from 'typescript';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../ts/transformers', () => ({
+  transformExtensions: [] as const,
+  transform: vi.fn(),
+}));
 
 import { hasGraphQLDocumentCandidate, shouldScanTurboFile } from '../scan';
+import { collectImportsFromSourceFile } from '../thread';
 
 describe('shouldScanTurboFile', () => {
   it('excludes generated cache, declarations, and node_modules files', () => {
@@ -68,6 +74,55 @@ describe('hasGraphQLDocumentCandidate', () => {
         `)
       )
     ).toBe(false);
+  });
+});
+
+describe('collectImportsFromSourceFile', () => {
+  it('excludes generated tada output imports for multi-schema projects', () => {
+    const sourceFile = ts.createSourceFile(
+      '/project/graphql/pokemon.ts',
+      `
+        import { initGraphQLTada } from 'gql.tada';
+        import type { introspection } from './pokemon-env.d';
+        import type { CountrySchema } from './countries-env.d';
+        import type { UserScalar } from './types';
+      `,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const imports = collectImportsFromSourceFile(
+      sourceFile,
+      {
+        schemas: [
+          {
+            name: 'pokemon',
+            schema: './graphql/pokemon.graphql',
+            tadaOutputLocation: '/project/graphql/pokemon-env.d.ts',
+          },
+          {
+            name: 'countries',
+            schema: './graphql/countries.graphql',
+            tadaOutputLocation: '/project/graphql/countries-env.d.ts',
+          },
+        ],
+      },
+      (specifier) => specifier,
+      (specifier, fromPath) => {
+        if (specifier === './pokemon-env.d') return '/project/graphql/pokemon-env.d.ts';
+        if (specifier === './countries-env.d') return '/project/graphql/countries-env.d.ts';
+        return path.resolve(path.dirname(fromPath), specifier);
+      },
+      '/project',
+      '/project/graphql/pokemon-cache.d.ts'
+    );
+
+    expect(imports).toEqual([
+      {
+        specifier: './types',
+        importClause: "import type { UserScalar } from './types';",
+      },
+    ]);
   });
 });
 

--- a/packages/cli-utils/src/commands/turbo/thread.ts
+++ b/packages/cli-utils/src/commands/turbo/thread.ts
@@ -133,23 +133,25 @@ function resolveModulePath(
   return undefined;
 }
 
-function collectImportsFromSourceFile(
+export function collectImportsFromSourceFile(
   sourceFile: ts.SourceFile,
   pluginConfig: GraphQLSPConfig,
   resolveModuleName: (importSpecifier: string, fromPath: string, toPath: string) => string,
+  resolveModulePath: (importSpecifier: string, fromPath: string) => string | undefined,
+  rootPath: string,
   turboOutputPath?: string,
   shouldTreatImportsAsNodeNext?: boolean
 ): GraphQLSourceImport[] {
   const imports: GraphQLSourceImport[] = [];
 
-  const tadaImportPaths = getTadaOutputPaths(pluginConfig);
+  const tadaImportPaths = getTadaOutputPaths(pluginConfig, rootPath);
 
   // NOTE: Import declarations may only appear as top-level statements
   for (const node of sourceFile.statements) {
     if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
       const specifier = node.moduleSpecifier.text;
 
-      if (!isTadaImport(specifier, sourceFile.fileName, tadaImportPaths)) {
+      if (!isTadaImport(specifier, sourceFile.fileName, tadaImportPaths, resolveModulePath)) {
         const importClause = node.getFullText().trim();
         if (turboOutputPath) {
           // Adjust the import specifier to point to the turbo output path
@@ -185,13 +187,17 @@ function collectImportsFromSourceFile(
   return imports;
 }
 
-function getTadaOutputPaths(pluginConfig: GraphQLSPConfig): string[] {
+function getTadaOutputPaths(pluginConfig: GraphQLSPConfig, rootPath: string): string[] {
   const paths: string[] = [];
 
   if ('schema' in pluginConfig && pluginConfig.tadaOutputLocation) {
-    paths.push(pluginConfig.tadaOutputLocation);
-  } else {
-    // Multiple schemas aren't supported in this context
+    paths.push(path.resolve(rootPath, pluginConfig.tadaOutputLocation));
+  } else if ('schemas' in pluginConfig) {
+    for (const schemaConfig of pluginConfig.schemas) {
+      if (schemaConfig.tadaOutputLocation) {
+        paths.push(path.resolve(rootPath, schemaConfig.tadaOutputLocation));
+      }
+    }
   }
 
   return paths;
@@ -200,18 +206,22 @@ function getTadaOutputPaths(pluginConfig: GraphQLSPConfig): string[] {
 function isTadaImport(
   importSpecifier: string,
   sourceFilePath: string,
-  tadaOutputLocationPaths: string[]
+  tadaOutputLocationPaths: string[],
+  resolveModulePath: (importSpecifier: string, fromPath: string) => string | undefined
 ): boolean {
+  const resolvedImportPath = resolveModulePath(importSpecifier, sourceFilePath);
+  if (resolvedImportPath) {
+    return tadaOutputLocationPaths.some(
+      (tadaOutputLocationPath) => resolvedImportPath === tadaOutputLocationPath
+    );
+  }
+
   if (importSpecifier.startsWith('.')) {
     const sourceDir = path.dirname(sourceFilePath);
     const absoluteImportPath = path.resolve(sourceDir, importSpecifier);
 
     return tadaOutputLocationPaths.some((tadaOutputLocationPath) => {
-      const absoluteTadaPath = path.resolve(tadaOutputLocationPath);
-      return (
-        absoluteImportPath === absoluteTadaPath ||
-        absoluteImportPath.startsWith(absoluteTadaPath + path.sep)
-      );
+      return absoluteImportPath === tadaOutputLocationPath;
     });
   }
 
@@ -328,6 +338,8 @@ export async function* _runTurbo(params: TurboParams): AsyncIterableIterator<Tur
             graphqlSourceFile,
             params.pluginConfig,
             factory.resolveModuleName.bind(factory),
+            factory.resolveModulePath.bind(factory),
+            params.rootPath,
             turboPath,
             !!factory.wasOriginallyNodeNext
           );

--- a/packages/cli-utils/src/ts/factory.ts
+++ b/packages/cli-utils/src/ts/factory.ts
@@ -44,6 +44,7 @@ export interface ProgramFactory {
 
   addVirtualFiles(files: readonly ts.SourceFile[]): Promise<this>;
 
+  resolveModulePath(importSpecifier: string, fromPath: string): string | undefined;
   resolveModuleName(importSpecifier: string, fromPath: string, toPath: string): string;
 
   build(): ProgramContainer;
@@ -185,6 +186,12 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
       return factory;
     },
 
+    resolveModulePath(importSpecifier: string, fromPath: string): string | undefined {
+      const resolved = ts.resolveModuleName(importSpecifier, fromPath, options, host.compilerHost);
+
+      return resolved.resolvedModule?.resolvedFileName;
+    },
+
     resolveModuleName(importSpecifier: string, fromPath: string, toPath: string): string {
       // For absolute imports (including path-mapped ones), keep them as-is
       // TypeScript's module resolution will handle them correctly
@@ -193,22 +200,13 @@ export const programFactory = (params: ProgramFactoryParams): ProgramFactory => 
       }
 
       // For relative imports, we need to adjust the path using the virtual compiler host
-      const compilerOptions = options;
-
       // First, resolve the import from the original location to get the actual file
-      const resolved = ts.resolveModuleName(
-        importSpecifier,
-        fromPath,
-        compilerOptions,
-        host.compilerHost
-      );
+      const resolvedFileName = factory.resolveModulePath(importSpecifier, fromPath);
 
-      if (resolved.resolvedModule) {
-        const targetFilePath = resolved.resolvedModule.resolvedFileName;
-
+      if (resolvedFileName) {
         // Now create a relative path from the new location (toPath) to the target
         const fromDir = path.dirname(toPath);
-        let relativePath = path.relative(fromDir, targetFilePath);
+        let relativePath = path.relative(fromDir, resolvedFileName);
 
         // Ensure it starts with ./ or ../
         if (!relativePath.startsWith('.')) {


### PR DESCRIPTION
Resolves #495

## Summary

The `tadaOutputLocation` file needs to be resolved against TypeScript then correctly filtered to prevent multiple output locations from being imported in the turbo output. This builds on an earlier fix and tightens up this logic.

## Set of changes

- use TS resolution and filter generated schema imports in turbo output
