### PR TITLE
fix(internal): Parse tsconfig.json without the TypeScript compiler API

### DIFF
--- a/.changeset/quiet-jsonc-config.md
+++ b/.changeset/quiet-jsonc-config.md
@@ -1,0 +1,7 @@
+---
+"gql.tada": patch
+"@gql.tada/cli-utils": patch
+"@gql.tada/internal": patch
+---
+
+Parse `tsconfig.json` files without relying on the TypeScript compiler API so schema output generation works with the TypeScript 7 package.

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -51,7 +51,8 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@0no-co/graphql.web": "^1.3.1"
+    "@0no-co/graphql.web": "^1.3.1",
+    "jsonc-parser": "^3.3.1"
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",

--- a/packages/internal/src/__tests__/resolve.test.ts
+++ b/packages/internal/src/__tests__/resolve.test.ts
@@ -46,6 +46,60 @@ describe('loadConfigs', () => {
     );
   });
 
+  it('parses tsconfig JSON with comments and trailing commas', () => {
+    return inFixture(
+      {
+        'tsconfig.json': `{
+          // TypeScript accepts JSONC in tsconfig files.
+          "compilerOptions": {
+            "plugins": [
+              { "name": "@0no-co/graphqlsp", "schema": "./schema.graphql", },
+            ],
+          },
+          "include": ["src",],
+        }`,
+      },
+      async (root) => {
+        const results = await loadConfigs(root);
+        expect(results).toHaveLength(1);
+        expect(results[0].pluginConfig).toEqual(PLUGIN);
+      }
+    );
+  });
+
+  it('parses tsconfig files starting with a UTF-8 byte order mark', () => {
+    return inFixture(
+      {
+        'tsconfig.json':
+          '\ufeff' +
+          JSON.stringify({ compilerOptions: { plugins: [PLUGIN] }, include: ['src'] }, null, 2),
+      },
+      async (root) => {
+        const results = await loadConfigs(root);
+        expect(results).toHaveLength(1);
+        expect(results[0].pluginConfig).toEqual(PLUGIN);
+      }
+    );
+  });
+
+  it('treats empty tsconfig files as empty configs', () => {
+    return inFixture(
+      {
+        'tsconfig.json': {
+          files: [],
+          references: [{ path: './tsconfig.empty.json' }, { path: './tsconfig.app.json' }],
+        },
+        'tsconfig.empty.json': '',
+        'tsconfig.app.json': { compilerOptions: { plugins: [PLUGIN] }, include: ['src'] },
+      },
+      async (root) => {
+        const results = await loadConfigs(root);
+        expect(results).toHaveLength(1);
+        expect(results[0].tsconfigPath).toBe(path.join(root, 'tsconfig.app.json'));
+      }
+    );
+  });
+
   it('resolves a referenced project from a solution-style root config', () => {
     return inFixture(
       {

--- a/packages/internal/src/resolve.ts
+++ b/packages/internal/src/resolve.ts
@@ -1,12 +1,12 @@
-import ts from 'typescript';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import type { Stats } from 'node:fs';
 import type { TsConfigJson } from 'type-fest';
+import { parse, printParseErrorCode, type ParseError } from 'jsonc-parser';
 
 import { cwd, maybeRelative } from './helpers';
-import { TSError, TadaError } from './errors';
+import { TadaError } from './errors';
 
 const TSCONFIG = 'tsconfig.json';
 
@@ -43,10 +43,26 @@ const toTSConfigPath = (tsconfigPath: string): string =>
 
 export const readTSConfigFile = async (filePath: string): Promise<TsConfigJson> => {
   const tsconfigPath = toTSConfigPath(filePath);
-  const contents = await fs.readFile(tsconfigPath, 'utf8');
-  const result = ts.parseConfigFileTextToJson(tsconfigPath, contents);
-  if (result.error) throw new TSError(result.error);
-  return result.config || {};
+  let contents = await fs.readFile(tsconfigPath, 'utf8');
+  // Like TypeScript itself, tolerate a UTF-8 BOM
+  if (contents.charCodeAt(0) === 0xfeff) contents = contents.slice(1);
+  const errors: ParseError[] = [];
+  const config = parse(contents, errors, {
+    allowTrailingComma: true,
+    allowEmptyContent: true,
+  }) as TsConfigJson | undefined;
+  if (errors.length) {
+    const error = errors[0];
+    const prefix = contents.slice(0, error.offset);
+    const line = prefix.split(/\r\n?|\n/).length;
+    const col = prefix.length - Math.max(prefix.lastIndexOf('\n'), prefix.lastIndexOf('\r'));
+    throw new TadaError(
+      `Failed to parse ${maybeRelative(tsconfigPath)} at ${line}:${col}: ${printParseErrorCode(
+        error.error
+      )}`
+    );
+  }
+  return config || {};
 };
 
 export const findTSConfigFile = async (targetPath?: string): Promise<string | null> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@0no-co/graphql.web':
         specifier: ^1.3.1
         version: 1.3.1(graphql@16.9.0)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@types/node':
         specifier: ^20.11.0
@@ -2616,6 +2619,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -6489,6 +6495,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:


### PR DESCRIPTION
Resolves #572

## Summary

TypeScript 7 no longer exposes the legacy JS compiler API from the `typescript` package's top-level export, so loading the GraphQLSP plugin config crashes with `TypeError: ts.parseConfigFileTextToJson is not a function`. This breaks `gql.tada generate-output` (and `generate schema` when it infers the output location) before any schema work happens.

Reading `tsconfig.json` only needs a JSONC parser, not a compiler, so this swaps `ts.parseConfigFileTextToJson` for `jsonc-parser`.

This intentionally isn't full TS7 support: commands that create a TypeScript program (`check`, `scan`, `turbo`, `generate-persisted`, `doctor`) still use the legacy compiler API. TypeScript 7.0 [ships no programmatic API](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) (a new, different one is expected in 7.1), and Microsoft publishes `@typescript/typescript6` as the interim path for tools that need the old API — those commands could load it as a compatibility bridge until the new API is worth porting to. Happy to write that up in a follow-up issue if there's interest.

## Set of changes

- `@gql.tada/internal`: `readTSConfigFile` now parses tsconfig contents with `jsonc-parser` (Microsoft-maintained, matches tsconfig's JSONC dialect). Comments and trailing commas still work; a UTF-8 BOM is stripped and blank files are treated as empty configs, matching the old TypeScript parser's behavior. Parse failures throw a `TadaError` with file path and line/column.
- New `jsonc-parser` dependency in `@gql.tada/internal`, kept external by the rollup build.
- Regression tests for JSONC configs, BOM-prefixed files, and empty referenced configs.
- Patch changeset for `@gql.tada/internal`, `@gql.tada/cli-utils`, and `gql.tada`.

Not a breaking change.
