### PR TITLE
chore(gql.tada,cli-utils): Update to `@0no-co/graphqlsp@^1.17.1`

### DIFF
--- a/.changeset/cruel-jars-decide.md
+++ b/.changeset/cruel-jars-decide.md
@@ -1,0 +1,6 @@
+---
+'@gql.tada/cli-utils': patch
+'gql.tada': patch
+---
+
+Update to `@0no-co/graphqlsp@^1.17.1`

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.3.2",
-    "@0no-co/graphqlsp": "^1.17.0",
+    "@0no-co/graphqlsp": "^1.17.1",
     "@gql.tada/cli-utils": "workspace:*",
     "@gql.tada/internal": "workspace:*"
   },

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -54,7 +54,7 @@
     "wonka": "^6.3.4"
   },
   "dependencies": {
-    "@0no-co/graphqlsp": "^1.17.0",
+    "@0no-co/graphqlsp": "^1.17.1",
     "@gql.tada/internal": "workspace:*",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
   typescript: ^5.9.3
-  '@0no-co/graphqlsp': ^1.17.0
+  '@0no-co/graphqlsp': ^1.17.1
 
 importers:
 
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2(graphql@16.9.0)
       '@0no-co/graphqlsp':
-        specifier: ^1.17.0
-        version: 1.17.0(graphql@16.9.0)(typescript@5.9.3)
+        specifier: ^1.17.1
+        version: 1.17.1(graphql@16.9.0)(typescript@5.9.3)
       '@gql.tada/cli-utils':
         specifier: workspace:*
         version: link:packages/cli-utils
@@ -141,8 +141,8 @@ importers:
         version: 4.1.0(@urql/core@5.0.6(graphql@16.9.0))(react@18.3.1)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.17.0
-        version: 1.17.0(graphql@16.9.0)(typescript@5.9.3)
+        specifier: ^1.17.1
+        version: 1.17.1(graphql@16.9.0)(typescript@5.9.3)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.3
@@ -175,8 +175,8 @@ importers:
         version: 4.2.18
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.17.0
-        version: 1.17.0(graphql@16.9.0)(typescript@5.9.3)
+        specifier: ^1.17.1
+        version: 1.17.1(graphql@16.9.0)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
         version: 3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))
@@ -206,8 +206,8 @@ importers:
         version: 3.4.38(typescript@5.9.3)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.17.0
-        version: 1.17.0(graphql@16.9.0)(typescript@5.9.3)
+        specifier: ^1.17.1
+        version: 1.17.1(graphql@16.9.0)(typescript@5.9.3)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.1.2(vite@5.4.1(@types/node@22.4.0)(terser@5.31.6))(vue@3.4.38(typescript@5.9.3))
@@ -224,8 +224,8 @@ importers:
   packages/cli-utils:
     dependencies:
       '@0no-co/graphqlsp':
-        specifier: ^1.17.0
-        version: 1.17.0(graphql@16.9.0)(typescript@5.9.3)
+        specifier: ^1.17.1
+        version: 1.17.1(graphql@16.9.0)(typescript@5.9.3)
       '@gql.tada/internal':
         specifier: workspace:*
         version: link:../internal
@@ -408,8 +408,8 @@ packages:
       graphql:
         optional: true
 
-  '@0no-co/graphqlsp@1.17.0':
-    resolution: {integrity: sha512-AXLpkO/ehrG/BDwifu7fqR3HQ3whHDC4Zd1/hCyAYqatFSHhuCLNr5C0LYZ3gkdKarhliplOv93L5VOfoCs+vw==}
+  '@0no-co/graphqlsp@1.17.1':
+    resolution: {integrity: sha512-grt2Nq6eBkFziaxYWrGcKQjuibTIX8df9kgn7KSKAFnI/mUajPhxBanbnIgQX8m1oEOEFf0OXz4vb2exOKro/A==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.9.3
@@ -3621,7 +3621,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.9.0
 
-  '@0no-co/graphqlsp@1.17.0(graphql@16.9.0)(typescript@5.9.3)':
+  '@0no-co/graphqlsp@1.17.1(graphql@16.9.0)(typescript@5.9.3)':
     dependencies:
       '@gql.tada/internal': link:packages/internal
       graphql: 16.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,4 +19,4 @@ overrides:
   '@gql.tada/internal': workspace:*
   astro-expressive-code: ^0.31.0
   typescript: ^5.9.3
-  '@0no-co/graphqlsp': ^1.17.0
+  '@0no-co/graphqlsp': ^1.17.1


### PR DESCRIPTION
## Summary

Mutes co-located fragment warnings when fragment is referenced in the current module.