### PR TITLE
fix(gql.tada): Extend tokenizer range to allow parsing slightly longer documents

### DIFF
--- a/.changeset/cool-kids-divide.md
+++ b/.changeset/cool-kids-divide.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': patch
+---
+
+Unroll tokenizer type into batch of 4 steps, which extends its range. This allows us to parse slightly longer documents with a very slight impact on parser performance. This means we're now bound by the parser/selection type depth, instead of by the tokenizer

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -32,3 +32,35 @@ testTypeHost('parses kitchen sink query (%o)', (options) => {
     })
   );
 });
+
+test('parses many inline fragments', () => {
+  const bigFragment = `
+    fragment Foo on A {
+      ${Array.from({ length: 130 }, (_, index) => `... on C${index} { f }`).join('\n')}
+    }
+  `;
+
+  const virtualHost = ts.createVirtualHost({
+    ...ts.readVirtualModule('expect-type'),
+    ...ts.readVirtualModule('@0no-co/graphql.web'),
+    'parser.ts': ts.readFileFromRoot('src/parser.ts'),
+    'tokenizer.ts': ts.readFileFromRoot('src/tokenizer.ts'),
+    'index.ts': `
+      import { expectTypeOf } from 'expect-type';
+      import { takeFragmentDefinition } from './parser';
+      import { tokenize } from './tokenizer';
+
+      const bigFragment = ${JSON.stringify(bigFragment)} as const;
+      type actual = takeFragmentDefinition<tokenize<typeof bigFragment>>;
+
+      expectTypeOf<actual>().not.toEqualTypeOf<void>();
+    `,
+  });
+
+  ts.runDiagnostics(
+    ts.createTypeHost({
+      rootNames: ['index.ts'],
+      host: virtualHost,
+    })
+  );
+});

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -118,53 +118,60 @@ interface _punctuator {
   ']': Token.BracketClose;
 }
 
+type tokenizeStep<State> =
+  State extends _state<'', any>
+    ? State
+    : State extends _state<infer In, infer Out>
+      ? In extends `#${string}`
+        ? _state<skipIgnored<In>, Out>
+        : In extends `${infer Char}${infer Rest}`
+          ? Char extends ignored
+            ? _state<skipIgnored<In>, Out>
+            : Char extends keyof _punctuator
+              ? _state<Rest, [...Out, _punctuator[Char]]>
+              : Char extends '"'
+                ? In extends `"""${infer In}`
+                  ? _state<skipBlockString<In>, [...Out, Token.BlockString]>
+                  : In extends `"${infer In}`
+                    ? _state<skipString<In>, [...Out, Token.String]>
+                    : void
+                : Char extends '.'
+                  ? In extends `...${infer In}`
+                    ? _state<In, [...Out, Token.Spread]>
+                    : void
+                  : Char extends '$'
+                    ? takeNameLiteralRec<'', Rest> extends _match<infer Match, infer In>
+                      ? _state<In, [...Out, VarTokenNode<Match>]>
+                      : void
+                    : Char extends '@'
+                      ? takeNameLiteralRec<'', Rest> extends _match<infer Match, infer In>
+                        ? _state<In, [...Out, DirectiveTokenNode<Match>]>
+                        : void
+                      : Char extends '-' | digit
+                        ? In extends `-${digit}${infer In}`
+                          ? skipFloat<skipDigits<In>> extends `${infer In}`
+                            ? _state<In, [...Out, Token.Float]>
+                            : _state<skipDigits<In>, [...Out, Token.Integer]>
+                          : In extends `${digit}${infer In}`
+                            ? skipFloat<skipDigits<In>> extends `${infer In}`
+                              ? _state<In, [...Out, Token.Float]>
+                              : _state<skipDigits<In>, [...Out, Token.Integer]>
+                            : void
+                        : Char extends letter | '_'
+                          ? takeNameLiteralRec<Char, Rest> extends _match<infer Match, infer In>
+                            ? _state<In, [...Out, NameTokenNode<Match>]>
+                            : void
+                          : void
+          : void
+      : void;
+
+type tokenizeStep4<State> = tokenizeStep<tokenizeStep<tokenizeStep<tokenizeStep<State>>>>;
+
 type tokenizeRec<State> =
   State extends _state<'', any>
     ? State['out']
-    : State extends _state<infer In, infer Out>
-      ? tokenizeRec<
-          In extends `#${string}`
-            ? _state<skipIgnored<In>, Out>
-            : In extends `${infer Char}${infer Rest}`
-              ? Char extends ignored
-                ? _state<skipIgnored<In>, Out>
-                : Char extends keyof _punctuator
-                  ? _state<Rest, [...Out, _punctuator[Char]]>
-                  : Char extends '"'
-                    ? In extends `"""${infer In}`
-                      ? _state<skipBlockString<In>, [...Out, Token.BlockString]>
-                      : In extends `"${infer In}`
-                        ? _state<skipString<In>, [...Out, Token.String]>
-                        : void
-                    : Char extends '.'
-                      ? In extends `...${infer In}`
-                        ? _state<In, [...Out, Token.Spread]>
-                        : void
-                      : Char extends '$'
-                        ? takeNameLiteralRec<'', Rest> extends _match<infer Match, infer In>
-                          ? _state<In, [...Out, VarTokenNode<Match>]>
-                          : void
-                        : Char extends '@'
-                          ? takeNameLiteralRec<'', Rest> extends _match<infer Match, infer In>
-                            ? _state<In, [...Out, DirectiveTokenNode<Match>]>
-                            : void
-                          : Char extends '-' | digit
-                            ? In extends `-${digit}${infer In}`
-                              ? skipFloat<skipDigits<In>> extends `${infer In}`
-                                ? _state<In, [...Out, Token.Float]>
-                                : _state<skipDigits<In>, [...Out, Token.Integer]>
-                              : In extends `${digit}${infer In}`
-                                ? skipFloat<skipDigits<In>> extends `${infer In}`
-                                  ? _state<In, [...Out, Token.Float]>
-                                  : _state<skipDigits<In>, [...Out, Token.Integer]>
-                                : void
-                            : Char extends letter | '_'
-                              ? takeNameLiteralRec<Char, Rest> extends _match<infer Match, infer In>
-                                ? _state<In, [...Out, NameTokenNode<Match>]>
-                                : void
-                              : void
-              : void
-        >
+    : State extends _state<any, any>
+      ? tokenizeRec<tokenizeStep4<State>>
       : [];
 
 export type tokenize<In extends string> = tokenizeRec<_state<In, []>>;


### PR DESCRIPTION
Resolves #484

## Summary

> [!NOTE]
> This isn't a full workaround for all issues that "explode" in complexity, which causes the TypeScript type checker to bail, but instead, makes the tokenizer not the limiting factor, as a compromise for reasonably sized documents.

Previously, due to performance changes, the tokenizer became the bounding factor for the size of documents `gql.tada` could parse within the type system. We can extend this range by unrolling a bathc of 4 tokenizer steps, which effectively is the performance sweet spot (only has a very modest impact), while extending the tokenizer range past what the parser/selection types limit us to.

This still means we're quite length restricted, but it resolves the bail-out seen in the linked issue, and extends the range of parsing slightly in most cases.

## Set of changes

- Apply batch of 4 steps to tokenizer, extending parsing range