### PR TITLE
fix(internal): bypass validation for assumed-valid SDL schemas

### DIFF
--- a/.changeset/curvy-wolves-validate.md
+++ b/.changeset/curvy-wolves-validate.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/internal': patch
+---
+
+Ensure assumed-valid SDL schemas bypass schema validation during introspection.

--- a/packages/internal/src/loaders/__tests__/loaders.test.ts
+++ b/packages/internal/src/loaders/__tests__/loaders.test.ts
@@ -30,6 +30,14 @@ afterEach(async () => {
 });
 
 describe('loadFromSDL', () => {
+  it('marks assumed-valid SDL schemas as valid', async () => {
+    const file = await makeSchemaFile(VALID_SCHEMA);
+    const loader = loadFromSDL({ file, assumeValid: true });
+
+    const result = await loader.load();
+    expect(result.schema.toConfig().assumeValid).toBe(true);
+  });
+
   it('returns the cached result unless a reload is forced', async () => {
     const file = await makeSchemaFile(VALID_SCHEMA);
     const loader = loadFromSDL({ file, assumeValid: true });

--- a/packages/internal/src/loaders/sdl.ts
+++ b/packages/internal/src/loaders/sdl.ts
@@ -42,7 +42,10 @@ export function loadFromSDL(config: LoadFromSDLConfig): SchemaLoader {
         schema: buildClientSchema(introspection, { assumeValid: !!config.assumeValid }),
       };
     } else {
-      const schema = buildSchema(data, { assumeValidSDL: !!config.assumeValid });
+      const schema = buildSchema(data, {
+        assumeValid: !!config.assumeValid,
+        assumeValidSDL: !!config.assumeValid,
+      });
       const query = makeIntrospectionQuery(getPeerSupportedFeatures());
       const queryResult = executeSync({ schema, document: query });
       if (queryResult.errors) {


### PR DESCRIPTION
## Summary

Fixes the local SDL loader failing to introspect schemas that are intentionally treated as assumed-valid.

GraphQL.js 17 validates schemas during execution and now rejects deprecated implementation fields whose interface fields are not deprecated. This exposed the issue with GitHub's published GraphQL schema in [discussion #574](https://github.com/0no-co/gql.tada/discussions/574): the loader passed `assumeValidSDL`, but not `assumeValid`, so the subsequent introspection execution still validated and rejected the schema.

## Set of changes

- Pass `assumeValid` to `buildSchema` alongside `assumeValidSDL`.
- Add a regression test asserting assumed-valid SDL schemas retain that setting on the built schema.
- Add a patch changeset for `@gql.tada/internal`.

This is not a breaking change.

## Verification

- `pnpm exec vitest run src/loaders/__tests__/loaders.test.ts` from `packages/internal`
- `pnpm run check`
- ESLint and Prettier checks for the changed files
- Reproduced `generate-output` successfully with GitHub's current SDL and GraphQL.js 17.0.2 after applying the fix
