### PR TITLE
fix(internal,cli-utils): Refine `references` iteration and loosen overlaps

### DIFF
--- a/.changeset/pink-parrots-repair.md
+++ b/.changeset/pink-parrots-repair.md
@@ -1,0 +1,6 @@
+---
+'@gql.tada/cli-utils': patch
+'@gql.tada/internal': patch
+---
+
+Refine how `references` are walked and when they conflict. We should only check references if we haven't yet found a plugin entry, and allow duplicate entries, if their output locations don't conflict.

--- a/packages/cli-utils/src/commands/generate-output/runner.ts
+++ b/packages/cli-utils/src/commands/generate-output/runner.ts
@@ -50,10 +50,29 @@ export async function* run(tty: TTY, opts: OutputOptions): AsyncIterable<Compose
     );
   }
 
+  // Projects may share an output file; its contents come only from the schema,
+  // so generate each distinct file once rather than once per referencing project.
+  const generated = new Set<string>();
   for (const project of projects) {
+    const destinations = outputDestinations(project);
+    if (destinations.length && destinations.every((destination) => generated.has(destination))) {
+      continue;
+    }
+    for (const destination of destinations) generated.add(destination);
     if (projects.length > 1) yield logger.projectHeader(project.label);
     yield* runProject(tty, opts, project);
   }
+}
+
+function outputDestinations(project: ProjectContext): string[] {
+  const { pluginConfig, projectPath } = project;
+  const locations =
+    'schemas' in pluginConfig
+      ? pluginConfig.schemas.map((schema) => schema.tadaOutputLocation)
+      : [pluginConfig.tadaOutputLocation];
+  return locations
+    .filter((location): location is string => !!location)
+    .map((location) => path.resolve(projectPath, location));
 }
 
 /** Generates the introspection output for a single project. */

--- a/packages/cli-utils/src/commands/shared/__tests__/projects.test.ts
+++ b/packages/cli-utils/src/commands/shared/__tests__/projects.test.ts
@@ -157,6 +157,38 @@ describe('generate-output', () => {
     );
   });
 
+  it('writes a shared output location only once across projects', () => {
+    const sharedPlugin = {
+      name: '@0no-co/graphqlsp',
+      schema: '../../schema.graphql',
+      tadaOutputLocation: '../../shared/graphql-env.d.ts',
+    };
+    return inFixture(
+      {
+        'tsconfig.json': {
+          files: [],
+          references: [{ path: './packages/a' }, { path: './packages/b' }],
+        },
+        'packages/a/tsconfig.json': { compilerOptions: { plugins: [sharedPlugin] } },
+        'packages/b/tsconfig.json': { compilerOptions: { plugins: [sharedPlugin] } },
+        'schema.graphql': SCHEMA,
+      },
+      async (root) => {
+        const signals: unknown[] = [];
+        for await (const signal of runGenerateOutput(tty, { output: undefined, tsconfig: root })) {
+          signals.push(signal);
+        }
+
+        // A deduplicated project is skipped before emitting its project header.
+        const headerCount = (JSON.stringify(signals).match(/tsconfig\.json/g) || []).length;
+        expect(headerCount).toBe(1);
+
+        const output = await fs.readFile(path.join(root, 'shared', 'graphql-env.d.ts'), 'utf8');
+        expect(output).toContain("declare module 'gql.tada'");
+      }
+    );
+  });
+
   it('does not write terminal output when silent is set', () => {
     return inFixture(
       {

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -60,6 +60,76 @@ describe('validateUniqueOutputLocations', () => {
     ).toThrow(/tadaOutputLocation/);
   });
 
+  it('allows projects to share an output location when they resolve the same schema', () => {
+    expect(() =>
+      validateUniqueOutputLocations([
+        {
+          projectPath: path.join(ROOT, 'apps', 'a'),
+          config: { schema: '../../schema.graphql', tadaOutputLocation: '../../graphql-env.d.ts' },
+          label: 'apps/a/tsconfig.json',
+        },
+        {
+          projectPath: path.join(ROOT, 'apps', 'b'),
+          config: { schema: '../../schema.graphql', tadaOutputLocation: '../../graphql-env.d.ts' },
+          label: 'apps/b/tsconfig.json',
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  it('still throws when a shared output location resolves to different schemas', () => {
+    expect(() =>
+      validateUniqueOutputLocations([
+        {
+          projectPath: path.join(ROOT, 'apps', 'a'),
+          config: { schema: '../../a.graphql', tadaOutputLocation: '../../graphql-env.d.ts' },
+          label: 'apps/a/tsconfig.json',
+        },
+        {
+          projectPath: path.join(ROOT, 'apps', 'b'),
+          config: { schema: '../../b.graphql', tadaOutputLocation: '../../graphql-env.d.ts' },
+          label: 'apps/b/tsconfig.json',
+        },
+      ])
+    ).toThrow(/tadaOutputLocation/);
+  });
+
+  it('still throws when projects share a turbo location, even with the same schema', () => {
+    // Turbo caches are built from each project's own documents, not the schema.
+    expect(() =>
+      validateUniqueOutputLocations([
+        {
+          projectPath: path.join(ROOT, 'apps', 'a'),
+          config: { schema: '../../schema.graphql', tadaTurboLocation: '../../graphql-cache.d.ts' },
+          label: 'apps/a/tsconfig.json',
+        },
+        {
+          projectPath: path.join(ROOT, 'apps', 'b'),
+          config: { schema: '../../schema.graphql', tadaTurboLocation: '../../graphql-cache.d.ts' },
+          label: 'apps/b/tsconfig.json',
+        },
+      ])
+    ).toThrow(/tadaTurboLocation/);
+  });
+
+  it('still throws when projects share a persisted manifest location', () => {
+    // Persisted manifests are built from each project's own documents, not the schema.
+    expect(() =>
+      validateUniqueOutputLocations([
+        {
+          projectPath: path.join(ROOT, 'apps', 'a'),
+          config: { schema: '../../schema.graphql', tadaPersistedLocation: '../../persisted.json' },
+          label: 'apps/a/tsconfig.json',
+        },
+        {
+          projectPath: path.join(ROOT, 'apps', 'b'),
+          config: { schema: '../../schema.graphql', tadaPersistedLocation: '../../persisted.json' },
+          label: 'apps/b/tsconfig.json',
+        },
+      ])
+    ).toThrow(/tadaPersistedLocation/);
+  });
+
   it('ignores repeated locations within the same project', () => {
     expect(() =>
       validateUniqueOutputLocations([

--- a/packages/internal/src/__tests__/resolve.test.ts
+++ b/packages/internal/src/__tests__/resolve.test.ts
@@ -264,6 +264,67 @@ describe('loadConfigs', () => {
     );
   });
 
+  it('scopes to a targeted project that has its own plugin entry, ignoring its references', () => {
+    return inFixture(
+      {
+        'apps/app/tsconfig.app.json': {
+          compilerOptions: { plugins: [PLUGIN] },
+          include: ['src'],
+          references: [{ path: '../../libs/a' }, { path: '../../libs/b' }],
+        },
+        'libs/a/tsconfig.json': { compilerOptions: { plugins: [PLUGIN] }, include: ['src'] },
+        'libs/b/tsconfig.json': { compilerOptions: { plugins: [PLUGIN] }, include: ['src'] },
+      },
+      async (root) => {
+        const results = await loadConfigs(path.join(root, 'apps', 'app', 'tsconfig.app.json'));
+        expect(results).toHaveLength(1);
+        expect(results[0].tsconfigPath).toBe(path.join(root, 'apps', 'app', 'tsconfig.app.json'));
+      }
+    );
+  });
+
+  it('scopes to a targeted project that inherits its plugin entry through `extends`', () => {
+    return inFixture(
+      {
+        'tsconfig.base.json': { compilerOptions: { plugins: [PLUGIN] } },
+        'apps/app/tsconfig.app.json': {
+          extends: '../../tsconfig.base.json',
+          include: ['src'],
+          references: [{ path: '../../libs/a' }],
+        },
+        'libs/a/tsconfig.json': { extends: '../../tsconfig.base.json', include: ['src'] },
+      },
+      async (root) => {
+        const results = await loadConfigs(path.join(root, 'apps', 'app', 'tsconfig.app.json'));
+        expect(results).toHaveLength(1);
+        expect(results[0].tsconfigPath).toBe(path.join(root, 'apps', 'app', 'tsconfig.app.json'));
+        expect(results[0].configPath).toBe(path.join(root, 'tsconfig.base.json'));
+      }
+    );
+  });
+
+  it('does not walk a referenced concrete project into its own references', () => {
+    return inFixture(
+      {
+        'tsconfig.json': {
+          files: [],
+          references: [{ path: './apps/app' }],
+        },
+        'apps/app/tsconfig.json': {
+          compilerOptions: { plugins: [PLUGIN] },
+          include: ['src'],
+          references: [{ path: '../../libs/a' }],
+        },
+        'libs/a/tsconfig.json': { compilerOptions: { plugins: [PLUGIN] }, include: ['src'] },
+      },
+      async (root) => {
+        const results = await loadConfigs(root);
+        expect(results).toHaveLength(1);
+        expect(results[0].tsconfigPath).toBe(path.join(root, 'apps', 'app', 'tsconfig.json'));
+      }
+    );
+  });
+
   it('rejects when no project has a plugin entry', () => {
     return inFixture(
       {

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -205,9 +205,24 @@ const LOCATION_PROPS = [
   'tadaPersistedLocation',
 ] as const;
 
+// Generated purely from the schema, so projects emitting it to the same path
+// with the same schema produce identical contents. Turbo and persisted locations
+// derive from each project's own documents instead, so a shared path clobbers.
+const SCHEMA_DERIVED_PROPS = new Set<(typeof LOCATION_PROPS)[number]>(['tadaOutputLocation']);
+
+const schemaIdentity = (projectPath: string, origin: SchemaOrigin | undefined): string => {
+  if (!origin) return '';
+  if (typeof origin === 'object')
+    return `url:${origin.url}\0${JSON.stringify(origin.headers || null)}`;
+  if (getURLConfig(origin)) return `url:${origin}`;
+  let resolved = path.resolve(projectPath, origin);
+  if (process.platform === 'win32') resolved = resolved.toLowerCase();
+  return `file:${resolved}`;
+};
+
 export const validateUniqueOutputLocations = (projects: readonly ProjectConfig[]): void => {
   for (const prop of LOCATION_PROPS) {
-    const seen = new Map<string, string>();
+    const seen = new Map<string, { label: string; schema: string }>();
     for (const project of projects) {
       const label = project.label || project.projectPath;
       const schemas = 'schemas' in project.config ? project.config.schemas : [project.config];
@@ -216,13 +231,19 @@ export const validateUniqueOutputLocations = (projects: readonly ProjectConfig[]
         if (!location) continue;
         let resolved = path.resolve(project.projectPath, location);
         if (process.platform === 'win32') resolved = resolved.toLowerCase();
+        const identity = schemaIdentity(project.projectPath, schema.schema);
         const previous = seen.get(resolved);
-        if (previous && previous !== label) {
-          throw new TadaError(
-            `Projects '${previous}' and '${label}' resolve '${prop}' to the same file: ${location}`
-          );
+        if (previous && previous.label !== label) {
+          // Identical schema-derived output is a deliberately shared file, not a conflict.
+          const isSharedOutput = SCHEMA_DERIVED_PROPS.has(prop) && previous.schema === identity;
+          if (!isSharedOutput) {
+            throw new TadaError(
+              `Projects '${previous.label}' and '${label}' resolve '${prop}' to the same file: ${location}`
+            );
+          }
+        } else if (!previous) {
+          seen.set(resolved, { label, schema: identity });
         }
-        seen.set(resolved, label);
       }
     }
   }

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -185,7 +185,11 @@ export const loadConfigs = async (targetPath?: string): Promise<LoadConfigResult
       }
     }
 
-    if (Array.isArray(tsconfig.references)) {
+    // A concrete project's `references` are build-order dependencies, not
+    // sub-projects to load, so only descend for an aggregator: one with no
+    // plugin entry of its own, or a solution-style config with no files.
+    const isAggregator = !entry || isSolutionStyleConfig(tsconfig);
+    if (isAggregator && Array.isArray(tsconfig.references)) {
       hasReferences = true;
       for (const reference of tsconfig.references) {
         if (!reference || typeof reference.path !== 'string') continue;


### PR DESCRIPTION
## Summary

Resolves https://github.com/0no-co/gql.tada/discussions/564

The `references` support mainly covers "aggregate" `tsconfig.json`s right now, where the main config doesn't itself contain a `plugins` entry (via `extends` or otherwise). We should instead only walk `references` for an individual entry, if the root configuration doesn't have any plugin entry of its own.

Further, we should allow overlapping configurations if they write to the same output location, for the purpose of `generate output` iterating `references`. We can deduplicate in `generate output` instead.

## Set of changes

- Loosen duplicates/overlaps check
- Deduplicate `generate output` locations manually