### PR TITLE
fix(cli-utils): Emit turbo cache entries in a stable sorted order

### DIFF
--- a/.changeset/stable-turbo-output.md
+++ b/.changeset/stable-turbo-output.md
@@ -1,0 +1,5 @@
+---
+'@gql.tada/cli-utils': patch
+---
+
+Emit `turbo` cache entries and imports in a stable sorted order. The cache file's contents now only depend on the set of discovered documents rather than file traversal order, which keeps the output stable across refactors and reduces merge conflicts in committed cache files. Existing cache files will be reordered once when `gql-tada turbo` is next run.

--- a/packages/cli-utils/src/commands/turbo/__tests__/runner.test.ts
+++ b/packages/cli-utils/src/commands/turbo/__tests__/runner.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+import type { TurboDocument, GraphQLSourceFile } from '../types';
+import { createCacheContents } from '../runner';
+
+const makeDocument = (argumentKey: string, extra?: Partial<TurboDocument>): TurboDocument => ({
+  schemaName: null,
+  argumentKey,
+  documentType: 'TadaDocumentNode<{ id: string; }, {}, void>',
+  ...extra,
+});
+
+describe('createCacheContents', () => {
+  it('emits documents sorted by argument key, independent of input order', () => {
+    const documents = [
+      makeDocument('"query Zebra { id }"', { documentHash: 'sha256:zebra' }),
+      makeDocument('"fragment Apple on Fruit { id }"', { documentHash: 'sha256:apple' }),
+      makeDocument('"query Mango { id }"'),
+    ];
+
+    const contents = createCacheContents(documents, [], '/project/src/graphql-cache.d.ts');
+    const reversed = createCacheContents(
+      [...documents].reverse(),
+      [],
+      '/project/src/graphql-cache.d.ts'
+    );
+
+    expect(reversed).toBe(contents);
+    expect(contents.indexOf('"fragment Apple on Fruit { id }"')).toBeLessThan(
+      contents.indexOf('"query Mango { id }"')
+    );
+    expect(contents.indexOf('"query Mango { id }"')).toBeLessThan(
+      contents.indexOf('"query Zebra { id }"')
+    );
+    expect(contents).toContain(
+      '    /** @gql.tada/hash sha256:apple */\n' +
+        '    "fragment Apple on Fruit { id }":\n' +
+        '      TadaDocumentNode<{ id: string; }, {}, void>;'
+    );
+  });
+
+  it('keeps the last duplicate of an argument key', () => {
+    const contents = createCacheContents(
+      [
+        makeDocument('"query Pokemon { id }"', { documentType: 'TadaDocumentNode<1, 1>' }),
+        makeDocument('"query Pokemon { id }"', { documentType: 'TadaDocumentNode<2, 2>' }),
+      ],
+      [],
+      '/project/src/graphql-cache.d.ts'
+    );
+
+    expect(contents).toContain('TadaDocumentNode<2, 2>');
+    expect(contents).not.toContain('TadaDocumentNode<1, 1>');
+  });
+
+  it('emits imports sorted by source path, independent of discovery order', () => {
+    const sources: GraphQLSourceFile[] = [
+      {
+        absolutePath: '/project/src/b/documents.ts',
+        imports: [{ specifier: './b-types', importClause: "import type { B } from './b-types';" }],
+      },
+      {
+        absolutePath: '/project/src/a/documents.ts',
+        imports: [{ specifier: './a-types', importClause: "import type { A } from './a-types';" }],
+      },
+    ];
+
+    const contents = createCacheContents([], sources, '/project/src/graphql-cache.d.ts');
+    const reversed = createCacheContents(
+      [],
+      [...sources].reverse(),
+      '/project/src/graphql-cache.d.ts'
+    );
+
+    expect(reversed).toBe(contents);
+    expect(contents.indexOf("from './a-types'")).toBeLessThan(contents.indexOf("from './b-types'"));
+  });
+});

--- a/packages/cli-utils/src/commands/turbo/runner.ts
+++ b/packages/cli-utils/src/commands/turbo/runner.ts
@@ -238,7 +238,7 @@ async function* runProject(
   return { warnings, failed: false };
 }
 
-function createCacheContents(
+export function createCacheContents(
   cache: TurboDocument[],
   graphqlSources: GraphQLSourceFile[],
   turboDestination: WriteTarget,
@@ -248,8 +248,15 @@ function createCacheContents(
   const documentsByKey = new Map<string, TurboDocument>();
   for (const document of cache) documentsByKey.set(document.argumentKey, document);
 
+  // Entries are sorted so the output only depends on the set of documents,
+  // rather than the order files are traversed in. This keeps the file stable across
+  // refactors and reduces line adjacency of unrelated changes in merge conflicts
+  const documents = [...documentsByKey.values()].sort((a, b) =>
+    compareUtf16(a.argumentKey, b.argumentKey)
+  );
+
   let output = '';
-  for (const document of documentsByKey.values()) {
+  for (const document of documents) {
     if (output) output += '\n';
     if (document.documentHash) output += `    /** @gql.tada/hash ${document.documentHash} */\n`;
     output += `    ${document.argumentKey}:\n      ${document.documentType};`;
@@ -264,8 +271,13 @@ function createCacheContents(
       'toString' in turboDestination &&
       !('writable' in turboDestination));
 
+  // Sources are sorted by path for the same reason documents are sorted above
+  const sortedSources = [...graphqlSources].sort((a, b) =>
+    compareUtf16(a.absolutePath, b.absolutePath)
+  );
+
   const addedImports = new Set<string>();
-  for (const source of graphqlSources) {
+  for (const source of sortedSources) {
     for (const importInfo of source.imports) {
       if (isFilePath) {
         const turboPath = turboDestination.toString();
@@ -293,4 +305,8 @@ function createCacheContents(
     '\n  }' +
     '\n}\n'
   );
+}
+
+function compareUtf16(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

The `turbo` cache file was written in program file-traversal order, so refactors reshuffled it and concurrent branches inserting documents at the same position caused frequent merge conflicts (see #570). Entries and imports are now sorted by content, making the output a pure function of the set of discovered documents.

## Set of changes

- `@gql.tada/cli-utils`: sort cache entries by argument key and imports by source path in `createCacheContents` (`runner.ts`), using a locale-independent comparator, with new unit tests covering byte-reproducibility, sort order, and dedupe behavior. Verified against `example-pokemon-api`: renames now leave the cache byte-identical, two-branch additions `git merge-file` cleanly to exactly what regeneration would produce, and incremental hash reuse is unaffected. Not a breaking change — existing cache files are reordered once on the next `gql-tada turbo` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)