### PR TITLE
fix(cli-utils): Fix `unref` in teardown failing in non-interactive invocations with Node 24

### DIFF
--- a/.changeset/eleven-sites-return.md
+++ b/.changeset/eleven-sites-return.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Fix teardown of interactive CLI keyhandlers on Node 24 with non-interactive stdin stream

--- a/packages/cli-utils/src/term/tty.ts
+++ b/packages/cli-utils/src/term/tty.ts
@@ -68,10 +68,17 @@ function fromReadStream(stream: ReadStream, onTerminate: () => void): Source<Key
     }
 
     function cleanup() {
-      if (stream.isTTY) stream.setRawMode(false);
-      observer.complete();
-      stream.removeListener('keypress', onKeypress);
-      stream.unref();
+      try {
+        if (stream.isTTY) stream.setRawMode(false);
+        stream.removeListener('keypress', onKeypress);
+        if (typeof stream.unref === 'function') {
+          stream.unref();
+        }
+      } catch {
+        // noop
+      } finally {
+        observer.complete();
+      }
     }
 
     if (stream.isTTY) stream.setRawMode(true);


### PR DESCRIPTION
## Summary

We don't care if the teardown fails in most cases for `stdin`, and can wrap it in a try-catch. We also should guard the `unref` call for Node 24 and non-interactive invocations.

## Set of changes

- Guard `cleanup` call in `fromReadStream`
