### PR TITLE
docs: Add "Testing" & "Recipebook" pages, add "Abstract Types" doc section

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -207,6 +207,14 @@ export default defineConfig({
               text: 'Multiple Schemas',
               link: '/guides/multiple-schemas',
             },
+            {
+              text: 'Testing',
+              link: '/guides/testing',
+            },
+            {
+              text: 'Recipebook',
+              link: '/guides/recipebook',
+            },
           ],
         },
         {

--- a/website/get-started/writing-graphql.md
+++ b/website/get-started/writing-graphql.md
@@ -638,3 +638,72 @@ export type SearchPokemon = ReturnType<typeof graphql.scalar<'SearchPokemon'>>;
 
 Reusing input types is common when we create local state that isn't immediately
 used as operation variables, or doesn't match the variables types of some operations.
+
+## Abstract Types
+
+When a field returns an abstract type (a union or interface) we select its
+possible types using inline fragments (`... on Type`). Selecting `__typename`
+alongside them gives TypeScript a discriminant it can use to narrow the result
+to a single variant.
+
+```ts twoslash
+import { initGraphQLTada, type ResultOf } from 'gql.tada';
+
+type introspection = {
+  name: 'sample';
+  query: 'Query';
+  mutation: never;
+  subscription: never;
+  types: {
+    String: { kind: 'SCALAR'; name: 'String' };
+    Query: {
+      kind: 'OBJECT';
+      name: 'Query';
+      fields: {
+        search: { name: 'search'; type: { kind: 'UNION'; name: 'SearchResult'; ofType: null } };
+      };
+    };
+    SearchResult: { kind: 'UNION'; name: 'SearchResult'; fields: {}; possibleTypes: 'Article' | 'Photo' };
+    Article: {
+      kind: 'OBJECT';
+      name: 'Article';
+      fields: {
+        title: { name: 'title'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null } } };
+      };
+    };
+    Photo: {
+      kind: 'OBJECT';
+      name: 'Photo';
+      fields: {
+        url: { name: 'url'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null } } };
+      };
+    };
+  };
+};
+
+const graphql = initGraphQLTada<{ introspection: introspection }>();
+// ---cut-before---
+const SearchQuery = graphql(`
+  query Search {
+    search {
+      __typename
+      ... on Article { title }
+      ... on Photo { url }
+    }
+  }
+`);
+
+declare const data: ResultOf<typeof SearchQuery>;
+
+if (data.search?.__typename === 'Article') {
+// @annotate: data.search is narrowed to Article here, so title is available
+
+  data.search.title;
+}
+```
+
+Without `__typename` in the selection set, we have no discriminant to let TypeScript
+tell the variants apart. In some cases `gql.tada` may automatically add optionally-typed
+`__typename` fields, so the result types are still readable. But, select `__typename`
+manually when you encounter unions or interfaces, so your code can switch between
+them directly.

--- a/website/guides/recipebook.md
+++ b/website/guides/recipebook.md
@@ -1,0 +1,194 @@
+---
+title: Recipebook
+description: A collection of tips, tricks, and patterns for common gql.tada use-cases.
+---
+
+# Recipebook
+
+<section>
+  A collection of miscellaneous patterns that work well with <code>gql.tada</code>.
+</section>
+
+## Customizing Scalars
+
+By default, `gql.tada` maps the [built-in GraphQL scalars](https://spec.graphql.org/October2021/#sec-Scalars.Built-in-Scalars)
+to their TypeScript equivalents, and maps any custom scalars it doesn't recognize
+to `unknown`. The `scalars` option on `initGraphQLTada<>()` overrides either of
+these.
+
+### Overriding scalar types
+
+The same `scalars` option maps both built-in and custom scalars to whatever
+TypeScript type matches what your API serializes.
+
+A common adjustment is the built-in `ID` scalar, which `gql.tada` types as
+`string | number`. The [GraphQL specification](https://spec.graphql.org/draft/#sec-ID)
+allows an `ID` to be serialized from either, but most APIs only return strings.
+Custom scalars like `DateTime` or `JSON` default to `unknown`, since their type
+isn't automatically known, and usually we'd want to map these too.
+
+::: code-group
+```ts twoslash [src/graphql.ts]
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from './graphql/graphql-env.d.ts';
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+  scalars: {
+    ID: string; // [!code ++]
+    DateTime: string; // [!code ++]
+    JSON: unknown; // [!code ++]
+    JSONObject: Record<string, unknown>; // [!code ++]
+  };
+}>();
+// ---cut-after---
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+```
+:::
+
+Since these are only type-level modifications, they don't change any runtime values.
+Make sure each matches what your GraphQL API actually returns.
+
+### Opaque (branded) scalar types
+
+Mapping a scalar to a primitive like `string` makes it indistinguishable from any
+other string. For scalars that need (de)serialization you could consider using
+an **opaque type** (also known as "branded types").
+
+For example, `DateTime` is a common type in GraphQL that usually is serialized
+as an ISO string. A branded type lets us annotate these strings with a unique symbol,
+which TypeScript treats as distinct from plain `string`s. This allows us to enforce
+serialization and deserialization.
+
+::: code-group
+```ts twoslash [src/graphql.ts]
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from './graphql/graphql-env.d.ts';
+
+declare const tag: unique symbol;
+export type DateTime = string & { readonly [tag]: 'DateTime' };
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+  scalars: {
+    DateTime: DateTime; // [!code ++]
+  };
+}>();
+// ---cut-after---
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+```
+:::
+
+The `DateTime` example type above makes this type distinct from just a `string`
+which means we can create utilities to deserialize and serialize this scalar.
+
+```ts twoslash
+declare const tag: unique symbol;
+type DateTime = string & { readonly [tag]: 'DateTime' };
+// ---cut-before---
+export const fromDateTime = (value: DateTime) => new Date(value);
+export const toDateTime = (date: Date) => date.toISOString() as DateTime;
+```
+
+This keeps all marshalling logic in a single place and naturally enforces this
+as a zero-cost typesystem abstraction, without any additional conversion overhead.
+
+Without branding, a raw `string` may flow straight into `new Date(...)` or can
+be missed at various code sites, scattering (and maybe diverging) its parsing
+logic across a large codebase. With branding, we enforce that specific utility
+functions are used with these scalars. The same can be useful for other unique
+types that serialize to `string`s or `number`s, such as `URL`, `UUID`, or
+`EmailAddress`.
+
+> [!TIP]
+> The cast inside `toDateTime()` is the one place the brand is asserted. Keeping
+> that assertion isolated in a utility is the point. The rest of your code never
+> casts.
+
+---
+
+## Working with Enums
+
+By default, `gql.tada` infers GraphQL enums as a union of string literals, e.g.
+`'Bug' | 'Dark' | 'Dragon'`. This is the right representation for new code: string
+literal unions are forward-compatible and compile away to nothing.
+
+`initGraphQLTada<>()` however allows remapping enum types to another TypeScript type.
+This is most useful when migrating an existing codebase onto `gql.tada` — for example
+from [GraphQL Code Generator](https://the-guild.dev/graphql/codegen), which by default
+may emit a large amount of TypeScript `enum`s.
+
+The `scalars` option can remap enum types by name, so you can slot your existing enum
+back in and `gql.tada` will infer the exact type your code expects. This lets you
+adopt it without rewriting every reference up front.
+
+::: code-group
+```ts twoslash [src/graphql.ts]
+import { initGraphQLTada } from 'gql.tada';
+import type { introspection } from './graphql/graphql-env.d.ts';
+
+// The enum your existing code already imports:
+export enum PokemonType {
+  Fire = 'Fire',
+  Water = 'Water',
+  Grass = 'Grass',
+}
+
+export const graphql = initGraphQLTada<{
+  introspection: introspection;
+  scalars: {
+    PokemonType: PokemonType; // [!code ++]
+  };
+}>();
+// ---cut-after---
+
+export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';
+export { readFragment } from 'gql.tada';
+```
+:::
+
+Wherever this enum's GraphQL type is selected, `gql.tada` now infers your
+`PokemonType` enum instead of the default string literal union, so
+existing call sites keep type checking unchanged.
+
+> [!WARNING]
+> Treat this as a migration aid, not a default. TypeScript `enum`s have
+> [well-documented drawbacks](https://www.totaltypescript.com/why-i-dont-like-typescript-enums).
+> They emit runtime code and are reference-incompatible with their own values, since
+> each enum value is an independent symbol in the TypeScript type checker.
+> Once a part of your codebase is migrated, drop the override and use the default
+> string literal unions, which align with GraphQL's backwards-compatibility
+> guarantees.
+
+---
+
+## TypeScript Performance
+
+`gql.tada` infers everything in TypeScript's type system, so type-checking speed
+scales with how much GraphQL you write. As a project grows, the editor or `tsc`
+can slow down, and very large documents can hit
+`Type instantiation is excessively deep and possibly infinite.ts(2589)`.
+
+A few habits keep things fast:
+
+- **Keep `gql.tada` up to date.** Inference performance and document-size limits
+  improve across releases, and upgrading is the most common fix for `ts(2589)`.
+- **Enable Turbo Mode.** [`gql-tada turbo`](/get-started/workflows#turbo-mode)
+  pre-computes a cache of all document types. Checking it into your repository
+  lets the plugin and CLI reuse the snapshot instead of re-inferring every type.
+- **Use the `.d.ts` output format.**
+  The [`tadaOutputLocation`](/reference/config-format#tadaoutputlocation) `.d.ts`
+  format is much more efficient for the type-checker than `.ts`. Only use `.ts` if
+  another tool needs the introspection data at runtime.
+- **Compose with fragments.** Splitting a large query into
+  [colocated fragments](/guides/fragment-colocation) keeps each selection set
+  small, which is easier on inference.
+
+<a href="/get-started/workflows" class="button">
+  <h3>Essential Workflows</h3>
+  <p>Learn more about Turbo Mode and the CLI commands</p>
+</a>

--- a/website/guides/testing.md
+++ b/website/guides/testing.md
@@ -1,0 +1,162 @@
+---
+title: Testing
+description: How to write type-safe test fixtures and fake data with fragment masking.
+---
+
+# Testing
+
+<section>
+  Fragment masking keeps each component honest about the data it
+  uses, but it can make test fixtures and fake data tricky to write.
+  <code>gql.tada/testing</code> has a set of testing helpers to make
+  test data type-safe.
+</section>
+
+With [fragment masking](/guides/fragment-colocation#fragment-masking), fragments
+are opaque and isolated at the type-level, which enforces that a parent never
+sees the data its children selected. This helps in app code, but complicates tests.
+Mock data written by hand has the shape of the _unmasked_ fragment result, which
+won't match the masked types the document expects.
+
+The `gql.tada/testing` entrypoint exports three helpers to bridge this gap. They
+are meant for tests, stories, fixtures, and cache updaters.
+
+::: tip
+Reach for these only at the boundary where you construct mock data.
+Inside the component or function under test, keep using
+[`readFragment()`](/reference/gql-tada-api#readfragment)
+as you normally would.
+:::
+
+---
+
+## Masking a fragment's data
+
+[`maskFragments()`](/reference/gql-tada-api#maskfragments) takes a list of
+fragments and the (unmasked) data for them, and returns that data typed as a
+masked fragment reference. This is the helper you want when a component under test
+accepts a `FragmentOf<typeof fragment>` prop and you need to hand it a fixture:
+
+```ts twoslash [pokemon.test.ts]
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql } from 'gql.tada';
+import { maskFragments } from 'gql.tada/testing';
+
+const pokemonItemFragment = graphql(`
+  fragment PokemonItem on Pokemon {
+    id
+    name
+  }
+`);
+
+// Ready to pass as a prop:
+const data = maskFragments([pokemonItemFragment], {
+  id: '001',
+  name: 'Bulbasaur',
+});
+```
+
+`maskFragments()` also accepts `null`, `undefined`, and arrays of data, so you can
+build fixtures for nullable or list-typed fragment props directly.
+
+---
+
+## Building a document's result
+
+[`readResult()`](/reference/gql-tada-api#readresult) builds a type-safe
+fixture for a whole document. You pass it the document, the data with fragment
+fields inlined, and the list of fragments the document uses. It resolves the
+references so your data is fully type checked, including fragments that
+themselves spread other fragments.
+
+```ts twoslash [pokemon.test.ts]
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql } from 'gql.tada';
+import { readResult } from 'gql.tada/testing';
+
+const pokemonNameFragment = graphql(`
+  fragment PokemonName on Pokemon {
+    name
+  }
+`);
+
+const pokemonItemFragment = graphql(`
+  fragment PokemonItem on Pokemon {
+    id
+    ...PokemonName
+  }
+`, [pokemonNameFragment]);
+
+const query = graphql(`
+  query {
+    pokemon(id: "001") {
+      ...PokemonItem
+    }
+  }
+`, [pokemonItemFragment]);
+
+// Fully type-checked, including nested fragments:
+const data = readResult(
+  query,
+  { pokemon: { id: '001', name: 'Bulbasaur' } },
+  [pokemonItemFragment, pokemonNameFragment]
+);
+```
+
+Pass **every** fragment you want inlined, including ones spread transitively by
+other fragments. Any fragment you leave out of the list stays masked: instead of
+inlined fields, it shows up as a still-masked reference in the expected data.
+
+This is handy when you'd rather build part of the result with
+[`maskFragments()`](#masking-a-fragment-s-data). Leave that fragment out, and
+slot the masked value in instead, if you already have mocked data for an individual
+fragment.
+
+### Casting results unsafely
+
+[`unsafe_readResult()`](/reference/gql-tada-api#unsafe_readresult) casts data to a
+document's result type **without type checking** the data nested inside fragment
+references. It's a slightly safer alternative to `as any as ResultOf<typeof query>`.
+
+```ts twoslash [pokemon.test.ts]
+import './graphql/graphql-env.d.ts';
+// ---cut-before---
+import { graphql } from 'gql.tada';
+import { unsafe_readResult } from 'gql.tada/testing';
+
+const pokemonItemFragment = graphql(`
+  fragment PokemonItem on Pokemon {
+    id
+    name
+  }
+`);
+
+const query = graphql(
+  `
+    query {
+      pokemon(id: "001") {
+        ...PokemonItem
+      }
+    }
+  `,
+  [pokemonItemFragment]
+);
+
+// ⚠️ data is cast to the result type WITHOUT checking the fragment fields:
+const data = unsafe_readResult(query, {
+  pokemon: { id: '001', name: 'Bulbasaur' },
+});
+```
+
+> [!CAUTION]
+> Because `unsafe_readResult()` doesn't check the data inside fragment masks, a
+> typo or missing field won't be caught. Prefer
+> [`readResult()`](#building-a-document-s-result) whenever you can, and reach for
+> this only when listing every fragment is impractical.
+
+<a href="/reference/gql-tada-api#testing-functions" class="button">
+  <h3>Testing Functions</h3>
+  <p>See the full API reference for these helpers</p>
+</a>


### PR DESCRIPTION
## Summary

Based on past issues and discussions, these are the main parts of the documentation that were missing

## Set of changes

- Add Recipebook page
  - Add note on custom scalars
  - Add note on opaque/branded types for custom scalars
  - Add enum override note
  - Add explicit TypeScript performance section
- Add Testing page (documents `gql.tada/testing`)
- Add "Abstract Types" section to "Writing GraphQL"
