### PR TITLE
fix(cli-utils): prevent EOF from terminating commands

### DIFF
--- a/.changeset/tidy-bats-listen.md
+++ b/.changeset/tidy-bats-listen.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Prevent non-interactive stdin and Ctrl-D/EOF bytes from terminating CLI commands with exit code 130.

--- a/packages/cli-utils/src/term/__tests__/tty.test.ts
+++ b/packages/cli-utils/src/term/__tests__/tty.test.ts
@@ -1,0 +1,77 @@
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { initTTY } from '../tty';
+
+function mockProcessStreams(isTTY: boolean) {
+  const stdin = Object.assign(new PassThrough(), {
+    isTTY,
+    setRawMode: vi.fn(),
+    unref: vi.fn(),
+  });
+  const stdout = Object.assign(new PassThrough(), { isTTY });
+  const stderr = Object.assign(new PassThrough(), { isTTY });
+
+  vi.spyOn(process, 'stdin', 'get').mockReturnValue(stdin as unknown as typeof process.stdin);
+  vi.spyOn(process, 'stdout', 'get').mockReturnValue(stdout as unknown as typeof process.stdout);
+  vi.spyOn(process, 'stderr', 'get').mockReturnValue(stderr as unknown as typeof process.stderr);
+
+  return { stdin };
+}
+
+function pendingOutputs() {
+  let finish!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  async function* outputs() {
+    await pending;
+  }
+  return { outputs: outputs(), finish };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('initTTY', () => {
+  it('does not subscribe to stdin in non-interactive environments', async () => {
+    vi.stubEnv('CI', '1');
+    const { stdin } = mockProcessStreams(true);
+    const tty = initTTY();
+    const { outputs, finish } = pendingOutputs();
+
+    const result = tty.start(outputs);
+
+    expect(tty.isInteractive).toBe(false);
+    expect(stdin.listenerCount('keypress')).toBe(0);
+    expect(stdin.setRawMode).not.toHaveBeenCalled();
+
+    finish();
+    await result;
+  });
+
+  it('does not interpret Ctrl-D as a termination request', async () => {
+    vi.stubEnv('CI', '');
+    vi.stubEnv('TERM', 'xterm');
+    const { stdin } = mockProcessStreams(true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const tty = initTTY();
+    const { outputs, finish } = pendingOutputs();
+
+    const result = tty.start(outputs);
+    stdin.emit('keypress', '\x04', {
+      sequence: '\x04',
+      name: 'd',
+      ctrl: true,
+      meta: false,
+      shift: false,
+    });
+
+    expect(exit).not.toHaveBeenCalled();
+
+    finish();
+    await result;
+  });
+});

--- a/packages/cli-utils/src/term/tty.ts
+++ b/packages/cli-utils/src/term/tty.ts
@@ -55,9 +55,9 @@ export interface TTY {
 function fromReadStream(stream: ReadStream, onTerminate: () => void): Source<KeypressEvent> {
   return make((observer) => {
     function onKeypress(data: string | undefined, event: KeypressEvent) {
+      // PTY hosts may send Ctrl-D to signal EOF, so it must not terminate the command.
       switch (event.name) {
         case 'c':
-        case 'd':
         case 'x':
           if (event.ctrl) return onTerminate();
           break;
@@ -100,7 +100,7 @@ export function initTTY(params: TTYParams = {}): TTY {
     output = process.stderr;
     pipeTo = process.stdout;
   } else {
-    isTTY = output.isTTY;
+    isTTY = isTTY && !!output.isTTY;
   }
 
   const hasColorArg = process.argv.includes('--color');
@@ -168,7 +168,7 @@ export function initTTY(params: TTYParams = {}): TTY {
     const write = (input: string | CLIError) => {
       if (!params.silent) output.write('' + input);
     };
-    if (params.disableTTY) {
+    if (params.disableTTY || !isTTY) {
       return pipe(compose(outputs), onPush(write), toPromise);
     } else {
       return pipe(compose(outputs), onPush(write), takeUntil(cancelSource), toPromise);


### PR DESCRIPTION
## Summary

Prevent PTY-delivered EOF/Ctrl-D bytes from terminating non-interactive CLI commands with exit code 130.

Resolves #577

## Set of changes

- Stop treating Ctrl-D as an explicit termination request, since PTY hosts may emit it to represent EOF.
- Preserve `CI`, `TERM=dumb`, and `disableTTY` when determining whether a TTY session is interactive.
- Avoid subscribing to or enabling raw mode on stdin when the session is non-interactive.
- Add regression tests for non-interactive stdin and Ctrl-D handling.
- Add a patch changeset for `@gql.tada/cli-utils`.

## Verification

- `pnpm vitest run --reporter=verbose` (438 passed)
- `pnpm run check`
- `pnpm --filter @gql.tada/cli-utils build`
- ESLint and Prettier checks for changed files
