### PR TITLE
feat(cli-utils,internal): Preserve comment preamble in output files

### DIFF
--- a/.changeset/modern-beans-decide.md
+++ b/.changeset/modern-beans-decide.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Preserve preamble headers in turbo and output introspection file

--- a/.changeset/sad-insects-count.md
+++ b/.changeset/sad-insects-count.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/internal': minor
+---
+
+Add `extractIntrospectionHeader` and accept `preamble` option in `outputIntrospectionFile`

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -1,10 +1,15 @@
 import * as path from 'node:path';
 
-import { loadRef, minifyIntrospection, outputIntrospectionFile } from '@gql.tada/internal';
+import {
+  loadRef,
+  minifyIntrospection,
+  outputIntrospectionFile,
+  extractIntrospectionHeader,
+} from '@gql.tada/internal';
 
 import type { TTY, ComposeInput } from '../../term';
 import type { ProjectContext, WriteTarget } from '../shared';
-import { loadProjects, writeOutput } from '../shared';
+import { loadProjects, writeOutput, readOutput } from '../shared';
 import * as logger from './logger';
 
 export interface OutputOptions {
@@ -89,6 +94,7 @@ async function* runProject(
       );
     }
 
+    const existing = await readOutput(destination);
     let contents: string;
     try {
       contents = outputIntrospectionFile(minifyIntrospection(schema.introspection), {
@@ -99,6 +105,7 @@ async function* runProject(
               ? '.ts'
               : '.d.ts',
         shouldPreprocess: !opts.disablePreprocessing,
+        preamble: existing ? extractIntrospectionHeader(existing) || undefined : undefined,
       });
     } catch (error) {
       throw logger.externalError('Could not generate introspection output', error);
@@ -139,11 +146,14 @@ async function* runProject(
         );
       }
 
+      const destination = path.resolve(projectPath, schema.tadaOutputLocation);
+      const existing = await readOutput(destination);
       let contents: string;
       try {
         contents = outputIntrospectionFile(minifyIntrospection(schema.introspection), {
           fileType: schema.tadaOutputLocation,
           shouldPreprocess: !opts.disablePreprocessing,
+          preamble: existing ? extractIntrospectionHeader(existing) || undefined : undefined,
         });
       } catch (error) {
         throw logger.externalError(
@@ -153,7 +163,7 @@ async function* runProject(
       }
 
       try {
-        await writeOutput(path.resolve(projectPath, schema.tadaOutputLocation), contents);
+        await writeOutput(destination, contents);
       } catch (error) {
         throw logger.externalError(
           `Something went wrong while writing the '${schemaName}' schema's output`,

--- a/packages/cli-utils/src/commands/shared/utils.ts
+++ b/packages/cli-utils/src/commands/shared/utils.ts
@@ -35,6 +35,16 @@ const touchFile = async (file: PathLike): Promise<void> => {
 
 export type WriteTarget = PathLike | WriteStream;
 
+/** Reads the current contents of a file target, or `undefined` for streams or missing files. */
+export const readOutput = async (target: WriteTarget): Promise<string | undefined> => {
+  if (target && typeof target === 'object' && 'writable' in target) return undefined;
+  try {
+    return await fs.readFile(target, 'utf8');
+  } catch {
+    return undefined;
+  }
+};
+
 /** Writes a file to a swapfile then moves it into place to prevent excess change events. */
 export const writeOutput = async (target: WriteTarget, contents: string): Promise<void> => {
   if (target && typeof target === 'object' && 'writable' in target) {

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 
+import { extractIntrospectionHeader } from '@gql.tada/internal';
+
 import type { TTY, ComposeInput } from '../../term';
 import type { ProjectContext, WriteTarget } from '../shared';
-import { loadProjects, writeOutput } from '../shared';
+import { loadProjects, writeOutput, readOutput } from '../shared';
 import type { TurboDocument, GraphQLSourceFile, TurboPath } from './types';
 import * as logger from './logger';
 
@@ -169,7 +171,8 @@ async function* runProject(
     }
 
     try {
-      const contents = createCacheContents(documents, graphqlSources, destination!);
+      const existing = await readOutput(destination!);
+      const contents = createCacheContents(documents, graphqlSources, destination!, existing);
       await writeOutput(destination!, contents);
     } catch (error) {
       throw logger.externalError('Something went wrong while writing the type cache file', error);
@@ -213,7 +216,8 @@ async function* runProject(
           }
         }
         const destination = path.resolve(projectPath, tadaTurboLocation);
-        const contents = createCacheContents(cache, graphqlSources, destination);
+        const existing = await readOutput(destination);
+        const contents = createCacheContents(cache, graphqlSources, destination, existing);
         await writeOutput(destination, contents);
       } catch (error) {
         throw logger.externalError(
@@ -237,8 +241,10 @@ async function* runProject(
 function createCacheContents(
   cache: TurboDocument[],
   graphqlSources: GraphQLSourceFile[],
-  turboDestination: WriteTarget
+  turboDestination: WriteTarget,
+  existing?: string
 ): string {
+  const preamble = (existing && extractIntrospectionHeader(existing)) || PREAMBLE_IGNORE;
   const documentsByKey = new Map<string, TurboDocument>();
   for (const document of cache) documentsByKey.set(document.argumentKey, document);
 
@@ -278,7 +284,7 @@ function createCacheContents(
   }
 
   return (
-    PREAMBLE_IGNORE +
+    preamble +
     imports +
     '\n' +
     "declare module 'gql.tada' {\n" +

--- a/packages/internal/src/index.ts
+++ b/packages/internal/src/index.ts
@@ -7,4 +7,5 @@ export {
   minifyIntrospection,
   preprocessIntrospection,
   outputIntrospectionFile,
+  extractIntrospectionHeader,
 } from './introspection';

--- a/packages/internal/src/introspection/output.ts
+++ b/packages/internal/src/introspection/output.ts
@@ -10,17 +10,52 @@ const TYPES_VAR = 'introspection_types';
 const stringifyJson = (input: unknown | string): string =>
   typeof input === 'string' ? input : JSON.stringify(input, null, 2);
 
+const ANNOTATION_SIGNATURE = 'An IntrospectionQuery representation';
+
+/** Extracts the leading comment header of a previously generated file, so it
+ * can be preserved across regenerations. Returns `null` when no custom header
+ * is present (or when only the generated annotation remains). */
+export function extractIntrospectionHeader(contents: string): string | null {
+  const lines = contents.split('\n');
+  const header: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (inBlock) {
+      header.push(line);
+      if (trimmed.includes('*/')) inBlock = false;
+    } else if (trimmed === '') {
+      break;
+    } else if (trimmed.startsWith('//')) {
+      header.push(line);
+    } else if (trimmed.startsWith('/*')) {
+      header.push(line);
+      if (!trimmed.includes('*/')) inBlock = true;
+    } else {
+      break;
+    }
+  }
+  if (!header.length || inBlock) return null;
+  const result = header.join('\n');
+  if (result.includes(ANNOTATION_SIGNATURE)) return null;
+  return result + '\n';
+}
+
 interface OutputIntrospectionFileOptions {
   fileType: '.ts' | '.d.ts' | string;
   shouldPreprocess?: boolean;
+  /** A custom leading comment header used in place of the default preamble,
+   * typically extracted from a prior file via `extractIntrospectionHeader`. */
+  preamble?: string;
 }
 
 export function outputIntrospectionFile(
   introspection: IntrospectionQuery | IntrospectionResult,
   opts: OutputIntrospectionFileOptions
 ): string {
+  const preamble = opts.preamble || PREAMBLE_IGNORE;
   if (/\.d\.ts$/.test(opts.fileType)) {
-    const out = [PREAMBLE_IGNORE];
+    const out = [preamble];
     if (typeof introspection !== 'string' && opts.shouldPreprocess) {
       // NOTE: When types aren't exported separately, composite tsconfigs
       // will output a serialization error in diagnostics
@@ -53,7 +88,7 @@ export function outputIntrospectionFile(
   } else if (/\.ts$/.test(opts.fileType)) {
     const json = stringifyJson(introspection);
     return [
-      PREAMBLE_IGNORE,
+      preamble,
       ANNOTATION_TS,
       `const introspection = ${json} as const;\n`,
       'export { introspection };',


### PR DESCRIPTION
Resolves #425

## Summary

This aims to preserve preamble comments as-is in the output introspection and turbo files. Since a user may customise them for different linters or formatters, we'd like the comments leading into the generated files to be preserved.

This is an alternative solution to #425 that doesn't add any extra new options API surface, and instead, allows partial customisation, how it might be expected.

> [!NOTE]
> This will have to be wired up in graphqlsp

## Set of changes

- Add `extractIntrospectionHeader` to `@gql.tada/internal`
- Accept `preamble` option optionally for `outputIntrospectionFile`
- Use new utilities to preserve preamble headers in introspection and turbo output files