### PR TITLE
feat(gql.tada): Add type-safe `readResult` testing function

### DIFF
--- a/.changeset/dark-aliens-melt.md
+++ b/.changeset/dark-aliens-melt.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Add typed `readResult` testing utility, which, unlike `unsafe_readResult`, accepts fragments as an array and then becomes fully typed.

--- a/.changeset/honest-paws-press.md
+++ b/.changeset/honest-paws-press.md
@@ -1,0 +1,5 @@
+---
+'gql.tada': minor
+---
+
+Move testing functions API to `gql.tada/testing`, increasing separation. This isn't a breaking change as `maskFragments` and `unsafe_readResult` are (for now) re-exported from the main entrypoint

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 /cli
 /internal
 /ts-plugin
+/testing

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "README.md",
     "cli/",
     "ts-plugin/",
+    "testing/",
     "bin/",
     "dist/"
   ],
@@ -38,6 +39,12 @@
       "import": "./dist/gql-tada-internal.mjs",
       "require": "./dist/gql-tada-internal.js",
       "source": "./src/internal/index.ts"
+    },
+    "./testing": {
+      "types": "./dist/gql-tada-testing.d.ts",
+      "import": "./dist/gql-tada-testing.mjs",
+      "require": "./dist/gql-tada-testing.js",
+      "source": "./src/testing.ts"
     },
     "./ts-plugin": {
       "types": "./dist/gql-tada-ts-plugin.d.ts",

--- a/src/__tests__/testing.bench.ts
+++ b/src/__tests__/testing.bench.ts
@@ -1,0 +1,84 @@
+import { describe, bench } from 'vitest';
+import * as ts from './tsHarness';
+
+const documents = `
+  import { initGraphQLTada } from './api';
+  import { simpleIntrospection } from './simpleIntrospection';
+
+  const graphql = initGraphQLTada<{ introspection: simpleIntrospection; }>();
+
+  export const authorFragment = graphql(\`
+    fragment AuthorFields on Author {
+      name
+    }
+  \`);
+
+  export const todoFragment = graphql(\`
+    fragment TodoFields on Todo {
+      id
+      author {
+        ...AuthorFields
+      }
+    }
+  \`, [authorFragment]);
+
+  export const query = graphql(\`
+    query {
+      todos {
+        id
+        ...TodoFields
+      }
+    }
+  \`, [todoFragment]);
+`;
+
+describe('readResult', () => {
+  // Control: building the documents without `readResult`, so a regression here
+  // would point at regular document creation rather than the unmasking machinery.
+  const controlHost = ts.createVirtualHost({
+    ...ts.readVirtualModule('@0no-co/graphql.web'),
+    ...ts.readSourceFolders(['.']),
+    'simpleIntrospection.ts': ts.readFileFromRoot('src/__tests__/fixtures/simpleIntrospection.ts'),
+    'index.ts': `
+      import { ResultOf } from './api';
+      import { query } from './documents';
+      const result: ResultOf<typeof query> = {} as any;
+    `,
+    'documents.ts': documents,
+  });
+
+  const controlTypeHost = ts.createTypeHost({
+    rootNames: ['index.ts'],
+    host: controlHost,
+  });
+
+  bench('create nested query (no readResult)', () => {
+    ts.runDiagnostics(controlTypeHost);
+  });
+
+  const readResultHost = ts.createVirtualHost({
+    ...ts.readVirtualModule('@0no-co/graphql.web'),
+    ...ts.readSourceFolders(['.']),
+    'simpleIntrospection.ts': ts.readFileFromRoot('src/__tests__/fixtures/simpleIntrospection.ts'),
+    'index.ts': `
+      import { readResult } from './testing';
+      import { authorFragment, todoFragment, query } from './documents';
+
+      const result = readResult(
+        query,
+        { todos: [{ id: 'id', author: { name: 'name' } }] },
+        [todoFragment, authorFragment]
+      );
+    `,
+    'documents.ts': documents,
+  });
+
+  const readResultTypeHost = ts.createTypeHost({
+    rootNames: ['index.ts'],
+    host: readResultHost,
+  });
+
+  bench('readResult with nested fragments', () => {
+    ts.runDiagnostics(readResultTypeHost);
+  });
+});

--- a/src/__tests__/testing.test-d.ts
+++ b/src/__tests__/testing.test-d.ts
@@ -1,0 +1,173 @@
+import { describe, it, expectTypeOf } from 'vitest';
+
+import type { simpleIntrospection } from './fixtures/simpleIntrospection';
+
+import { initGraphQLTada } from '../api';
+import type { ResultOf } from '../api';
+import { readResult, maskFragments, unsafe_readResult } from '../testing';
+
+const graphql = initGraphQLTada<{ introspection: simpleIntrospection }>();
+
+const authorFragment = graphql(`
+  fragment AuthorFields on Author {
+    name
+  }
+`);
+
+const todoFragment = graphql(
+  `
+    fragment TodoFields on Todo {
+      id
+      author {
+        ...AuthorFields
+      }
+    }
+  `,
+  [authorFragment]
+);
+
+const query = graphql(
+  `
+    query Test {
+      todos {
+        id
+        ...TodoFields
+      }
+    }
+  `,
+  [todoFragment]
+);
+
+describe('readResult', () => {
+  it('re-exports the testing helpers from `gql.tada/testing`', () => {
+    expectTypeOf(readResult).toBeFunction();
+    expectTypeOf(maskFragments).toBeFunction();
+    expectTypeOf(unsafe_readResult).toBeFunction();
+  });
+
+  it('reads a query with a single (direct) fragment', () => {
+    const directFragment = graphql(`
+      fragment Fields on Todo {
+        fields: id
+      }
+    `);
+
+    const directQuery = graphql(
+      `
+        query Test {
+          todos {
+            id
+            ...Fields
+          }
+        }
+      `,
+      [directFragment]
+    );
+
+    const result = readResult(directQuery, { todos: [{ id: 'id', fields: 'id' }] }, [
+      directFragment,
+    ]);
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<typeof directQuery>>();
+  });
+
+  it('reads nested fragments (a fragment that spreads another fragment)', () => {
+    const result = readResult(query, { todos: [{ id: 'id', author: { name: 'name' } }] }, [
+      todoFragment,
+      authorFragment,
+    ]);
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<typeof query>>();
+  });
+
+  it('reads nullable nested fragment data', () => {
+    const result = readResult(query, { todos: [{ id: 'id', author: null }, null] }, [
+      todoFragment,
+      authorFragment,
+    ]);
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<typeof query>>();
+  });
+
+  it('reads unmasked (@_unmask) nested fragments', () => {
+    const unmaskedFragment = graphql(`
+      fragment Fields on Todo @_unmask {
+        text
+      }
+    `);
+
+    const unmaskedQuery = graphql(
+      `
+        query Test {
+          todos {
+            id
+            ...Fields
+          }
+        }
+      `,
+      [unmaskedFragment]
+    );
+
+    const result = readResult(unmaskedQuery, { todos: [{ id: 'id', text: 'text' }] }, [
+      unmaskedFragment,
+    ]);
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<typeof unmaskedQuery>>();
+  });
+
+  it('errors when a nested fragment field has the wrong type', () => {
+    readResult(
+      query,
+      {
+        // @ts-expect-error - `author.name` must be a string
+        todos: [{ id: 'id', author: { name: 42 } }],
+      },
+      [todoFragment, authorFragment]
+    );
+  });
+
+  it('errors when a nested fragment field is missing', () => {
+    readResult(
+      query,
+      {
+        // @ts-expect-error - `author.name` is missing
+        todos: [{ id: 'id', author: {} }],
+      },
+      [todoFragment, authorFragment]
+    );
+  });
+
+  it('keeps a fragment masked when it is left out of the fragments list', () => {
+    readResult(
+      query,
+      {
+        // @ts-expect-error - `AuthorFields` is still masked, so inlined data is rejected
+        todos: [{ id: 'id', author: { name: 'name' } }],
+      },
+      [todoFragment]
+    );
+  });
+
+  it('treats an empty fragments list as everything staying masked', () => {
+    readResult(
+      query,
+      {
+        // @ts-expect-error - `TodoFields` is still masked, so inlined data is rejected
+        todos: [{ id: 'id' }],
+      },
+      []
+    );
+  });
+
+  it('accepts masked data for a fragment left out of the fragments list', () => {
+    const result = readResult(
+      query,
+      {
+        todos: [{ id: 'id', author: maskFragments([authorFragment], { name: 'name' }) }],
+      },
+      [todoFragment]
+    );
+
+    expectTypeOf<typeof result>().toEqualTypeOf<ResultOf<typeof query>>();
+  });
+});

--- a/src/__tests__/testing.test.ts
+++ b/src/__tests__/testing.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { initGraphQLTada } from '../api';
+import { readResult, maskFragments, unsafe_readResult } from '../testing';
+
+const graphql = initGraphQLTada<{
+  introspection: import('./fixtures/simpleIntrospection').simpleIntrospection;
+}>();
+
+describe('readResult', () => {
+  it('re-exports the testing helpers', () => {
+    expect(typeof readResult).toBe('function');
+    expect(typeof maskFragments).toBe('function');
+    expect(typeof unsafe_readResult).toBe('function');
+  });
+
+  it('returns the passed data unchanged', () => {
+    const authorFragment = graphql(`
+      fragment AuthorFields on Author {
+        name
+      }
+    `);
+
+    const todoFragment = graphql(
+      `
+        fragment TodoFields on Todo {
+          id
+          author {
+            ...AuthorFields
+          }
+        }
+      `,
+      [authorFragment]
+    );
+
+    const query = graphql(
+      `
+        query Test {
+          todos {
+            id
+            ...TodoFields
+          }
+        }
+      `,
+      [todoFragment]
+    );
+
+    const data = { todos: [{ id: 'id', author: { name: 'name' } }] };
+    const result = readResult(query, data, [todoFragment, authorFragment]);
+
+    expect(result).toBe(data);
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,14 +14,13 @@ import type {
   FragmentShape,
   getFragmentsOfDocuments,
   decorateFragmentDef,
-  omitFragmentRefsRec,
   makeFragmentRef,
 } from './namespace';
 
 import type { getDocumentType } from './selection';
 import type { parseDocument, DocumentNodeLike } from './parser';
 import type { getVariablesType, getScalarType } from './variables';
-import type { obj, matchOr, writable, DocumentDecoration } from './utils';
+import type { matchOr, writable, DocumentDecoration } from './utils';
 import { concatLocSources } from './utils';
 
 /** Abstract configuration type input for your schema and scalars.
@@ -513,20 +512,6 @@ type resultOfT<Document extends FragmentShape, T = unknown> =
       : Result
     : never;
 
-type resultOfFragmentsRec<
-  Fragments extends readonly any[],
-  Result = {},
-> = Fragments extends readonly [infer Fragment, ...infer Rest]
-  ? resultOfFragmentsRec<Rest, ResultOf<Fragment> & Result>
-  : Result;
-
-type fragmentRefsOfFragmentsRec<
-  Fragments extends readonly any[],
-  FragmentRefs = {},
-> = Fragments extends readonly [infer Fragment, ...infer Rest]
-  ? fragmentRefsOfFragmentsRec<Rest, makeFragmentRef<Fragment> & FragmentRefs>
-  : obj<FragmentRefs>;
-
 /** Unmasks a fragment mask for a given fragment document and data.
  *
  * @param _document - A GraphQL document of a fragment, created using {@link graphql}.
@@ -652,121 +637,10 @@ function readFragment(...args: [unknown] | [unknown, unknown]) {
   return args.length === 2 ? args[1] : args[0];
 }
 
-/** For testing, masks fragment data for given data and fragments.
- *
- * @param _fragments - A list of GraphQL documents of fragments, created using {@link graphql}.
- * @param data - The combined result data of the fragments, which can be wrapped in arrays.
- * @returns The masked data of the fragments.
- *
- * @remarks
- * When creating test data, you may define data for fragments that’s unmasked, making it
- * unusable in parent fragments or queries that require masked data.
- *
- * This means that you may have to use {@link maskFragments} to mask your data first
- * for TypeScript to not report an error.
- *
- * @example
- * ```
- * import { FragmentOf, ResultOf, graphql, maskFragments } from 'gql.tada';
- *
- * const bookFragment = graphql(`
- *   fragment BookComponent on Book {
- *     id
- *     title
- *   }
- * `);
- *
- * const data = maskFragments([bookFragment], { id: 'id', title: 'book' });
- * ```
- *
- * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
- */
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments>
-): fragmentRefsOfFragmentsRec<Fragments>;
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments> | null
-): fragmentRefsOfFragmentsRec<Fragments> | null;
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments> | undefined
-): fragmentRefsOfFragmentsRec<Fragments> | undefined;
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: resultOfFragmentsRec<Fragments> | null | undefined
-): fragmentRefsOfFragmentsRec<Fragments> | null | undefined;
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: readonly resultOfFragmentsRec<Fragments>[]
-): readonly fragmentRefsOfFragmentsRec<Fragments>[];
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: readonly (resultOfFragmentsRec<Fragments> | null)[]
-): readonly (fragmentRefsOfFragmentsRec<Fragments> | null)[];
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: readonly (resultOfFragmentsRec<Fragments> | undefined)[]
-): readonly (fragmentRefsOfFragmentsRec<Fragments> | undefined)[];
-function maskFragments<const Fragments extends readonly FragmentShape[]>(
-  _fragments: Fragments,
-  fragment: readonly (resultOfFragmentsRec<Fragments> | null | undefined)[]
-): readonly (fragmentRefsOfFragmentsRec<Fragments> | null | undefined)[];
-function maskFragments(_fragments: unknown, data: unknown) {
-  return data;
-}
-
-/** For testing, converts document data without fragment refs to their result type.
- *
- * @param _document - A GraphQL document, created using {@link graphql}.
- * @param data - The result data of the GraphQL document with optional fragment refs.
- * @returns The masked result data of the document.
- *
- * @remarks
- * When creating test data, you may define data for documents that’s unmasked, but
- * need to cast the data to match the result type of your document.
- *
- * This means that you may have to use {@link unsafe_readResult} to cast
- * them to the result type, instead of doing `as any as ResultOf<typeof document>`.
- *
- * This function is inherently unsafe, since it doesn't check that your document
- * actually contains the masked fragment data!
- *
- * @example
- * ```
- * import { FragmentOf, ResultOf, graphql, unsafe_readResult } from 'gql.tada';
- *
- * const bookFragment = graphql(`
- *   fragment BookComponent on Book {
- *     id
- *     title
- *   }
- * `);
- *
- * const query = graphql(`
- *   query {
- *     book {
- *       ...BookComponent
- *     }
- *   }
- * `, [bookFragment]);
- *
- * const data = unsafe_readResult(query, { book: { id: 'id', title: 'book' } });
- * ```
- *
- * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
- */
-function unsafe_readResult<
-  const Document extends DocumentDecoration<any, any>,
-  const Data extends omitFragmentRefsRec<ResultOf<Document>>,
->(_document: Document, data: Data): ResultOf<Document> {
-  return data as any;
-}
-
 const graphql: initGraphQLTada<setupSchema> = initGraphQLTada();
 
-export { parse, graphql, readFragment, maskFragments, unsafe_readResult };
+export { parse, graphql, readFragment };
+export { maskFragments, unsafe_readResult } from './testing';
 
 export type {
   setupCache,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,8 +1,6 @@
 import type { DocumentDecoration, obj, overload } from './utils';
-import type { $tada, FragmentShape } from './namespace';
+import type { $tada, FragmentShape, omitFragmentRefsRec, makeFragmentRef } from './namespace';
 import type { ResultOf } from './api';
-
-export { maskFragments, unsafe_readResult } from './api';
 
 type fragmentRegistryEntry<Fragment> =
   Fragment extends FragmentShape<infer Definition, infer Result>
@@ -117,4 +115,134 @@ function readResult(_document: unknown, data: unknown, _fragments?: unknown): un
   return data;
 }
 
-export { readResult };
+type resultOfFragmentsRec<
+  Fragments extends readonly any[],
+  Result = {},
+> = Fragments extends readonly [infer Fragment, ...infer Rest]
+  ? resultOfFragmentsRec<Rest, ResultOf<Fragment> & Result>
+  : Result;
+
+type fragmentRefsOfFragmentsRec<
+  Fragments extends readonly any[],
+  FragmentRefs = {},
+> = Fragments extends readonly [infer Fragment, ...infer Rest]
+  ? fragmentRefsOfFragmentsRec<Rest, makeFragmentRef<Fragment> & FragmentRefs>
+  : obj<FragmentRefs>;
+
+/** For testing, masks fragment data for given data and fragments.
+ *
+ * @param _fragments - A list of GraphQL documents of fragments, created using `graphql`.
+ * @param data - The combined result data of the fragments, which can be wrapped in arrays.
+ * @returns The masked data of the fragments.
+ *
+ * @remarks
+ * When creating test data, you may define data for fragments that’s unmasked, making it
+ * unusable in parent fragments or queries that require masked data.
+ *
+ * This means that you may have to use {@link maskFragments} to mask your data first
+ * for TypeScript to not report an error.
+ *
+ * @example
+ * ```
+ * import { FragmentOf, ResultOf, graphql } from 'gql.tada';
+ * import { maskFragments } from 'gql.tada/testing';
+ *
+ * const bookFragment = graphql(`
+ *   fragment BookComponent on Book {
+ *     id
+ *     title
+ *   }
+ * `);
+ *
+ * const data = maskFragments([bookFragment], { id: 'id', title: 'book' });
+ * ```
+ *
+ * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
+ */
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments>
+): fragmentRefsOfFragmentsRec<Fragments>;
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments> | null
+): fragmentRefsOfFragmentsRec<Fragments> | null;
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments> | undefined
+): fragmentRefsOfFragmentsRec<Fragments> | undefined;
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: resultOfFragmentsRec<Fragments> | null | undefined
+): fragmentRefsOfFragmentsRec<Fragments> | null | undefined;
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: readonly resultOfFragmentsRec<Fragments>[]
+): readonly fragmentRefsOfFragmentsRec<Fragments>[];
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: readonly (resultOfFragmentsRec<Fragments> | null)[]
+): readonly (fragmentRefsOfFragmentsRec<Fragments> | null)[];
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: readonly (resultOfFragmentsRec<Fragments> | undefined)[]
+): readonly (fragmentRefsOfFragmentsRec<Fragments> | undefined)[];
+function maskFragments<const Fragments extends readonly FragmentShape[]>(
+  _fragments: Fragments,
+  fragment: readonly (resultOfFragmentsRec<Fragments> | null | undefined)[]
+): readonly (fragmentRefsOfFragmentsRec<Fragments> | null | undefined)[];
+function maskFragments(_fragments: unknown, data: unknown) {
+  return data;
+}
+
+/** For testing, converts document data without fragment refs to their result type.
+ *
+ * @param _document - A GraphQL document, created using `graphql`.
+ * @param data - The result data of the GraphQL document with optional fragment refs.
+ * @returns The masked result data of the document.
+ *
+ * @remarks
+ * When creating test data, you may define data for documents that’s unmasked, but
+ * need to cast the data to match the result type of your document.
+ *
+ * This means that you may have to use {@link unsafe_readResult} to cast
+ * them to the result type, instead of doing `as any as ResultOf<typeof document>`.
+ *
+ * This function is inherently unsafe, since it doesn't check that your document
+ * actually contains the masked fragment data! For a type-safe alternative that
+ * resolves nested fragments, see {@link readResult}.
+ *
+ * @example
+ * ```
+ * import { FragmentOf, ResultOf, graphql } from 'gql.tada';
+ * import { unsafe_readResult } from 'gql.tada/testing';
+ *
+ * const bookFragment = graphql(`
+ *   fragment BookComponent on Book {
+ *     id
+ *     title
+ *   }
+ * `);
+ *
+ * const query = graphql(`
+ *   query {
+ *     book {
+ *       ...BookComponent
+ *     }
+ *   }
+ * `, [bookFragment]);
+ *
+ * const data = unsafe_readResult(query, { book: { id: 'id', title: 'book' } });
+ * ```
+ *
+ * @see {@link readResult} for a type-safe alternative that resolves nested fragments.
+ * @see {@link readFragment} for how to read from fragment masks (i.e. the reverse)
+ */
+function unsafe_readResult<
+  const Document extends DocumentDecoration<any, any>,
+  const Data extends omitFragmentRefsRec<ResultOf<Document>>,
+>(_document: Document, data: Data): ResultOf<Document> {
+  return data as any;
+}
+
+export { readResult, maskFragments, unsafe_readResult };

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,0 +1,120 @@
+import type { DocumentDecoration, obj, overload } from './utils';
+import type { $tada, FragmentShape } from './namespace';
+import type { ResultOf } from './api';
+
+export { maskFragments, unsafe_readResult } from './api';
+
+type fragmentRegistryEntry<Fragment> =
+  Fragment extends FragmentShape<infer Definition, infer Result>
+    ? { [Name in Definition['fragment']]: Result }
+    : never;
+
+type fragmentRegistry<Fragments extends readonly FragmentShape[]> = overload<
+  fragmentRegistryEntry<Fragments[number]> | {}
+>;
+
+type unmaskFragmentSpreadsRec<Refs, Registry> = overload<
+  keyof Refs extends infer Name
+    ? Name extends keyof Registry
+      ? unmaskFragmentRefsRec<Registry[Name], Registry>
+      : Name extends keyof Refs
+        ? { [$tada.fragmentRefs]: { [N in Name]: Refs[N] } }
+        : never
+    : never
+>;
+
+type unmaskFragmentRefsRec<Data, Registry> = Data extends readonly (infer Value)[]
+  ? readonly unmaskFragmentRefsRec<Value, Registry>[]
+  : Data extends null
+    ? null
+    : Data extends undefined
+      ? undefined
+      : Data extends { [$tada.fragmentRefs]: infer Refs }
+        ? obj<
+            {
+              [Key in Exclude<keyof Data, $tada.fragmentRefs>]: unmaskFragmentRefsRec<
+                Data[Key],
+                Registry
+              >;
+            } & unmaskFragmentSpreadsRec<Refs, Registry>
+          >
+        : Data extends object
+          ? { [Key in keyof Data]: unmaskFragmentRefsRec<Data[Key], Registry> }
+          : Data;
+
+/** For testing, converts document data to its result type, resolving nested fragments.
+ *
+ * @param _document - A GraphQL document, created using `graphql`.
+ * @param data - The result data of the document, with fragment data inlined.
+ * @param _fragments - A list of every fragment used in the document, transitively.
+ * @returns The result data, cast to the result type of the document.
+ *
+ * @remarks
+ * When a document spreads fragments, its result type only contains opaque
+ * references to them, rather than the fragments’ fields, which makes it hard to
+ * write a fixture for the full result.
+ *
+ * Unlike `unsafe_readResult`, which discards all fragment references and checks
+ * nothing nested inside them, `readResult` accepts the document’s fragments and
+ * recursively resolves their references, so your data is fully type-checked —
+ * including fragments that spread other fragments.
+ *
+ * Any fragment you leave out of the `fragments` argument stays masked, so a
+ * missing fragment surfaces as a still-masked reference rather than inlined data,
+ * and can be filled with `maskFragments` instead.
+ *
+ * Intended for tests, storybooks, fixtures, and cache updaters.
+ *
+ * @example
+ * ```
+ * import { graphql } from 'gql.tada';
+ * import { readResult } from 'gql.tada/testing';
+ *
+ * const authorFragment = graphql(`
+ *   fragment AuthorFields on Author {
+ *     name
+ *   }
+ * `);
+ *
+ * const todoFragment = graphql(`
+ *   fragment TodoFields on Todo {
+ *     id
+ *     author {
+ *       ...AuthorFields
+ *     }
+ *   }
+ * `, [authorFragment]);
+ *
+ * const query = graphql(`
+ *   query {
+ *     todos {
+ *       id
+ *       ...TodoFields
+ *     }
+ *   }
+ * `, [todoFragment]);
+ *
+ * const data = readResult(
+ *   query,
+ *   { todos: [{ id: 'id', author: { name: 'name' } }] },
+ *   [todoFragment, authorFragment]
+ * );
+ * ```
+ *
+ * @see {@link maskFragments} for masking a single level of fragment data.
+ * @see {@link unsafe_readResult} for the unsafe variant that performs no checks.
+ */
+function readResult<
+  const Document extends DocumentDecoration<any, any>,
+  const Fragments extends readonly FragmentShape[],
+>(
+  document: Document,
+  data: unmaskFragmentRefsRec<ResultOf<Document>, fragmentRegistry<Fragments>>,
+  fragments: Fragments
+): ResultOf<Document>;
+
+function readResult(_document: unknown, data: unknown, _fragments?: unknown): unknown {
+  return data;
+}
+
+export { readResult };

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -465,6 +465,85 @@ const data = unsafe_readResult(query, {
 
 ---
 
+### `readResult()`
+
+|                      | Description                                                         |
+| -------------------- | ------------------------------------------------------------------ |
+| `document` argument  | A GraphQL document, created using [`graphql()`](#graphql).         |
+| `data` argument      | The result data of the document, with fragment data inlined.       |
+| `fragments` argument | A list of every fragment used in the document, transitively.       |
+| returns              | The result data, typed as the document’s [result type](#resultof). |
+
+> [!NOTE]
+> `readResult()` is exported from `gql.tada/testing`, and is meant to be used
+> in tests, stories, fixtures, or cache updaters — not in your regular app code.
+
+When [`graphql()`](#graphql) composes fragments into a document, the result type
+only contains opaque references to those fragments, rather than the fragments’
+fields. This makes it hard to assemble a full result as “fake data”.
+
+Unlike [`unsafe_readResult()`](#unsafe_readresult), which discards all fragment
+references and doesn’t type check the data nested inside them, `readResult()` is
+type-safe. You pass it the fragments used in the document, and it recursively
+resolves their references, so the data you write is fully type checked — including
+data for nested fragments and fragments that themselves spread other fragments.
+
+Pass every fragment you’d like to inline — including fragments spread by other
+fragments — to the `fragments` argument. Any fragment you leave out stays masked
+in the expected data, merged into its surrounding object as a fragment reference.
+This keeps the result’s shape intact and makes it easy to spot which fragments
+are still missing, and lets you fill them with [`maskFragments()`](#maskfragments)
+instead.
+
+- [For masking a single level of fragment data, see `maskFragments()`.](#maskfragments)
+- [For the unsafe variant that performs no checks, see `unsafe_readResult()`.](#unsafe_readresult)
+
+#### Example
+
+```ts twoslash
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql } from 'gql.tada';
+import { readResult } from 'gql.tada/testing';
+
+const pokemonNameFragment = graphql(`
+  fragment PokemonName on Pokemon {
+    name
+  }
+`);
+
+const pokemonItemFragment = graphql(
+  `
+    fragment PokemonItem on Pokemon {
+      id
+      ...PokemonName
+    }
+  `,
+  [pokemonNameFragment]
+);
+
+const query = graphql(
+  `
+    query {
+      pokemon(id: "001") {
+        ...PokemonItem
+      }
+    }
+  `,
+  [pokemonItemFragment]
+);
+
+// @log: data is fully type-checked, including the nested fragment fields
+
+const data = readResult(
+  query,
+  { pokemon: { id: '001', name: 'Bulbasaur' } },
+  [pokemonItemFragment, pokemonNameFragment]
+);
+```
+
+---
+
 ### `initGraphQLTada()`
 
 |                 | Description                                                           |

--- a/website/reference/gql-tada-api.md
+++ b/website/reference/gql-tada-api.md
@@ -350,200 +350,6 @@ const getQuery = (data: ResultOf<typeof pokemonQuery>) => {
 
 ---
 
-### `maskFragments()`
-
-|                       | Description                                                                      |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `_fragments` argument | A list of GraphQL documents of fragments, created using [`graphql()`](#graphql). |
-| `data` argument       | The combined result data of the fragments, which can be wrapped in arrays.       |
-| returns               | The masked data of the fragments.                                                |
-
-> [!NOTE]
-> While useful, `maskFragments()` is mostly meant to be used in tests or as
-> an escape hatch to convert data to masked fragments.
->
-> You shouldn’t have to use it in your regular component code.
-
-When [`graphql()`](#graphql) is used to compose fragments into another fragment or
-operation, the resulting type will by default be masked, [unless the `@_unmask`
-directive is used.](../guides/fragment-colocation#fragment-masking)
-
-This means that when we’re writing tests or are creating “fake data” without
-inferring types from a full document, the types in TypeScript may not match,
-since our testing data will not be masked and will be equal to [the result type](#resultof)
-of the fragments.
-
-To address this, the `maskFragments` utility takes a list of fragments and masks data (or an array of data)
-to match the masked fragment types of the fragments.
-
-- [Read more about fragment masking on the “Writing GraphQL” page.](../get-started/writing-graphql#fragment-masking)
-- [For the reverse operation, see `readFragment()`.](#readfragment)
-
-#### Example
-
-```ts twoslash
-import './graphql/graphql-env.d.ts';
-// ---cut-before---
-import { graphql, maskFragments } from 'gql.tada';
-
-const pokemonItemFragment = graphql(`
-  fragment PokemonItem on Pokemon {
-    id
-    name
-  }
-`);
-
-const data = maskFragments([pokemonItemFragment], {
-  id: '001',
-  name: 'Bulbasaur',
-});
-```
-
----
-
-### `unsafe_readResult()`
-
-|                      | Description                                                          |
-| -------------------- | -------------------------------------------------------------------- |
-| `_document` argument | A GraphQL document, created using [`graphql()`](#graphql).           |
-| `data` argument      | The result data of the GraphQL document with optional fragment refs. |
-| returns              | The masked result data of the document.                              |
-
-> [!CAUTION]
-> Unlike, [`maskFragments()`](#maskfragments), this utility is unsafe, and
-> should only be used when you know that data matches the expected shape
-> of a GraphQL query you created.
->
-> While useful, this utility is only a slightly safer alternative to `as any`
-> and doesn’t type check the result shape against the masked fragments in your
-> document.
->
-> You shouldn’t have to use it in your regular app code.
-
-When [`graphql()`](#graphql) is used to compose fragments into a document,
-the resulting type will by default be masked, [unless the `@_unmask`
-directive is used.](../guides/fragment-colocation#fragment-masking)
-
-This means that when we’re writing tests and are creating “fake data”,
-for instance for a query, that we cannot convert this data to the query’s
-result type, if it contains masked fragment refs.
-
-To address this, the `unsafe_readResult` utility accepts the document and
-converts a query’s data to masked data.
-
-#### Example
-
-```ts twoslash
-import './graphql/graphql-env.d.ts';
-// ---cut-before---
-import { graphql, unsafe_readResult } from 'gql.tada';
-
-const pokemonItemFragment = graphql(`
-  fragment PokemonItem on Pokemon {
-    id
-    name
-  }
-`);
-
-const query = graphql(
-  `
-    query {
-      pokemon(id: "001") {
-        ...PokemonItem
-      }
-    }
-  `,
-  [pokemonItemFragment]
-);
-
-// @warn: data will be cast (unsafely!) to the result type
-
-const data = unsafe_readResult(query, {
-  pokemon: { id: '001', name: 'Bulbasaur' },
-});
-```
-
----
-
-### `readResult()`
-
-|                      | Description                                                         |
-| -------------------- | ------------------------------------------------------------------ |
-| `document` argument  | A GraphQL document, created using [`graphql()`](#graphql).         |
-| `data` argument      | The result data of the document, with fragment data inlined.       |
-| `fragments` argument | A list of every fragment used in the document, transitively.       |
-| returns              | The result data, typed as the document’s [result type](#resultof). |
-
-> [!NOTE]
-> `readResult()` is exported from `gql.tada/testing`, and is meant to be used
-> in tests, stories, fixtures, or cache updaters — not in your regular app code.
-
-When [`graphql()`](#graphql) composes fragments into a document, the result type
-only contains opaque references to those fragments, rather than the fragments’
-fields. This makes it hard to assemble a full result as “fake data”.
-
-Unlike [`unsafe_readResult()`](#unsafe_readresult), which discards all fragment
-references and doesn’t type check the data nested inside them, `readResult()` is
-type-safe. You pass it the fragments used in the document, and it recursively
-resolves their references, so the data you write is fully type checked — including
-data for nested fragments and fragments that themselves spread other fragments.
-
-Pass every fragment you’d like to inline — including fragments spread by other
-fragments — to the `fragments` argument. Any fragment you leave out stays masked
-in the expected data, merged into its surrounding object as a fragment reference.
-This keeps the result’s shape intact and makes it easy to spot which fragments
-are still missing, and lets you fill them with [`maskFragments()`](#maskfragments)
-instead.
-
-- [For masking a single level of fragment data, see `maskFragments()`.](#maskfragments)
-- [For the unsafe variant that performs no checks, see `unsafe_readResult()`.](#unsafe_readresult)
-
-#### Example
-
-```ts twoslash
-import './graphql/graphql-env.d.ts';
-// ---cut-before---
-import { graphql } from 'gql.tada';
-import { readResult } from 'gql.tada/testing';
-
-const pokemonNameFragment = graphql(`
-  fragment PokemonName on Pokemon {
-    name
-  }
-`);
-
-const pokemonItemFragment = graphql(
-  `
-    fragment PokemonItem on Pokemon {
-      id
-      ...PokemonName
-    }
-  `,
-  [pokemonNameFragment]
-);
-
-const query = graphql(
-  `
-    query {
-      pokemon(id: "001") {
-        ...PokemonItem
-      }
-    }
-  `,
-  [pokemonItemFragment]
-);
-
-// @log: data is fully type-checked, including the nested fragment fields
-
-const data = readResult(
-  query,
-  { pokemon: { id: '001', name: 'Bulbasaur' } },
-  [pokemonItemFragment, pokemonNameFragment]
-);
-```
-
----
-
 ### `initGraphQLTada()`
 
 |                 | Description                                                           |
@@ -720,3 +526,196 @@ enums, the `enumValues` defined by the schema will be used.
 
 The `disableMasking` flag may be set to `true` instead of using `@_unmask` on individual fragments
 and allows fragment masking to be disabled globally.
+
+## Testing Functions
+
+These functions are all exported from `gql.tada/testing`, and are meant for tests,
+stories, fixtures, or cache updaters, rather than your regular app code.
+
+### `maskFragments()`
+
+|                       | Description                                                                      |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `_fragments` argument | A list of GraphQL documents of fragments, created using [`graphql()`](#graphql). |
+| `data` argument       | The combined result data of the fragments, which can be wrapped in arrays.       |
+| returns               | The masked data of the fragments.                                                |
+
+> [!NOTE]
+> While useful, `maskFragments()` is mostly meant to be used in tests or as
+> an escape hatch to convert data to masked fragments.
+>
+> You shouldn’t have to use it in your regular component code.
+
+When [`graphql()`](#graphql) is used to compose fragments into another fragment or
+operation, the resulting type will by default be masked, [unless the `@_unmask`
+directive is used.](../guides/fragment-colocation#fragment-masking)
+
+This means that when we’re writing tests or are creating “fake data” without
+inferring types from a full document, the types in TypeScript may not match,
+since our testing data will not be masked and will be equal to [the result type](#resultof)
+of the fragments.
+
+To address this, the `maskFragments` utility takes a list of fragments and masks data (or an array of data)
+to match the masked fragment types of the fragments.
+
+- [Read more about fragment masking on the “Writing GraphQL” page.](../get-started/writing-graphql#fragment-masking)
+- [For the reverse operation, see `readFragment()`.](#readfragment)
+
+#### Example
+
+```ts twoslash
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql, maskFragments } from 'gql.tada';
+
+const pokemonItemFragment = graphql(`
+  fragment PokemonItem on Pokemon {
+    id
+    name
+  }
+`);
+
+const data = maskFragments([pokemonItemFragment], {
+  id: '001',
+  name: 'Bulbasaur',
+});
+```
+
+---
+
+### `unsafe_readResult()`
+
+|                      | Description                                                          |
+| -------------------- | -------------------------------------------------------------------- |
+| `_document` argument | A GraphQL document, created using [`graphql()`](#graphql).           |
+| `data` argument      | The result data of the GraphQL document with optional fragment refs. |
+| returns              | The masked result data of the document.                              |
+
+> [!CAUTION]
+> Unlike, [`maskFragments()`](#maskfragments), this utility is unsafe, and
+> should only be used when you know that data matches the expected shape
+> of a GraphQL query you created.
+>
+> While useful, this utility is only a slightly safer alternative to `as any`
+> and doesn’t type check the result shape against the masked fragments in your
+> document.
+>
+> You shouldn’t have to use it in your regular app code.
+
+When [`graphql()`](#graphql) is used to compose fragments into a document,
+the resulting type will by default be masked, [unless the `@_unmask`
+directive is used.](../guides/fragment-colocation#fragment-masking)
+
+This means that when we’re writing tests and are creating “fake data”,
+for instance for a query, that we cannot convert this data to the query’s
+result type, if it contains masked fragment refs.
+
+To address this, the `unsafe_readResult` utility accepts the document and
+converts a query’s data to masked data.
+
+#### Example
+
+```ts twoslash
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql, unsafe_readResult } from 'gql.tada';
+
+const pokemonItemFragment = graphql(`
+  fragment PokemonItem on Pokemon {
+    id
+    name
+  }
+`);
+
+const query = graphql(
+  `
+    query {
+      pokemon(id: "001") {
+        ...PokemonItem
+      }
+    }
+  `,
+  [pokemonItemFragment]
+);
+
+// @warn: data will be cast (unsafely!) to the result type
+
+const data = unsafe_readResult(query, {
+  pokemon: { id: '001', name: 'Bulbasaur' },
+});
+```
+
+---
+
+### `readResult()`
+
+|                      | Description                                                         |
+| -------------------- | ------------------------------------------------------------------ |
+| `document` argument  | A GraphQL document, created using [`graphql()`](#graphql).         |
+| `data` argument      | The result data of the document, with fragment data inlined.       |
+| `fragments` argument | A list of every fragment used in the document, transitively.       |
+| returns              | The result data, typed as the document’s [result type](#resultof). |
+
+When [`graphql()`](#graphql) composes fragments into a document, the result type
+only contains opaque references to those fragments, rather than the fragments’
+fields. This makes it hard to assemble a full result as “fake data”.
+
+Unlike [`unsafe_readResult()`](#unsafe_readresult), which discards all fragment
+references and doesn’t type check the data nested inside them, `readResult()` is
+type-safe. You pass it the fragments used in the document, and it recursively
+resolves their references, so the data you write is fully type checked — including
+data for nested fragments and fragments that themselves spread other fragments.
+
+Pass every fragment you’d like to inline — including fragments spread by other
+fragments — to the `fragments` argument. Any fragment you leave out stays masked
+in the expected data, merged into its surrounding object as a fragment reference.
+This keeps the result’s shape intact and makes it easy to spot which fragments
+are still missing, and lets you fill them with [`maskFragments()`](#maskfragments)
+instead.
+
+- [For masking a single level of fragment data, see `maskFragments()`.](#maskfragments)
+- [For the unsafe variant that performs no checks, see `unsafe_readResult()`.](#unsafe_readresult)
+
+#### Example
+
+```ts twoslash
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql } from 'gql.tada';
+import { readResult } from 'gql.tada/testing';
+
+const pokemonNameFragment = graphql(`
+  fragment PokemonName on Pokemon {
+    name
+  }
+`);
+
+const pokemonItemFragment = graphql(
+  `
+    fragment PokemonItem on Pokemon {
+      id
+      ...PokemonName
+    }
+  `,
+  [pokemonNameFragment]
+);
+
+const query = graphql(
+  `
+    query {
+      pokemon(id: "001") {
+        ...PokemonItem
+      }
+    }
+  `,
+  [pokemonItemFragment]
+);
+
+// @log: data is fully type-checked, including the nested fragment fields
+
+const data = readResult(
+  query,
+  { pokemon: { id: '001', name: 'Bulbasaur' } },
+  [pokemonItemFragment, pokemonNameFragment]
+);
+```


### PR DESCRIPTION
Resolves #273

## Summary

This implements the type-safe `readResult` helper (as per the outcome of the linked issue). This, unlike `unsafe_readResult`, checks all nested, masked fragment types by unwrapping them, via an additionally provided fragments array, mirroring fragment spreading.

When a fragment is left out, it remains masked in the input type that's inferred.

All testing utilities will now live at `gql.tada/testing` (existing ones are for now re-exported in the main entrypoint), and the docs have a separate section for them.

## Set of changes

- Add `readResult` in new `gql.tada/testing` entrypoint
- Move `maskFragments` and `unsafe_readResult` over then reexport from main entrypoint
- Add documentation and tests